### PR TITLE
codegen(meta): accept WinRT classes that extend other WinRT classes

### DIFF
--- a/tools/dynwinrt-codegen/src/meta.rs
+++ b/tools/dynwinrt-codegen/src/meta.rs
@@ -153,7 +153,22 @@ pub fn parse_namespace(winmd_paths: &str, namespace: &str) -> Vec<ClassMeta> {
             Some(e) => e,
             None => continue,
         };
-        if extends.namespace() != "System" || extends.name() != "Object" {
+        // A WinRT runtime class either extends System.Object directly or extends
+        // another WinRT class (WinUI XAML classes: Button -> ButtonBase ->
+        // ContentControl -> ... -> UIElement -> DependencyObject). Filter out
+        // structs/enums/interfaces (which extend System.ValueType, System.Enum,
+        // or nothing) but keep any class that extends a real WinRT type.
+        let extends_system_object = extends.namespace() == "System" && extends.name() == "Object";
+        let extends_winrt_class = !matches!(
+            (extends.namespace(), extends.name()),
+            ("System", "Object")
+                | ("System", "ValueType")
+                | ("System", "Enum")
+                | ("System", "Delegate")
+                | ("System", "MulticastDelegate")
+                | ("System", _)
+        );
+        if !extends_system_object && !extends_winrt_class {
             continue;
         }
 


### PR DESCRIPTION
## Problem

The parser dropped any class whose base type wasn't `System.Object`, which silently excluded most WinUI XAML types. `Button` extends `ButtonBase` extends `ContentControl` extends `Control` extends ... extends `DependencyObject`, and only `DependencyObject` extends `System.Object` directly. Whole-namespace generation over `Microsoft.UI.Xaml.Controls` returned almost nothing usable.

## Fix

Broaden the filter to accept a class that either:
- directly extends `System.Object`, or
- extends any non-`System.*` type (i.e. another WinRT class).

Continue to exclude:
- structs (`System.ValueType`)
- enums (`System.Enum`)
- delegates (`System.Delegate` / `System.MulticastDelegate`)
- any other `System.*` pseudo-class base (defensive)

## Testing

- `cargo test --release` — 67 unit + 3 consistency + 2 output_dir + 4 snapshot + 1 async scaffolding tests all pass.
- Manually verified downstream: `winapp node generate-bindings` with `includeTypes` targeting `Microsoft.UI.Xaml.Controls.Button` now emits `Button.js` (previously empty).

## Notes

Strict-widening change — no class that was previously emitted is now filtered out.

First of a series of small focused PRs breaking up a larger local branch that made Tier 2 (WinUI XAML from JavaScript) work end-to-end.