### PR TITLE
Handle null WinRT object returns in generated JavaScript bindings

### DIFF
--- a/tools/dynwinrt-codegen/src/codegen/common.rs
+++ b/tools/dynwinrt-codegen/src/codegen/common.rs
@@ -255,7 +255,21 @@ mod tests {
         // Refs come out as `__DWRT_REF__<name>__`; render layer rewrites.
         assert_eq!(
             convert_return("r", Some(&rt), false, &known, &deferred),
-            "new __DWRT_REF__Uri__(r)"
+            "((v) => v.isNull() ? null : new __DWRT_REF__Uri__(v))(r)"
+        );
+    }
+
+    #[test]
+    fn convert_return_with_unknown_class_preserves_non_null_raw_values() {
+        let rt = TypeMeta::RuntimeClass {
+            namespace: "Windows.Foundation".into(),
+            name: "Uri".into(),
+            default_iid: "abc".into(),
+        };
+
+        assert_eq!(
+            convert_return("r", Some(&rt), false, &HashSet::new(), &HashSet::new()),
+            "((v) => v.isNull() ? null : v)(r)"
         );
     }
 

--- a/tools/dynwinrt-codegen/src/codegen/sig.rs
+++ b/tools/dynwinrt-codegen/src/codegen/sig.rs
@@ -389,6 +389,14 @@ pub(crate) fn resolve_type_name(name: &str, _deferred: &HashSet<String>) -> Stri
     ref_marker(name)
 }
 
+fn wrap_nullable_return(expr: &str, wrapper: &str) -> String {
+    format!("((v) => v.isNull() ? null : new {}(v))({})", wrapper, expr)
+}
+
+fn unwrap_nullable_return(expr: &str) -> String {
+    format!("((v) => v.isNull() ? null : v)({})", expr)
+}
+
 /// Convert an array return expression to the appropriate JS array type.
 pub(crate) fn convert_array_return(
     arr_expr: &str,
@@ -420,11 +428,35 @@ pub(crate) fn convert_array_return(
         }
         TypeMeta::RuntimeClass { name, .. } if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
-            format!("{}.toValues().map(v => new {}(v))", arr_expr, r)
+            format!(
+                "{}.toValues().map(v => v.isNull() ? null : new {}(v))",
+                arr_expr, r
+            )
         }
         TypeMeta::Interface { name, .. } if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
-            format!("{}.toValues().map(v => new {}(v))", arr_expr, r)
+            format!(
+                "{}.toValues().map(v => v.isNull() ? null : new {}(v))",
+                arr_expr, r
+            )
+        }
+        TypeMeta::Parameterized { name, args, .. } => {
+            let concrete = crate::meta::make_parameterized_name(name, args);
+            if known_types.contains(&concrete) {
+                let r = resolve_type_name(&concrete, deferred);
+                format!(
+                    "{}.toValues().map(v => v.isNull() ? null : new {}(v))",
+                    arr_expr, r
+                )
+            } else {
+                format!("{}.toValues().map(v => v.isNull() ? null : v)", arr_expr)
+            }
+        }
+        TypeMeta::Object
+        | TypeMeta::Delegate { .. }
+        | TypeMeta::RuntimeClass { .. }
+        | TypeMeta::Interface { .. } => {
+            format!("{}.toValues().map(v => v.isNull() ? null : v)", arr_expr)
         }
         _ => format!("{}.toValues()", arr_expr),
     }
@@ -463,23 +495,26 @@ pub(crate) fn convert_return(
         Some(TypeMeta::Enum { .. }) => format!("{}.toNumber()", expr),
         Some(TypeMeta::RuntimeClass { name, .. }) if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
-            format!("new {}({})", r, expr)
+            wrap_nullable_return(expr, &r)
         }
         Some(TypeMeta::Struct { name, .. }) if name == "HResult" => format!("{}.toNumber()", expr),
         Some(TypeMeta::Struct { name, .. }) => format!("_unpack{}({})", name, expr),
-        Some(TypeMeta::Delegate { .. }) => expr.to_string(),
+        Some(TypeMeta::Object | TypeMeta::Delegate { .. }) => unwrap_nullable_return(expr),
         Some(TypeMeta::Interface { name, .. }) if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
-            format!("new {}({})", r, expr)
+            wrap_nullable_return(expr, &r)
         }
         Some(TypeMeta::Parameterized { name, args, .. }) => {
             let concrete = crate::meta::make_parameterized_name(name, args);
             if known_types.contains(&concrete) {
                 let r = resolve_type_name(&concrete, deferred);
-                format!("new {}({})", r, expr)
+                wrap_nullable_return(expr, &r)
             } else {
-                expr.to_string()
+                unwrap_nullable_return(expr)
             }
+        }
+        Some(TypeMeta::RuntimeClass { .. } | TypeMeta::Interface { .. }) => {
+            unwrap_nullable_return(expr)
         }
         Some(TypeMeta::Array(inner)) => {
             let arr_expr = format!("{}.asArray()", expr);

--- a/tools/dynwinrt-codegen/tests/nullable_return_test.rs
+++ b/tools/dynwinrt-codegen/tests/nullable_return_test.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use dynwinrt_codegen::codegen::{project, render_dts, render_js};
+use dynwinrt_codegen::meta;
+use dynwinrt_codegen::types::TypeMeta;
+
+const WINDOWS_WINMD: &str =
+    r"C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.26100.0\Windows.winmd";
+
+#[test]
+fn nullable_runtime_class_returns_are_guarded_without_type_changes() {
+    if !Path::new(WINDOWS_WINMD).exists() {
+        eprintln!("Skipping: Windows.winmd not found");
+        return;
+    }
+
+    let Some(accelerometer) =
+        meta::parse_class(WINDOWS_WINMD, "Windows.Devices.Sensors", "Accelerometer")
+    else {
+        panic!("Accelerometer metadata not found");
+    };
+
+    let roots = vec![accelerometer];
+    let deps = meta::resolve_dependencies(WINDOWS_WINMD, &roots, &[], &[]);
+    let mut classes = roots;
+    classes.extend(deps.classes);
+    let interfaces = deps.interfaces;
+
+    let mut known_types = HashSet::new();
+    for class in &classes {
+        known_types.insert(class.name.clone());
+    }
+    for interface in &interfaces {
+        known_types.insert(interface.name.clone());
+    }
+    for en in &deps.enums {
+        if let TypeMeta::Enum { name, .. } = en {
+            known_types.insert(name.clone());
+        }
+    }
+
+    let delegate_type_names: HashSet<String> = interfaces
+        .iter()
+        .filter(|interface| {
+            interface
+                .methods
+                .iter()
+                .any(|method| method.name == ".ctor")
+                && interface
+                    .methods
+                    .iter()
+                    .any(|method| method.name == "Invoke")
+        })
+        .map(|interface| interface.name.clone())
+        .collect();
+    let (delegate_sigs, delegate_sig_refs, delegate_param_wraps) =
+        project::build_delegate_signatures(&interfaces, &delegate_type_names, &known_types);
+
+    let class = classes
+        .iter()
+        .find(|class| class.name == "Accelerometer")
+        .expect("Accelerometer class missing after dependency resolution");
+    let projected = project::project_class(
+        class,
+        &known_types,
+        &delegate_type_names,
+        &HashSet::new(),
+        &delegate_sigs,
+        &delegate_sig_refs,
+        &delegate_param_wraps,
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+
+    assert!(js.contains("v.isNull() ? null : new Accelerometer(v)"));
+    assert!(dts.contains("static getDefault(): Accelerometer;"));
+    assert!(dts.contains("Promise<Accelerometer>"));
+    assert!(dts.contains("getCurrentReading(): AccelerometerReading;"));
+}

--- a/tools/dynwinrt-codegen/tests/snapshots/uri/Uri.js
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri/Uri.js
@@ -137,7 +137,7 @@ class Uri {
         return _IUriRuntimeClass.method(14).invoke(this._obj, []).toString();
     }
     get queryParsed() {
-        return new (__get_WwwFormUrlDecoder())(_IUriRuntimeClass.method(15).invoke(this._obj, []));
+        return ((v) => v.isNull() ? null : new (__get_WwwFormUrlDecoder())(v))(_IUriRuntimeClass.method(15).invoke(this._obj, []));
     }
     get rawUri() {
         return _IUriRuntimeClass.method(16).invoke(this._obj, []).toString();
@@ -158,7 +158,7 @@ class Uri {
         return _IUriRuntimeClass.method(21).invoke(this._obj, [(pUri == null ? DynWinRtValue.nullValue() : _unwrap(pUri))]).toBool();
     }
     combineUri(relativeUri) {
-        return new Uri(_IUriRuntimeClass.method(22).invoke(this._obj, [DynWinRtValue.hstring(relativeUri)]));
+        return ((v) => v.isNull() ? null : new Uri(v))(_IUriRuntimeClass.method(22).invoke(this._obj, [DynWinRtValue.hstring(relativeUri)]));
     }
     toString() {
         return IStringable.from(this._obj).toString();


### PR DESCRIPTION
WinRT APIs can return `S_OK` with a null object pointer. For example, `Accelerometer.GetDefault()` returns null when no accelerometer is available.

Generated bindings previously constructed a wrapper unconditionally, causing a `QueryInterface` error for valid null results.

This change:

- Checks `DynWinRtValue.isNull()` before constructing object wrappers.
- Returns JavaScript `null` for null WinRT object results.
- Preserves existing TypeScript signatures.
- Leaves failed HRESULT behavior unchanged.