### PR TITLE
project inherited members on WinUI-style runtime classes

### DIFF
--- a/tools/dynwinrt-codegen/src/codegen/project.rs
+++ b/tools/dynwinrt-codegen/src/codegen/project.rs
@@ -354,12 +354,11 @@ pub fn project_class(
         push_registration(&mut registrations, &mut emitted_reg_vars, iface);
     }
     for iface in &class.required_interfaces {
-        if !iface.iid.is_empty()
-            && shared_iids.contains(&iface.iid)
-            && imported_names.contains(&iface.name)
-        {
-            continue;
-        }
+        // Register locally regardless of shared/imported status — the flatten
+        // step below references `_<InterfaceName>.method(...)` in every method
+        // body, so the registration must exist in this file. `registerInterface`
+        // is idempotent in the runtime (dedup by IID), so re-registering a
+        // shared interface across files is safe.
         push_registration(&mut registrations, &mut emitted_reg_vars, iface);
     }
 
@@ -605,9 +604,7 @@ pub fn project_class(
         if req_iface.iid.is_empty() {
             continue;
         }
-        if imported_names.contains(&req_iface.name) {
-            continue;
-        }
+        let is_imported = imported_names.contains(&req_iface.name);
 
         let reg_var = format!("_{}", req_iface.name);
         let mut ri_members = Vec::new();
@@ -630,19 +627,22 @@ pub fn project_class(
         }
 
         // Also build members with this._obj for the standalone interface class
+        // (only emitted when we produce an inline wrapper below).
         let mut ri_own_members = Vec::new();
-        for method in &req_iface.methods {
-            if let Some(m) = project_instance_method(
-                &reg_var,
-                "this._obj",
-                method,
-                known_types,
-                &delegate_names,
-                Some(&req_iface.methods),
-                delegate_sigs,
-                delegate_param_wraps,
-            ) {
-                ri_own_members.push(m);
+        if !is_imported {
+            for method in &req_iface.methods {
+                if let Some(m) = project_instance_method(
+                    &reg_var,
+                    "this._obj",
+                    method,
+                    known_types,
+                    &delegate_names,
+                    Some(&req_iface.methods),
+                    delegate_sigs,
+                    delegate_param_wraps,
+                ) {
+                    ri_own_members.push(m);
+                }
             }
         }
 
@@ -650,6 +650,11 @@ pub fn project_class(
         merge_overload_names(&mut ri_members);
 
         // Flatten: copy members onto the main class.
+        // Always flatten, even when the interface is shared/imported — the
+        // imported .js file gives users an escape hatch (`new IContentControl(x)...`),
+        // but the main class must still expose inherited members directly so that
+        // e.g. `button.background = ...` (from Control) reaches the underlying COM
+        // vtable instead of silently creating a JS-only field.
         // Allow multiple methods with the same name (overloads).
         for member in &ri_members {
             let name = match member {
@@ -676,15 +681,20 @@ pub fn project_class(
             }
         }
 
-        required_ifaces.push(ProjectedRequiredIface {
-            name: req_iface.name.clone(),
-            iid: req_iface.iid.clone(),
-            disposition: RequiredIfaceDisposition::InlineWrapper,
-            members: ri_own_members,
-            registration: None,
-            has_static_from: true,
-            has_parameterized_cast: false,
-        });
+        // Inline wrapper class inside this file — only when the interface is NOT
+        // imported from a shared IContentControl.js. When imported, downstream
+        // code uses that standalone file's class instead.
+        if !is_imported {
+            required_ifaces.push(ProjectedRequiredIface {
+                name: req_iface.name.clone(),
+                iid: req_iface.iid.clone(),
+                disposition: RequiredIfaceDisposition::InlineWrapper,
+                members: ri_own_members,
+                registration: None,
+                has_static_from: true,
+                has_parameterized_cast: false,
+            });
+        }
     }
 
     // Merge overloaded method names: rename `foo2`, `foo3` to `foo` when `foo` exists.

--- a/tools/dynwinrt-codegen/src/codegen/render_js.rs
+++ b/tools/dynwinrt-codegen/src/codegen/render_js.rs
@@ -539,6 +539,23 @@ fn render_member_js(out: &mut String, member: &ProjectedMember, _class_name: &st
                 out.push_str(&format!("        const unsub = this.{}((...args) => {{ unsub(); callback(...args); }});\n", event.subscribe_name));
                 out.push_str("        return unsub;\n");
                 out.push_str("    }\n");
+
+                // offXxx — token-based unsubscribe. DTS advertises this even
+                // when the event has both add and remove; keep JS in sync so
+                // consumers who saved the raw token can call off explicitly.
+                if let Some(idx) = event.remove_vtable_index {
+                    let event_name = event
+                        .subscribe_name
+                        .strip_prefix("on")
+                        .unwrap_or(&event.subscribe_name);
+                    let off_name = format!("off{}", event_name);
+                    out.push_str(&format!("    {}(token) {{\n", off_name));
+                    out.push_str(&format!(
+                        "        {}.method({}).invoke({}, [token]);\n",
+                        event.remove_iface_var, idx, event.remove_obj_expr
+                    ));
+                    out.push_str("    }\n");
+                }
             }
             // Unsubscribe (offX) — standalone event remove
             if event.subscribe_name.is_empty() && !event.unsubscribe_name.is_empty() {

--- a/tools/dynwinrt-codegen/src/main.rs
+++ b/tools/dynwinrt-codegen/src/main.rs
@@ -30,7 +30,7 @@ use dynwinrt_codegen::xml_doc::DocTable;
     # Generate a single namespace (siblings auto-discovered)\n\
     dynwinrt-codegen generate --winmd path\\to\\Microsoft.Windows.AI.Imaging.winmd --namespace Microsoft.Windows.AI.Imaging\n\n\
     # Generate a single class\n\
-    dynwinrt-codegen generate --namespace Windows.Foundation --class Uri\n\n\
+    dynwinrt-codegen generate --namespace Windows.Foundation --class-name Uri\n\n\
     # Custom output directory\n\
     dynwinrt-codegen generate --folder path\\to\\metadata --output ./src/generated")]
 struct Cli {
@@ -80,7 +80,7 @@ enum Commands {
         namespace: Option<String>,
 
         /// Generate bindings for specific class(es), comma-separated (requires --namespace).
-        /// E.g. --class Uri or --class StorageFile,StorageFolder
+        /// E.g. --class-name Uri or --class-name StorageFile,StorageFolder
         #[arg(long, name = "class", value_name = "NAME")]
         class_name: Option<String>,
 
@@ -256,7 +256,7 @@ fn run() -> Result<(), String> {
                 // Class mode: supports comma-separated list (e.g. "StorageFile,StorageFolder")
                 let ns = namespace
                     .as_deref()
-                    .ok_or("--namespace is required when --class is specified")?;
+                    .ok_or("--namespace is required when --class-name is specified")?;
                 let class_names: Vec<&str> = cls_arg
                     .split(',')
                     .map(|s| s.trim())

--- a/tools/dynwinrt-codegen/src/meta.rs
+++ b/tools/dynwinrt-codegen/src/meta.rs
@@ -714,6 +714,51 @@ fn parse_class_from_index(index: &reader::Index, namespace: &str, name: &str) ->
         }
     }
 
+    // 1a. Walk ancestor classes and inherit their interfaces. In WinRT the runtime
+    // reaches parent-class members via QI on the child instance — but each parent's
+    // interface_impls are only listed on the parent's TypeDef, not repeated on the
+    // child. So we walk def.extends() ourselves and flatten every non-generic
+    // ancestor interface onto this class's required_interfaces. Without this,
+    // Button.background (from Control), ScrollViewer.content (from ContentControl),
+    // and every other inherited member is silently absent from the wrapper class.
+    let default_iface_key = default_interface
+        .as_ref()
+        .map(|d| (d.namespace.clone(), d.name.clone()));
+    let mut ancestor_key: Option<(String, String)> = def
+        .extends()
+        .map(|e| (e.namespace().to_string(), e.name().to_string()));
+    while let Some((ext_ns, ext_name)) = ancestor_key.take() {
+        if ext_ns == "System" && ext_name == "Object" {
+            break;
+        }
+        let parent_def = match index.get(&ext_ns, &ext_name).next() {
+            Some(d) => d,
+            None => break,
+        };
+        for iface_impl in parent_def.interface_impls() {
+            let iface_ty = iface_impl.interface(&[]);
+            if let windows_metadata::Type::Name(tn) = &iface_ty {
+                // Skip generic instantiations — parse_interface can't substitute
+                // args here, and their flavor-specific files (IVector_T.js etc.)
+                // are already emitted separately for explicit casts.
+                if !tn.generics.is_empty() {
+                    continue;
+                }
+                let key = (tn.namespace.clone(), tn.name.clone());
+                if default_iface_key.as_ref() == Some(&key) {
+                    continue;
+                }
+                if required_iface_names.iter().any(|k| k == &key) {
+                    continue;
+                }
+                required_iface_names.push(key);
+            }
+        }
+        ancestor_key = parent_def
+            .extends()
+            .map(|e| (e.namespace().to_string(), e.name().to_string()));
+    }
+
     // 1b. Parse required interfaces (e.g. ILanguageModel2, versioned interfaces)
     // These contain instance methods accessible on the class, but on separate COM interfaces.
     let mut required_interfaces: Vec<InterfaceMeta> = Vec::new();
@@ -1229,7 +1274,15 @@ fn resolve_named_type(
         if extends.namespace() == "System" && extends.name() == "Enum" {
             return parse_enum_def(&def);
         }
-        if extends.namespace() == "System" && extends.name() == "Object" {
+        // Any WinRT class extends System.Object directly, or extends another
+        // WinRT class (WinUI XAML: Button -> ButtonBase -> ... -> DependencyObject).
+        // Only structs/enums/delegates hit the branches above; everything else
+        // with an Extends is a runtime class.
+        let is_delegate = matches!(
+            (extends.namespace(), extends.name()),
+            ("System", "Delegate") | ("System", "MulticastDelegate")
+        );
+        if !is_delegate {
             if let Some(default_type) = find_default_interface_type(&def, index) {
                 if default_type.is_async() {
                     return default_type;


### PR DESCRIPTION
This PR fixes three related codegen bugs that prevented dynwinrt from correctly projecting classes whose members are inherited across a chain of interfaces (the common WinUI XAML pattern: `Button → ButtonBase → Control → …`), and refreshes the surrounding documentation which had drifted from the actual CLI and codegen output.