### PR TITLE
Runtime fixes for delegate dispatch and metadata arena

### DIFF
--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -1328,16 +1328,139 @@ impl DynWinRtDelegate {
     #[napi(ts_arg_type = "(...args: DynWinRTValue[]) => void")]
     callback: napi::bindgen_prelude::Function<'static, Vec<DynWinRTValue>, ()>,
   ) -> napi::Result<DynWinRtDelegate> {
-    let tsfn = callback.build_threadsafe_function()
-      .build()?;
+    use napi::bindgen_prelude::ToNapiValue;
+    use napi::JsValue;
+    use windows::Win32::System::Threading::GetCurrentThreadId;
+
+    // Track the thread we were registered on. WinRT delegate callbacks that
+    // fire on this same thread are dispatched synchronously (see closure below),
+    // which is required when the JS thread is running a WinUI/DispatcherQueue
+    // message pump: in that state libuv is starved and the TSFN uv_async_send
+    // path never wakes up. Any other thread falls back to the TSFN.
+    //
+    // NOTE: `GetCurrentThreadId` returns a Windows DWORD that the OS is free
+    // to recycle once a thread exits. We assume the register thread outlives
+    // every delegate invocation — this holds for the common case (delegate is
+    // dropped when the subscription is released, and both are typically owned
+    // by the JS thread that registered them). If a Node worker exits while
+    // its delegate is still reachable from another thread, a recycled TID
+    // could steer a cross-thread invocation into the same-thread branch and
+    // touch a stale `napi_env`. Fixing that would require a per-thread epoch
+    // or TLS handshake; not needed for current use cases.
+    let register_tid = unsafe { GetCurrentThreadId() };
+
+    // Raw env is needed to make direct N-API calls from the delegate closure.
+    // It's only ever dereferenced on `register_tid`, so we wrap it in a Send+Sync
+    // newtype to satisfy the DelegateCallback trait bounds.
+    struct SendableEnv(napi::sys::napi_env);
+    unsafe impl Send for SendableEnv {}
+    unsafe impl Sync for SendableEnv {}
+    let raw_env_wrap = Arc::new(SendableEnv(callback.value().env));
+
+    let fn_ref = Arc::new(callback.create_ref()?);
+    let tsfn = callback.build_threadsafe_function().build()?;
 
     let type_handles: Vec<dynwinrt::TypeHandle> = param_types.iter()
       .map(|t| t.0.clone())
       .collect();
 
+    let raw_env_cb = raw_env_wrap.clone();
+    let fn_ref_cb = fn_ref.clone();
+
     let delegate_callback: dynwinrt::delegate::DelegateCallback = Box::new(move |args: &[dynwinrt::WinRTValue]| {
+      // Well-known HRESULTs used below to signal failure to the WinRT event
+      // source (rather than silently returning S_OK, which would look like
+      // the delegate ran).
+      const E_FAIL: windows::core::HRESULT      = windows::core::HRESULT(0x80004005u32 as i32);
+      const E_UNEXPECTED: windows::core::HRESULT = windows::core::HRESULT(0x8000FFFFu32 as i32);
+
+      let current_tid = unsafe { GetCurrentThreadId() };
       let js_args: Vec<DynWinRTValue> = args.iter().map(|a| DynWinRTValue(a.clone())).collect();
-      tsfn.call(js_args, napi::threadsafe_function::ThreadsafeFunctionCallMode::NonBlocking);
+
+      if current_tid == register_tid {
+        // Same-thread synchronous direct invocation. Bypass the TSFN because
+        // libuv may be blocked (e.g. DispatcherQueue.runEventLoop), so
+        // uv_async_send would queue the callback but never fire it.
+        //
+        // The entire body is wrapped in `catch_unwind`: this closure is
+        // ultimately called by an `extern "system"` COM stub, and letting a
+        // Rust panic unwind through the FFI boundary is UB. On panic we
+        // convert to E_UNEXPECTED so the WinRT caller sees a clean failure.
+        let raw_env = raw_env_cb.0;
+        let unwind_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> windows::core::HRESULT {
+          unsafe {
+            let mut scope: napi::sys::napi_handle_scope = std::ptr::null_mut();
+            if napi::sys::napi_open_handle_scope(raw_env, &mut scope) != napi::sys::Status::napi_ok {
+              // Env is probably being torn down. Don't lie to WinRT that we
+              // ran successfully — surface E_FAIL so async ops etc. don't
+              // silently hang waiting for a completion that never happens.
+              eprintln!("[dynwinrt] delegate: napi_open_handle_scope failed (env teardown?)");
+              return E_FAIL;
+            }
+            let scoped_env = napi::Env::from_raw(raw_env);
+            let call_result = (|| -> napi::Result<()> {
+              let fn_scope = fn_ref_cb.borrow_back(&scoped_env)?;
+              let fn_val = napi::JsValue::raw(&fn_scope);
+              // Spread each DynWinRTValue as its own napi_value so the JS
+              // callback receives them as positional args. The blanket
+              // `Vec<T>::into_vec` impl wraps the whole vec as a single JS
+              // Array, which is wrong here — we need one arg per element.
+              let mut argv: Vec<napi::sys::napi_value> = Vec::with_capacity(js_args.len());
+              for v in js_args {
+                let raw = DynWinRTValue::to_napi_value(raw_env, v)?;
+                argv.push(raw);
+              }
+              let mut undefined: napi::sys::napi_value = std::ptr::null_mut();
+              napi::sys::napi_get_undefined(raw_env, &mut undefined);
+              let mut result: napi::sys::napi_value = std::ptr::null_mut();
+              let status = napi::sys::napi_call_function(
+                raw_env,
+                undefined,
+                fn_val,
+                argv.len(),
+                argv.as_ptr(),
+                &mut result,
+              );
+              if status != napi::sys::Status::napi_ok {
+                // Surface any pending JS exception so it doesn't silently poison
+                // future calls. Delegates return HRESULT; there's no clean way to
+                // propagate a JS throw back through WinRT, so we route it through
+                // napi_fatal_exception (same policy tsfn uses).
+                let mut is_pending: bool = false;
+                napi::sys::napi_is_exception_pending(raw_env, &mut is_pending);
+                if is_pending {
+                  let mut err: napi::sys::napi_value = std::ptr::null_mut();
+                  napi::sys::napi_get_and_clear_last_exception(raw_env, &mut err);
+                  napi::sys::napi_fatal_exception(raw_env, err);
+                }
+                return Err(napi::Error::from_reason("napi_call_function failed"));
+              }
+              Ok(())
+            })();
+            napi::sys::napi_close_handle_scope(raw_env, scope);
+            // Log and report any non-exception error to WinRT. Without this,
+            // failures like invalid handles or marshaler errors would be
+            // silently dropped and the delegate would appear to have run.
+            if let Err(e) = call_result {
+              eprintln!("[dynwinrt] delegate dispatch error: {e}");
+              return E_FAIL;
+            }
+            windows::core::HRESULT(0)
+          }
+        }));
+        return match unwind_result {
+          Ok(hr) => hr,
+          Err(_) => {
+            eprintln!("[dynwinrt] delegate: panic caught at FFI boundary");
+            E_UNEXPECTED
+          }
+        };
+      }
+
+      // Cross-thread fallback: schedule via the TSFN. This requires libuv to
+      // be pumping on the JS thread, which is fine for classic Node.js work
+      // but not for a JS thread stuck inside a foreign message pump.
+      tsfn.call(js_args, ThreadsafeFunctionCallMode::NonBlocking);
       windows::core::HRESULT(0)
     });
 

--- a/crates/dynwinrt/src/metadata_table/append_only_arena.rs
+++ b/crates/dynwinrt/src/metadata_table/append_only_arena.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::sync::RwLock;
+
+/// Thread-safe, append-only arena that returns stable heap pointers.
+///
+/// Once a value is pushed:
+/// * its address never changes (values are boxed on the heap), and
+/// * it is never removed until the arena itself is dropped.
+///
+/// Callers may therefore take a raw `*const T` via [`stable_ptr`] while
+/// holding the read guard, drop the guard, and later dereference the
+/// pointer without risk of UAF.
+///
+/// The public surface intentionally exposes only `push`, `stable_ptr`,
+/// and `len` — there is no way to `pop`, `remove`, `retain`, `clear`,
+/// or otherwise invalidate a previously handed-out pointer through
+/// this type. This is a compile-time enforcement of the invariant that
+/// the raw-pointer callers rely on; changing the invariant requires
+/// changing this type, not any downstream caller.
+///
+/// [`stable_ptr`]: AppendOnlyBoxArena::stable_ptr
+pub(super) struct AppendOnlyBoxArena<T> {
+    inner: RwLock<Vec<Box<T>>>,
+}
+
+impl<T> AppendOnlyBoxArena<T> {
+    pub(super) fn new() -> Self {
+        Self { inner: RwLock::new(Vec::new()) }
+    }
+
+    /// Append a value and return its arena index.
+    pub(super) fn push(&self, value: T) -> u32 {
+        let mut g = self.inner.write().unwrap();
+        let idx = g.len() as u32;
+        g.push(Box::new(value));
+        idx
+    }
+
+    /// Get a raw pointer to the boxed value at `index`. The pointer is
+    /// stable for the lifetime of the arena — see the type-level docs.
+    ///
+    /// Panics if `index` is out of range.
+    pub(super) fn stable_ptr(&self, index: u32) -> *const T {
+        let g = self.inner.read().unwrap();
+        &**g.get(index as usize)
+            .expect("AppendOnlyBoxArena index out of range")
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn len(&self) -> usize {
+        self.inner.read().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pointers_stay_valid_across_growth() {
+        let arena: AppendOnlyBoxArena<u64> = AppendOnlyBoxArena::new();
+        let mut ptrs = Vec::new();
+        for i in 0..1024u64 {
+            let idx = arena.push(i);
+            ptrs.push((idx, arena.stable_ptr(idx)));
+        }
+        // Force many more pushes (Vec likely reallocates its backing
+        // buffer several times); the boxed values must remain at their
+        // original heap addresses.
+        for i in 1024..8192u64 {
+            arena.push(i);
+        }
+        for (idx, p) in ptrs {
+            unsafe {
+                assert_eq!(*p, idx as u64);
+            }
+        }
+    }
+}

--- a/crates/dynwinrt/src/metadata_table/arena.rs
+++ b/crates/dynwinrt/src/metadata_table/arena.rs
@@ -130,12 +130,7 @@ impl MetadataTable {
 
         let vtable_index = 6 + table.method_indices.len();
         let method = sig.build(vtable_index);
-        let arena_index = {
-            let mut methods = self.methods.write().unwrap();
-            let idx = methods.len() as u32;
-            methods.push(method);
-            idx
-        };
+        let arena_index = self.methods.push(method);
         table.method_names.push(name.to_string());
         table.method_indices.push(arena_index);
         vtable_index as u32
@@ -202,13 +197,21 @@ impl MetadataTable {
         obj: *mut std::ffi::c_void,
         args: &[WinRTValue],
     ) -> windows_core::Result<Vec<WinRTValue>> {
-        let methods = self.methods.read().unwrap();
-        methods[index as usize].call_dynamic(obj, args)
+        // Grab a stable pointer to the method, then invoke. `AppendOnlyBoxArena`
+        // guarantees the pointer remains valid for the arena's lifetime, which
+        // lets us release the read lock before making the COM call. Holding the
+        // read lock across dispatch would deadlock any re-entrant `push_method`
+        // triggered from within (e.g. an event handler that touches a lazy
+        // proxy while `runEventLoop` is pumping). See the doc comment on
+        // `methods` in mod.rs for the safety argument.
+        let method_ptr: *const crate::signature::Method = self.methods.stable_ptr(index);
+        unsafe { (*method_ptr).call_dynamic(obj, args) }
     }
 
-    /// Read-lock the methods arena. Used by fast getter paths on MethodHandle.
-    pub(crate) fn methods_read(&self) -> std::sync::RwLockReadGuard<'_, Vec<crate::signature::Method>> {
-        self.methods.read().unwrap()
+    /// Get a stable pointer to a Method by arena index. See the safety notes
+    /// on `MetadataTable::methods` for why this is sound.
+    pub(crate) fn method_ptr(&self, index: u32) -> *const crate::signature::Method {
+        self.methods.stable_ptr(index)
     }
 
     pub(super) fn get_method_arena_index_by_vtable(

--- a/crates/dynwinrt/src/metadata_table/method_handle.rs
+++ b/crates/dynwinrt/src/metadata_table/method_handle.rs
@@ -39,28 +39,32 @@ impl MethodHandle {
     }
 
     // --- Fast getter paths: zero Vec/WinRTValue allocation ---
+    //
+    // Each path grabs a stable Method pointer under the read lock via
+    // `method_ptr`, drops the guard, and then makes the COM call. See the
+    // safety comment on `MetadataTable::methods` for why this is sound.
 
     pub fn call_getter_i32(&self, obj: *mut std::ffi::c_void) -> crate::result::Result<i32> {
-        let methods = self.table.methods_read();
-        methods[self.index as usize].call_getter_i32(obj)
+        let method_ptr = self.table.method_ptr(self.index);
+        unsafe { (*method_ptr).call_getter_i32(obj) }
             .map_err(crate::result::Error::WindowsError)
     }
 
     pub fn call_getter_bool(&self, obj: *mut std::ffi::c_void) -> crate::result::Result<bool> {
-        let methods = self.table.methods_read();
-        methods[self.index as usize].call_getter_bool(obj)
+        let method_ptr = self.table.method_ptr(self.index);
+        unsafe { (*method_ptr).call_getter_bool(obj) }
             .map_err(crate::result::Error::WindowsError)
     }
 
     pub fn call_getter_hstring(&self, obj: *mut std::ffi::c_void) -> crate::result::Result<windows_core::HSTRING> {
-        let methods = self.table.methods_read();
-        methods[self.index as usize].call_getter_hstring(obj)
+        let method_ptr = self.table.method_ptr(self.index);
+        unsafe { (*method_ptr).call_getter_hstring(obj) }
             .map_err(crate::result::Error::WindowsError)
     }
 
     pub fn call_getter_object(&self, obj: *mut std::ffi::c_void) -> crate::result::Result<WinRTValue> {
-        let methods = self.table.methods_read();
-        methods[self.index as usize].call_getter_object(obj)
+        let method_ptr = self.table.method_ptr(self.index);
+        unsafe { (*method_ptr).call_getter_object(obj) }
             .map_err(crate::result::Error::WindowsError)
     }
 }

--- a/crates/dynwinrt/src/metadata_table/mod.rs
+++ b/crates/dynwinrt/src/metadata_table/mod.rs
@@ -6,6 +6,7 @@ mod type_handle;
 mod value_data;
 mod method_handle;
 mod arena;
+mod append_only_arena;
 mod iid;
 
 pub use type_kind::*;
@@ -20,6 +21,7 @@ use windows_core::GUID;
 
 use crate::signature::{Method, MethodSignature};
 
+use append_only_arena::AppendOnlyBoxArena;
 use arena::*;
 
 // ===========================================================================
@@ -41,7 +43,22 @@ pub struct MetadataTable {
     enum_entries: RwLock<Vec<EnumData>>,
 
     // --- Methods arena ---
-    methods: RwLock<Vec<Method>>,
+    //
+    // Stored in an `AppendOnlyBoxArena` so entries have heap-stable
+    // addresses that can never be invalidated: callers may take a raw
+    // `*const Method` under the read guard, drop the guard, and then
+    // invoke the method. This is essential because a method call can be
+    // `DispatcherQueue.runEventLoop`, which pumps messages and may
+    // re-enter this arena for `push_method` (requiring `.write()`); if
+    // the outer call still held the read lock during dispatch, we would
+    // deadlock.
+    //
+    // Vec growth may move the `Box<Method>` slots inside the arena's
+    // backing buffer, but the boxed `Method` itself never moves. The
+    // arena type intentionally exposes only `push` / `stable_ptr`
+    // (no `pop`/`remove`/`clear`), so the "never removed" invariant
+    // is enforced by the type system rather than by convention.
+    methods: AppendOnlyBoxArena<Method>,
 
     // --- Indexes (no data duplication, only pointers) ---
     /// IID → method table for O(1) interface method lookup.
@@ -71,7 +88,7 @@ impl MetadataTable {
             inner_types: RwLock::new(Vec::new()),
             inner_type_pairs: RwLock::new(Vec::new()),
             enum_entries: RwLock::new(Vec::new()),
-            methods: RwLock::new(Vec::new()),
+            methods: AppendOnlyBoxArena::new(),
             interface_methods: RwLock::new(HashMap::new()),
             type_names: RwLock::new(HashMap::new()),
         })


### PR DESCRIPTION
This PR fixes several correctness issues in the JS delegate dispatch path and hardens the metadata arena that backs raw method pointers.

The starting point was a repro in the Electron gallery / Node XAML sample:
`DispatcherQueueTimer.onTick` would crash on the first tick with
`TypeError: obj.cast is not a function`, killing `runEventLoop` and
freezing all UI input. Root cause investigation surfaced a stack of
related issues that are all fixed here.