### PR TITLE
Enable WinUI 3 Application + Window hosting with Fluent themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ console.log(result.text);
 
 That's the whole story: install, generate, import, call.
 
-> **Scope** — `dynwinrt` targets **data-style WinRT APIs** (AI, storage, networking, notifications, globalization, cryptography, sensors, …). It is **not** built for XAML / WinUI hosting — those need composable-class aggregation and a UI thread the library doesn't model. For everything else, it is the easiest path from JavaScript / TypeScript to native Windows.
+> **Scope** — `dynwinrt` primarily targets **data-style WinRT APIs**. WinUI `Application + Window` hosting is also supported on a caller-managed STA UI thread; the application remains responsible for package identity and lifecycle.
 
 ## Quick start
 
@@ -51,6 +51,29 @@ console.log(uri.host);                                 // "example.com"
 ```
 
 Generated bindings include async + progress support, generic collections (`IVector<T>`, `IMap<K,V>`), structs, enums, and delegates — see `tools/dynwinrt-codegen/npm/README.md` for the full feature list.
+
+### WinUI `Application + Window`
+
+When `Microsoft.UI.Xaml.Application` is selected, JavaScript codegen also emits `XamlControlsXamlMetaDataProvider` and `XamlControlsResources`. Use the generated helper to compose the application outer, register WinUI metadata, and install the default Fluent resources before creating controls:
+
+```js
+const { roInitialize } = require('@microsoft/dynwinrt');
+const { Application, Button, Window } = require('./generated');
+
+roInitialize(0); // STA
+
+let app;
+Application.start(() => {
+  app = Application.createWithFluentResources(() => {
+    const window = Window.createInstance(null);
+    window.content = Button.createInstance(null);
+    window.activate();
+  });
+  app.requestedTheme = 1; // Dark
+});
+```
+
+`Application.start()` runs the WinUI dispatcher loop. `createWithFluentResources()` also configures its UI thread for Per-Monitor V2 DPI awareness so WinUI content renders at the monitor's native scale. Launch this from a packaged or otherwise correctly initialized WinAppSDK process.
 
 ## Repository layout
 

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -14,7 +14,7 @@ If you've ever tried to call a Windows API from an Electron or Node app, you've 
 
 `dynwinrt` removes all of that. It reads the `.winmd` metadata that ships with the Windows SDK (and WinAppSDK NuGet packages) at **runtime**, resolves the COM vtables, and invokes WinRT methods dynamically. There is no native build step in your Electron project. There is no version pinning — the same generated bindings work across Windows SDK / WinAppSDK revisions as long as the metadata is forward-compatible. You just install `@microsoft/dynwinrt` from npm and call the API.
 
-The trade-off: `dynwinrt` is designed for **data-style WinRT APIs** (AI, storage, notifications, networking, globalization, …). It is **not** intended for XAML / WinUI hosting — those scenarios need composable-class aggregation and a UI thread the library doesn't model. For everything else, this is the easiest path from JavaScript to native Windows.
+The runtime primarily targets **data-style WinRT APIs** (AI, storage, notifications, networking, globalization, …). It also supports WinUI `Application + Window` hosting through the generated `Application.createWithFluentResources()` helper when the caller supplies an STA UI thread, package identity, and application lifecycle. The helper enables Per-Monitor V2 DPI awareness on that UI thread.
 
 ## Quick start
 

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -434,6 +434,24 @@ impl DynWinRTValue {
     Ok(DynWinRTValue(factory))
   }
 
+  /// Create a composed WinUI Application that forwards IXamlMetadataProvider
+  /// calls to the supplied provider.
+  #[napi]
+  pub fn create_xaml_application(
+    metadata_provider: &DynWinRTValue,
+    launched_callback: Option<&DynWinRTValue>,
+  ) -> napi::Result<DynWinRTValue> {
+    let provider = metadata_provider.0.as_object()
+      .ok_or_else(|| napi::Error::from_reason("createXamlApplication: metadataProvider must be an Object"))?;
+    let callback = launched_callback
+      .map(|value| value.0.as_object()
+        .ok_or_else(|| napi::Error::from_reason("createXamlApplication: launchedCallback must be an Object")))
+      .transpose()?;
+    dynwinrt::create_xaml_application(&provider, callback.as_ref())
+      .map(DynWinRTValue)
+      .map_err(|e| napi::Error::from_reason(format!("createXamlApplication failed: {}", e.message())))
+  }
+
   #[napi]
   pub fn bool_value(value: bool) -> DynWinRTValue {
     DynWinRTValue(dynwinrt::WinRTValue::Bool(value))

--- a/crates/dynwinrt/Cargo.toml
+++ b/crates/dynwinrt/Cargo.toml
@@ -29,6 +29,7 @@ features = [
     "Win32_System_Com",
     "Win32_System_LibraryLoader",
     "Win32_System_WinRT",
+    "Win32_UI_HiDpi",
     "Management_Deployment",
 ]
 

--- a/crates/dynwinrt/src/lib.rs
+++ b/crates/dynwinrt/src/lib.rs
@@ -11,6 +11,7 @@ mod roapi;
 mod signature;
 mod value;
 mod winapp;
+mod xaml_application;
 
 mod array;
 #[macro_use]
@@ -29,6 +30,7 @@ pub use crate::metadata_table::{TypeHandle, TypeKind, MetadataTable, MethodHandl
 pub use crate::array::ArrayData;
 pub use crate::value::WinRTValue;
 pub use crate::winapp::{WinAppSdkContext, initialize_winappsdk};
+pub use crate::xaml_application::create_xaml_application;
 pub use crate::dasync::{create_progress_handler, ProgressCallback};
 pub use interfaces::uri_vtable;
 

--- a/crates/dynwinrt/src/xaml_application.rs
+++ b/crates/dynwinrt/src/xaml_application.rs
@@ -1,0 +1,523 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use core::ffi::c_void;
+use std::sync::Mutex;
+
+use windows::Win32::System::Com::{CoTaskMemAlloc, CoTaskMemFree};
+use windows::Win32::UI::HiDpi::{
+    DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, SetThreadDpiAwarenessContext,
+};
+use windows_core::{GUID, HRESULT, HSTRING, IInspectable, IUnknown, Interface};
+
+use crate::com_helpers::{E_FAIL, E_NOINTERFACE, E_POINTER, IInspectableVtbl, S_OK};
+use crate::{Result, WinRTValue};
+
+const IID_IAPPLICATION_FACTORY: GUID = GUID::from_u128(0x9fd96657_5294_5a65_a1db_4fea143597da);
+const IID_IAPPLICATION_OVERRIDES: GUID = GUID::from_u128(0xa33e81ef_c665_503b_8827_d27ef1720a06);
+const IID_IXAML_METADATA_PROVIDER: GUID = GUID::from_u128(0xa96251f0_2214_5d53_8746_ce99a2593cd7);
+const IID_XAML_LAUNCHED_CALLBACK: GUID = GUID::from_u128(0xf81c4e72_7a18_4a30_9126_6f62b6bdac83);
+
+#[repr(C)]
+struct ApplicationFactoryVtbl {
+    base: IInspectableVtbl,
+    create_instance: unsafe extern "system" fn(
+        this: *mut c_void,
+        outer: *mut c_void,
+        inner: *mut *mut c_void,
+        instance: *mut *mut c_void,
+    ) -> HRESULT,
+}
+
+#[repr(C)]
+struct ApplicationOverridesVtbl {
+    base: IInspectableVtbl,
+    on_launched: unsafe extern "system" fn(this: *mut c_void, args: *mut c_void) -> HRESULT,
+}
+
+#[repr(C)]
+struct DelegateVtbl {
+    base: windows_core::IUnknown_Vtbl,
+    invoke: unsafe extern "system" fn(
+        this: *mut c_void,
+        arg: *mut c_void,
+        unused: *mut c_void,
+    ) -> HRESULT,
+}
+
+#[repr(C)]
+struct XamlMetadataProviderVtbl {
+    base: IInspectableVtbl,
+    get_xaml_type: unsafe extern "system" fn(
+        this: *mut c_void,
+        type_name: AbiTypeName,
+        result: *mut *mut c_void,
+    ) -> HRESULT,
+    get_xaml_type_by_full_name: unsafe extern "system" fn(
+        this: *mut c_void,
+        full_name: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT,
+    get_xmlns_definitions: unsafe extern "system" fn(
+        this: *mut c_void,
+        count: *mut u32,
+        result: *mut *mut c_void,
+    ) -> HRESULT,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct AbiTypeName {
+    name: *mut c_void,
+    kind: i32,
+}
+
+#[repr(C)]
+struct XamlApplicationHost {
+    vtable_overrides: *const ApplicationOverridesVtbl,
+    vtable_metadata: *const XamlMetadataProviderVtbl,
+    ref_count: windows_core::imp::WeakRefCount,
+    metadata_provider: IUnknown,
+    launched_callback: Option<IUnknown>,
+    inner: Mutex<Option<IUnknown>>,
+}
+
+unsafe impl Send for XamlApplicationHost {}
+unsafe impl Sync for XamlApplicationHost {}
+
+impl XamlApplicationHost {
+    const OVERRIDES_VTBL: ApplicationOverridesVtbl = ApplicationOverridesVtbl {
+        base: IInspectableVtbl {
+            base: windows_core::IUnknown_Vtbl {
+                QueryInterface: Self::query_interface_overrides,
+                AddRef: Self::add_ref_overrides,
+                Release: Self::release_overrides,
+            },
+            get_iids: Self::get_iids_overrides,
+            get_runtime_class_name: Self::get_runtime_class_name_overrides,
+            get_trust_level: Self::get_trust_level_overrides,
+        },
+        on_launched: Self::on_launched,
+    };
+
+    const METADATA_VTBL: XamlMetadataProviderVtbl = XamlMetadataProviderVtbl {
+        base: IInspectableVtbl {
+            base: windows_core::IUnknown_Vtbl {
+                QueryInterface: Self::query_interface_metadata,
+                AddRef: Self::add_ref_metadata,
+                Release: Self::release_metadata,
+            },
+            get_iids: Self::get_iids_metadata,
+            get_runtime_class_name: Self::get_runtime_class_name_metadata,
+            get_trust_level: Self::get_trust_level_metadata,
+        },
+        get_xaml_type: Self::get_xaml_type,
+        get_xaml_type_by_full_name: Self::get_xaml_type_by_full_name,
+        get_xmlns_definitions: Self::get_xmlns_definitions,
+    };
+
+    fn new(metadata_provider: IUnknown, launched_callback: Option<IUnknown>) -> Box<Self> {
+        Box::new(Self {
+            vtable_overrides: &Self::OVERRIDES_VTBL,
+            vtable_metadata: &Self::METADATA_VTBL,
+            ref_count: windows_core::imp::WeakRefCount::new(),
+            metadata_provider,
+            launched_callback,
+            inner: Mutex::new(None),
+        })
+    }
+
+    unsafe fn from_overrides_ptr(this: *mut c_void) -> &'static Self {
+        &*(this as *const Self)
+    }
+
+    unsafe fn from_metadata_ptr(this: *mut c_void) -> &'static Self {
+        let base = (this as *const *const c_void).sub(1) as *const Self;
+        &*base
+    }
+
+    fn identity_ptr(&self) -> *mut c_void {
+        self as *const Self as *mut c_void
+    }
+
+    fn metadata_ptr(&self) -> *mut c_void {
+        unsafe { (self.identity_ptr() as *mut *mut c_void).add(1) as *mut c_void }
+    }
+
+    fn inner(&self) -> std::result::Result<Option<IUnknown>, HRESULT> {
+        self.inner
+            .lock()
+            .map(|inner| inner.clone())
+            .map_err(|_| E_FAIL)
+    }
+
+    unsafe extern "system" fn query_interface_overrides(
+        this: *mut c_void,
+        iid: *const GUID,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        Self::query_interface_impl(Self::from_overrides_ptr(this), iid, result)
+    }
+
+    unsafe extern "system" fn query_interface_metadata(
+        this: *mut c_void,
+        iid: *const GUID,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        Self::query_interface_impl(Self::from_metadata_ptr(this), iid, result)
+    }
+
+    unsafe fn query_interface_impl(
+        host: &Self,
+        iid: *const GUID,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        if iid.is_null() || result.is_null() {
+            return E_POINTER;
+        }
+
+        *result = std::ptr::null_mut();
+        let iid = &*iid;
+        if *iid == IUnknown::IID
+            || *iid == IInspectable::IID
+            || *iid == IID_IAPPLICATION_OVERRIDES
+            || *iid == windows_core::imp::IAgileObject::IID
+        {
+            *result = host.identity_ptr();
+            host.ref_count.add_ref();
+            return S_OK;
+        }
+        if *iid == IID_IXAML_METADATA_PROVIDER {
+            *result = host.metadata_ptr();
+            host.ref_count.add_ref();
+            return S_OK;
+        }
+        if *iid == windows_core::imp::IMarshal::IID {
+            host.ref_count.add_ref();
+            return windows_core::imp::marshaler(core::mem::transmute(host.identity_ptr()), result);
+        }
+        let tear_off = host.ref_count.query(iid, host.identity_ptr());
+        if !tear_off.is_null() {
+            *result = tear_off;
+            return S_OK;
+        }
+
+        match host.inner() {
+            Ok(Some(inner)) => inner.query(iid, result),
+            Ok(None) => E_NOINTERFACE,
+            Err(hr) => hr,
+        }
+    }
+
+    unsafe extern "system" fn add_ref_overrides(this: *mut c_void) -> u32 {
+        Self::from_overrides_ptr(this).ref_count.add_ref()
+    }
+
+    unsafe extern "system" fn add_ref_metadata(this: *mut c_void) -> u32 {
+        Self::from_metadata_ptr(this).ref_count.add_ref()
+    }
+
+    unsafe extern "system" fn release_overrides(this: *mut c_void) -> u32 {
+        Self::release_impl(Self::from_overrides_ptr(this))
+    }
+
+    unsafe extern "system" fn release_metadata(this: *mut c_void) -> u32 {
+        Self::release_impl(Self::from_metadata_ptr(this))
+    }
+
+    unsafe fn release_impl(host: &Self) -> u32 {
+        let remaining = host.ref_count.release();
+        if remaining == 0 {
+            drop(Box::from_raw(host.identity_ptr() as *mut Self));
+        }
+        remaining
+    }
+
+    unsafe extern "system" fn get_iids_overrides(
+        this: *mut c_void,
+        count: *mut u32,
+        result: *mut *mut GUID,
+    ) -> HRESULT {
+        Self::get_iids_impl(Self::from_overrides_ptr(this), count, result)
+    }
+
+    unsafe extern "system" fn get_iids_metadata(
+        this: *mut c_void,
+        count: *mut u32,
+        result: *mut *mut GUID,
+    ) -> HRESULT {
+        Self::get_iids_impl(Self::from_metadata_ptr(this), count, result)
+    }
+
+    unsafe fn get_iids_impl(host: &Self, count: *mut u32, result: *mut *mut GUID) -> HRESULT {
+        if count.is_null() || result.is_null() {
+            return E_POINTER;
+        }
+
+        let local_iids = [IID_IAPPLICATION_OVERRIDES, IID_IXAML_METADATA_PROVIDER];
+        let mut inner_count = 0;
+        let mut inner_iids = std::ptr::null_mut();
+        match host.inner() {
+            Ok(Some(inner)) => {
+                let vtable = *(inner.as_raw() as *const *const IInspectableVtbl);
+                let hr = ((*vtable).get_iids)(inner.as_raw(), &mut inner_count, &mut inner_iids);
+                if hr.is_err() {
+                    return hr;
+                }
+            }
+            Ok(None) => {}
+            Err(hr) => return hr,
+        }
+
+        let total = local_iids.len() + inner_count as usize;
+        let bytes = total
+            .checked_mul(std::mem::size_of::<GUID>())
+            .unwrap_or(usize::MAX);
+        let combined = CoTaskMemAlloc(bytes) as *mut GUID;
+        if combined.is_null() {
+            if !inner_iids.is_null() {
+                CoTaskMemFree(Some(inner_iids.cast()));
+            }
+            return HRESULT(0x8007000Eu32 as i32);
+        }
+
+        std::ptr::copy_nonoverlapping(local_iids.as_ptr(), combined, local_iids.len());
+        if inner_count != 0 {
+            std::ptr::copy_nonoverlapping(
+                inner_iids,
+                combined.add(local_iids.len()),
+                inner_count as usize,
+            );
+        }
+        if !inner_iids.is_null() {
+            CoTaskMemFree(Some(inner_iids.cast()));
+        }
+
+        *count = total as u32;
+        *result = combined;
+        S_OK
+    }
+
+    unsafe extern "system" fn get_runtime_class_name_overrides(
+        this: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        Self::get_runtime_class_name_impl(Self::from_overrides_ptr(this), result)
+    }
+
+    unsafe extern "system" fn get_runtime_class_name_metadata(
+        this: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        Self::get_runtime_class_name_impl(Self::from_metadata_ptr(this), result)
+    }
+
+    unsafe fn get_runtime_class_name_impl(host: &Self, result: *mut *mut c_void) -> HRESULT {
+        if result.is_null() {
+            return E_POINTER;
+        }
+        match host.inner() {
+            Ok(Some(inner)) => {
+                let vtable = *(inner.as_raw() as *const *const IInspectableVtbl);
+                ((*vtable).get_runtime_class_name)(inner.as_raw(), result)
+            }
+            Ok(None) => {
+                *result = std::ptr::null_mut();
+                S_OK
+            }
+            Err(hr) => hr,
+        }
+    }
+
+    unsafe extern "system" fn get_trust_level_overrides(
+        this: *mut c_void,
+        result: *mut i32,
+    ) -> HRESULT {
+        Self::get_trust_level_impl(Self::from_overrides_ptr(this), result)
+    }
+
+    unsafe extern "system" fn get_trust_level_metadata(
+        this: *mut c_void,
+        result: *mut i32,
+    ) -> HRESULT {
+        Self::get_trust_level_impl(Self::from_metadata_ptr(this), result)
+    }
+
+    unsafe fn get_trust_level_impl(host: &Self, result: *mut i32) -> HRESULT {
+        if result.is_null() {
+            return E_POINTER;
+        }
+        match host.inner() {
+            Ok(Some(inner)) => {
+                let vtable = *(inner.as_raw() as *const *const IInspectableVtbl);
+                ((*vtable).get_trust_level)(inner.as_raw(), result)
+            }
+            Ok(None) => {
+                *result = 0;
+                S_OK
+            }
+            Err(hr) => hr,
+        }
+    }
+
+    unsafe extern "system" fn on_launched(this: *mut c_void, args: *mut c_void) -> HRESULT {
+        let host = Self::from_overrides_ptr(this);
+        let Some(callback) = host.launched_callback.as_ref() else {
+            return S_OK;
+        };
+        let callback_ptr = callback.as_raw();
+        let vtable = *(callback_ptr as *const *const DelegateVtbl);
+        ((*vtable).invoke)(callback_ptr, args, std::ptr::null_mut())
+    }
+
+    unsafe extern "system" fn get_xaml_type(
+        this: *mut c_void,
+        type_name: AbiTypeName,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        let host = Self::from_metadata_ptr(this);
+        let provider = host.metadata_provider.as_raw();
+        let vtable = *(provider as *const *const XamlMetadataProviderVtbl);
+        ((*vtable).get_xaml_type)(provider, type_name, result)
+    }
+
+    unsafe extern "system" fn get_xaml_type_by_full_name(
+        this: *mut c_void,
+        full_name: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        let host = Self::from_metadata_ptr(this);
+        let provider = host.metadata_provider.as_raw();
+        let vtable = *(provider as *const *const XamlMetadataProviderVtbl);
+        ((*vtable).get_xaml_type_by_full_name)(provider, full_name, result)
+    }
+
+    unsafe extern "system" fn get_xmlns_definitions(
+        this: *mut c_void,
+        count: *mut u32,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        let host = Self::from_metadata_ptr(this);
+        let provider = host.metadata_provider.as_raw();
+        let vtable = *(provider as *const *const XamlMetadataProviderVtbl);
+        ((*vtable).get_xmlns_definitions)(provider, count, result)
+    }
+}
+
+fn query_interface(object: &IUnknown, iid: &GUID) -> windows_core::Result<IUnknown> {
+    let mut result = std::ptr::null_mut();
+    unsafe {
+        object.query(iid, &mut result).ok()?;
+        Ok(IUnknown::from_raw(result))
+    }
+}
+
+fn enable_per_monitor_v2() -> windows_core::Result<()> {
+    // WinUI windows inherit DPI awareness from the UI thread that creates them.
+    let previous =
+        unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
+    if previous.0.is_null() {
+        Err(windows_core::Error::from_thread())
+    } else {
+        Ok(())
+    }
+}
+
+struct InitialHostRef(*mut XamlApplicationHost);
+
+impl Drop for InitialHostRef {
+    fn drop(&mut self) {
+        unsafe {
+            XamlApplicationHost::release_impl(&*self.0);
+        }
+    }
+}
+
+fn compose_xaml_application(
+    factory: &IUnknown,
+    metadata_provider: IUnknown,
+    launched_callback: Option<IUnknown>,
+) -> windows_core::Result<IUnknown> {
+    let host = XamlApplicationHost::new(metadata_provider, launched_callback);
+    let host_ptr = Box::into_raw(host);
+    let _initial_ref = InitialHostRef(host_ptr);
+    let outer = host_ptr as *mut c_void;
+    let mut inner = std::ptr::null_mut();
+    let mut instance = std::ptr::null_mut();
+
+    let vtable = unsafe { *(factory.as_raw() as *const *const ApplicationFactoryVtbl) };
+    let hr =
+        unsafe { ((*vtable).create_instance)(factory.as_raw(), outer, &mut inner, &mut instance) };
+    if hr.is_err() {
+        unsafe {
+            if !instance.is_null() {
+                drop(IUnknown::from_raw(instance));
+            }
+            if !inner.is_null() {
+                drop(IUnknown::from_raw(inner));
+            }
+        }
+        return Err(windows_core::Error::from_hresult(hr));
+    }
+    if inner.is_null() || instance.is_null() {
+        unsafe {
+            if !instance.is_null() {
+                drop(IUnknown::from_raw(instance));
+            }
+            if !inner.is_null() {
+                drop(IUnknown::from_raw(inner));
+            }
+        }
+        return Err(windows_core::Error::from_hresult(E_POINTER));
+    }
+
+    unsafe {
+        let inner = IUnknown::from_raw(inner);
+        let application = IUnknown::from_raw(instance);
+        *(*host_ptr)
+            .inner
+            .lock()
+            .map_err(|_| windows_core::Error::from_hresult(E_FAIL))? = Some(inner);
+        Ok(application)
+    }
+}
+
+/// Create a composed WinUI `Application` whose outer object exposes the supplied
+/// `IXamlMetadataProvider`.
+pub fn create_xaml_application(
+    metadata_provider: &IUnknown,
+    launched_callback: Option<&IUnknown>,
+) -> Result<WinRTValue> {
+    enable_per_monitor_v2()?;
+    let provider = query_interface(metadata_provider, &IID_IXAML_METADATA_PROVIDER)?;
+    let activation_factory =
+        crate::ro_get_activation_factory_2(&HSTRING::from("Microsoft.UI.Xaml.Application"))?;
+    let factory = activation_factory
+        .as_object()
+        .expect("activation factory must be an object");
+    let factory = query_interface(&factory, &IID_IAPPLICATION_FACTORY)?;
+    let callback = launched_callback
+        .map(|callback| query_interface(callback, &IID_XAML_LAUNCHED_CALLBACK))
+        .transpose()?;
+    let application = compose_xaml_application(&factory, provider, callback)?;
+    Ok(WinRTValue::Object(application))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows::Win32::UI::HiDpi::{AreDpiAwarenessContextsEqual, GetThreadDpiAwarenessContext};
+
+    #[test]
+    fn enables_per_monitor_v2_on_the_ui_thread() {
+        enable_per_monitor_v2().unwrap();
+
+        let current = unsafe { GetThreadDpiAwarenessContext() };
+        assert!(unsafe {
+            AreDpiAwarenessContextsEqual(current, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+                .as_bool()
+        });
+    }
+}

--- a/docs/guides/node/dev-mode.md
+++ b/docs/guides/node/dev-mode.md
@@ -8,8 +8,8 @@ The [WinApp CLI](https://github.com/microsoft/winappCli) handles all the packagi
 - [Prerequisites](#prerequisites)
 - [Path A — execution alias (recommended for iteration)](#path-a--execution-alias-recommended-for-iteration)
 - [Path B — one-shot `winapp run` (recommended for scripts and CI)](#path-b--one-shot-winapp-run-recommended-for-scripts-and-ci)
-- [Path C — bare `winapp run` without a copied Node](#path-c--bare-winapp-run-without-a-copied-node)
-- [Why copy `node.exe` into the project?](#why-copy-nodeexe-into-the-project)
+- [Path C — bare `winapp run` without a local Node link](#path-c--bare-winapp-run-without-a-local-node-link)
+- [Why link `node.exe` into the project?](#why-link-nodeexe-into-the-project)
 - [Cleaning up: `winapp unregister`](#cleaning-up-winapp-unregister)
 - [From dev mode to distribution](#from-dev-mode-to-distribution)
 - [Troubleshooting](#troubleshooting)
@@ -53,14 +53,13 @@ Now pick one of the three paths below depending on your workflow.
 
 Best when you want to iterate quickly on the same experiment: register **once**, then invoke your script many times from **any terminal** through a personal command name like `mynode.exe`.
 
-### 1. Copy Node into the project
+### 1. Link Node into the project
 
 ```powershell
-mkdir .local-node
-copy (Get-Command node).Source .\.local-node\node.exe
+New-Item -ItemType Junction -Path .\.local-node -Target (Split-Path (Get-Command node).Source)
 ```
 
-See [Why copy `node.exe` into the project?](#why-copy-nodeexe-into-the-project) below for the rationale.
+This exposes the active Node installation at `.local-node` without copying its files. See [Why link `node.exe` into the project?](#why-link-nodeexe-into-the-project) below for the rationale.
 
 ### 2. Add an execution alias
 
@@ -97,8 +96,7 @@ Best when you want a **single command** that does everything in one go — no pe
 Skip the alias step and let `winapp run` do register-launch-unregister in one go:
 
 ```powershell
-mkdir .local-node
-copy (Get-Command node).Source .\.local-node\node.exe
+New-Item -ItemType Junction -Path .\.local-node -Target (Split-Path (Get-Command node).Source)
 
 npx winapp run . --exe .local-node\node.exe --args "app.js" --unregister-on-exit
 ```
@@ -112,9 +110,9 @@ What this does:
 
 Every run pays a couple of seconds for register + unregister, so it's slower than Path A for tight loops, but it leaves nothing behind afterwards.
 
-## Path C — bare `winapp run` without a copied Node
+## Path C — bare `winapp run` without a local Node link
 
-If you don't need a stable executable path (e.g. you just want to run `node --version` under identity to check something), you can point `--exe` at the system `node.exe` directly:
+If you don't want a project-local junction (for example, you just want to run `node --version` under identity to check something), you can point `--exe` at the system `node.exe` directly:
 
 ```powershell
 npx winapp run . --exe (Get-Command node).Source --args "app.js" --unregister-on-exit
@@ -125,19 +123,19 @@ This works, but it's not recommended for anything you'll iterate on:
 - **A Node upgrade or `nvm use` changes where `node.exe` lives.** Your package will silently point at whatever version happens to be first on `PATH` at register time, not the one you meant.
 - **Windows caches the executable path in the registered manifest.** If `node.exe` moves, the package can end up pointing at a stale file and fail to launch.
 
-Copy Node into the project (Paths A / B) for anything you'll come back to more than once.
+Link Node into the project (Paths A / B) for anything you'll come back to more than once.
 
-## Why copy `node.exe` into the project?
+## Why link `node.exe` into the project?
 
-Windows loose-layout packages resolve executables **relative to the package root**. Your app's registered manifest needs to point at an `.exe` inside the package layout — the system `node.exe` at `C:\Program Files\nodejs\node.exe` (or wherever nvm dropped it) isn't part of your package.
+Windows loose-layout packages resolve executables **relative to the package root**. A directory junction exposes your installed Node directory through the package-relative path `.local-node`, without duplicating the Node installation.
 
-Copying `node.exe` into `.local-node\node.exe` gives you:
+Linking the Node directory at `.local-node` gives you:
 
-- **A stable, in-project path.** The manifest points at `.local-node\node.exe` and never breaks when your global Node changes.
-- **A pinned Node version.** The copy is frozen at the moment you set up the experiment — global upgrades don't affect it. Handy when comparing behavior across Node versions.
+- **A stable, in-project path.** The manifest always points at `.local-node\node.exe`.
+- **No duplicated runtime files.** The junction uses Node directly from its installed directory.
 - **Ability to add an execution alias.** Execution aliases can only alias `.exe` files inside the package. A system-wide `node.exe` isn't eligible.
 
-The copy is a plain byte-for-byte copy of `node.exe` — no wrapper, no launcher script. Everything about how it runs your `app.js` is identical to `node app.js`, except that it has package identity.
+The junction targets whichever Node installation is active when you create it. If a version manager later switches Node to a different directory, remove and recreate `.local-node` so it points at the new installation.
 
 ## Cleaning up: `winapp unregister`
 

--- a/tools/dynwinrt-codegen/src/codegen/project.rs
+++ b/tools/dynwinrt-codegen/src/codegen/project.rs
@@ -51,6 +51,10 @@ const PIID_IMAP: &str = "3c2925fe-8519-45c1-aa79-197b6718c1c1";
 const PIID_IMAP_VIEW: &str = "e480ce40-a338-4ada-adcf-272272e48cb9";
 const ICLOSABLE_IID: &str = "30d5a829-7fa4-4026-83bb-d75bae4ea99e";
 const ISTRINGABLE_IID: &str = "96369f54-8eb6-48f0-abce-c1b211e627c3";
+const XAML_APPLICATION: &str = "Microsoft.UI.Xaml.Application";
+const XAML_METADATA_PROVIDER: &str = "XamlControlsXamlMetaDataProvider";
+const XAML_CONTROLS_RESOURCES: &str = "XamlControlsResources";
+const XAML_LAUNCHED_CALLBACK_IID: &str = "f81c4e72-7a18-4a30-9126-6f62b6bdac83";
 
 // ======================================================================
 // Top-level projection functions
@@ -146,6 +150,18 @@ pub fn project_class(
         .collect();
     for iface in &all_ifaces {
         collect_delegate_names_from_methods(&iface.methods, &mut delegate_names);
+        for method in &iface.methods {
+            for param in method
+                .params
+                .iter()
+                .filter(|param| param.direction == ParamDirection::In)
+            {
+                let type_name = ts_param_type_dts(&param.typ, known_types);
+                if delegate_type_names.contains(&type_name) {
+                    delegate_names.insert(type_name);
+                }
+            }
+        }
     }
     // All known delegate type names (used to filter type imports — delegates typed as Interface
     // in parameter metadata must not be imported as regular type imports)
@@ -230,6 +246,17 @@ pub fn project_class(
             is_runtime_package: false,
             });
             imported_names.insert(r.name.clone());
+        }
+    }
+
+    let has_xaml_fluent_bootstrap = class.full_name == XAML_APPLICATION
+        && known_types.contains(XAML_METADATA_PROVIDER)
+        && known_types.contains(XAML_CONTROLS_RESOURCES);
+    if has_xaml_fluent_bootstrap {
+        for name in [XAML_METADATA_PROVIDER, XAML_CONTROLS_RESOURCES] {
+            if imported_names.insert(name.into()) {
+                imports.push(format_type_import_projected(name, TypeKind::Class));
+            }
         }
     }
 
@@ -476,6 +503,95 @@ pub fn project_class(
                 }
             }
         }
+    }
+
+    if has_xaml_fluent_bootstrap {
+        members.push(ProjectedMember::Method(ProjectedMethod {
+            name: "createWithMetadataProvider".into(),
+            doc: Some(DocInfo {
+                summary: Some(
+                    "Create a composed `Application` that exposes the supplied WinUI XAML metadata provider."
+                        .into(),
+                ),
+                deprecated: None,
+                returns: None,
+                params: vec![(
+                    "onLaunched".into(),
+                    "Runs from `Application.OnLaunched`, when XAML resources and windows can be initialized."
+                        .into(),
+                )],
+            }),
+            params: vec![
+                ProjectedParam {
+                    name: "metadataProvider".into(),
+                    ts_type: XAML_METADATA_PROVIDER.into(),
+                    optional: false,
+                    delegate_wrap: None,
+                },
+                ProjectedParam {
+                    name: "onLaunched".into(),
+                    ts_type: "() => void".into(),
+                    optional: true,
+                    delegate_wrap: None,
+                },
+            ],
+            return_type: class.name.clone(),
+            async_kind: AsyncKind::None,
+            is_static: true,
+            invoke_expr: String::new(),
+            sync_return_expr: Some(format!(
+                "(() => {{ const _launched = onLaunched == null ? null : DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], onLaunched).toValue(); return new {class_name}(DynWinRtValue.createXamlApplication(_unwrap(metadataProvider), _launched)); }})()",
+                callback_iid = XAML_LAUNCHED_CALLBACK_IID,
+                class_name = class.name,
+            )),
+            async_convert_v: None,
+            progress_convert: None,
+            is_void: false,
+            array_return_expr: None,
+            delegate_wraps: vec![],
+            js_only: false,
+            overload_of: None,
+        }));
+        members.push(ProjectedMember::Method(ProjectedMethod {
+            name: "createWithFluentResources".into(),
+            doc: Some(DocInfo {
+                summary: Some(
+                    "Create a composed `Application` and install WinUI's default Fluent resources before the launch callback."
+                        .into(),
+                ),
+                deprecated: None,
+                returns: None,
+                params: vec![(
+                    "onLaunched".into(),
+                    "Runs after `XamlControlsResources` has been added to the application resources."
+                        .into(),
+                )],
+            }),
+            params: vec![ProjectedParam {
+                name: "onLaunched".into(),
+                ts_type: "() => void".into(),
+                optional: true,
+                delegate_wrap: None,
+            }],
+            return_type: class.name.clone(),
+            async_kind: AsyncKind::None,
+            is_static: true,
+            invoke_expr: String::new(),
+            sync_return_expr: Some(format!(
+                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); return new {class_name}(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); }})()",
+                callback_iid = XAML_LAUNCHED_CALLBACK_IID,
+                provider = XAML_METADATA_PROVIDER,
+                resources = XAML_CONTROLS_RESOURCES,
+                class_name = class.name,
+            )),
+            async_convert_v: None,
+            progress_convert: None,
+            is_void: false,
+            array_return_expr: None,
+            delegate_wraps: vec![],
+            js_only: false,
+            overload_of: None,
+        }));
     }
 
     // Static methods
@@ -1057,16 +1173,33 @@ fn project_factory_method(
         delegate_param_wraps,
     );
     let args_expr = build_args_expr(&in_params);
+    let out_count = method
+        .params
+        .iter()
+        .filter(|p| p.direction == ParamDirection::Out)
+        .count()
+        + usize::from(method.return_type.is_some());
 
     let is_async = method.return_type.as_ref().is_some_and(|rt| rt.is_async());
 
-    let mut invoke_expr = format!(
-        "_{iface}.method({idx}).invoke({cls}.f_{iface}(), [{args}])",
-        iface = iface.name,
-        idx = method.vtable_index,
-        cls = class.name,
-        args = args_expr
-    );
+    let mut invoke_expr = if out_count > 1 {
+        format!(
+            "_{iface}.method({idx}).invokeAll({cls}.f_{iface}(), [{args}])[{result_index}]",
+            iface = iface.name,
+            idx = method.vtable_index,
+            cls = class.name,
+            args = args_expr,
+            result_index = out_count - 1,
+        )
+    } else {
+        format!(
+            "_{iface}.method({idx}).invoke({cls}.f_{iface}(), [{args}])",
+            iface = iface.name,
+            idx = method.vtable_index,
+            cls = class.name,
+            args = args_expr
+        )
+    };
     invoke_expr = rewrite_delegate_args_in_expr(&invoke_expr, &params);
 
     let return_type;

--- a/tools/dynwinrt-codegen/src/main.rs
+++ b/tools/dynwinrt-codegen/src/main.rs
@@ -272,6 +272,7 @@ fn run() -> Result<(), String> {
                         None => return Err(format!("Class {}.{} not found in {}", ns, cls, winmd)),
                     }
                 }
+                add_implicit_js_types(&winmd, &lang, &mut classes);
                 generate_for_types(
                     &winmd,
                     output_dir,
@@ -414,6 +415,7 @@ fn run() -> Result<(), String> {
                     let mut classes = meta::parse_namespace(&winmd, ns);
                     let mut interfaces = meta::parse_interfaces(&winmd, ns);
                     let mut enums = meta::parse_enums(&winmd, ns);
+                    add_implicit_js_types(&winmd, &lang, &mut classes);
                     for c in classes.iter_mut() {
                         doc_table.apply_to_class(c);
                     }
@@ -523,6 +525,32 @@ fn run() -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+fn add_implicit_js_types(winmd: &str, lang: &str, classes: &mut Vec<meta::ClassMeta>) {
+    if lang != "js"
+        || !classes
+            .iter()
+            .any(|class| class.full_name == "Microsoft.UI.Xaml.Application")
+    {
+        return;
+    }
+
+    for (namespace, name) in [
+        (
+            "Microsoft.UI.Xaml.XamlTypeInfo",
+            "XamlControlsXamlMetaDataProvider",
+        ),
+        ("Microsoft.UI.Xaml.Controls", "XamlControlsResources"),
+    ] {
+        let full_name = format!("{}.{}", namespace, name);
+        if classes.iter().any(|class| class.full_name == full_name) {
+            continue;
+        }
+        if let Some(class) = meta::parse_class(winmd, namespace, name) {
+            classes.push(class);
+        }
+    }
 }
 
 /// Generate files for a set of types plus their transitive dependencies.

--- a/tools/dynwinrt-codegen/tests/composable_factory_test.rs
+++ b/tools/dynwinrt-codegen/tests/composable_factory_test.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::{HashMap, HashSet};
+
+use dynwinrt_codegen::codegen::{project, render_dts, render_js};
+use dynwinrt_codegen::meta::{ClassMeta, InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
+use dynwinrt_codegen::types::TypeMeta;
+
+#[test]
+fn composable_factory_returns_public_instance() {
+    let factory = InterfaceMeta {
+        name: "IWidgetFactory".into(),
+        namespace: "Contoso".into(),
+        iid: "11111111-1111-1111-1111-111111111111".into(),
+        methods: vec![MethodMeta {
+            name: "CreateInstance".into(),
+            raw_name: "CreateInstance".into(),
+            vtable_index: 6,
+            params: vec![
+                ParamMeta {
+                    name: "outer".into(),
+                    typ: TypeMeta::Object,
+                    direction: ParamDirection::In,
+                },
+                ParamMeta {
+                    name: "inner".into(),
+                    typ: TypeMeta::Object,
+                    direction: ParamDirection::Out,
+                },
+            ],
+            return_type: Some(TypeMeta::RuntimeClass {
+                namespace: "Contoso".into(),
+                name: "Widget".into(),
+                default_iid: "22222222-2222-2222-2222-222222222222".into(),
+            }),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let class = ClassMeta {
+        name: "Widget".into(),
+        namespace: "Contoso".into(),
+        full_name: "Contoso.Widget".into(),
+        default_interface: Some(InterfaceMeta {
+            name: "IWidget".into(),
+            namespace: "Contoso".into(),
+            iid: "22222222-2222-2222-2222-222222222222".into(),
+            ..Default::default()
+        }),
+        factory_interfaces: vec![factory],
+        ..Default::default()
+    };
+
+    let projected = project::project_class(
+        &class,
+        &HashSet::from(["Widget".into()]),
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+
+    assert!(
+        js.contains("new Widget(_IWidgetFactory.method(6).invokeAll(") && js.contains("])[1])"),
+        "composable factory must select the final public-instance output:\n{js}"
+    );
+    assert!(
+        dts.contains("static createInstance(outer: unknown): Widget;"),
+        "factory declaration must return the runtime class:\n{dts}"
+    );
+}
+
+#[test]
+fn winui_application_projects_fluent_bootstrap_helpers() {
+    let application = ClassMeta {
+        name: "Application".into(),
+        namespace: "Microsoft.UI.Xaml".into(),
+        full_name: "Microsoft.UI.Xaml.Application".into(),
+        default_interface: Some(InterfaceMeta {
+            name: "IApplication".into(),
+            namespace: "Microsoft.UI.Xaml".into(),
+            iid: "33333333-3333-3333-3333-333333333333".into(),
+            ..Default::default()
+        }),
+        static_interfaces: vec![InterfaceMeta {
+            name: "IApplicationStatics".into(),
+            namespace: "Microsoft.UI.Xaml".into(),
+            iid: "44444444-4444-4444-4444-444444444444".into(),
+            methods: vec![MethodMeta {
+                name: "Start".into(),
+                raw_name: "Start".into(),
+                vtable_index: 6,
+                params: vec![ParamMeta {
+                    name: "callback".into(),
+                    typ: TypeMeta::Interface {
+                        namespace: "Microsoft.UI.Xaml".into(),
+                        name: "ApplicationInitializationCallback".into(),
+                        iid: "d8eef1c9-1234-56f1-9963-45dd9c80a661".into(),
+                    },
+                    direction: ParamDirection::In,
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let known_types = HashSet::from([
+        "Application".into(),
+        "ApplicationInitializationCallback".into(),
+        "XamlControlsXamlMetaDataProvider".into(),
+        "XamlControlsResources".into(),
+    ]);
+    let delegate_names = HashSet::from(["ApplicationInitializationCallback".into()]);
+    let delegate_sigs = HashMap::from([(
+        "ApplicationInitializationCallback".into(),
+        "(p: DynWinRtValue) => void".into(),
+    )]);
+
+    let projected = project::project_class(
+        &application,
+        &known_types,
+        &delegate_names,
+        &HashSet::new(),
+        &delegate_sigs,
+        &HashMap::new(),
+        &HashMap::from([(
+            "ApplicationInitializationCallback".into(),
+            vec!["__a0__".into()],
+        )]),
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+
+    assert!(js.contains("static createWithMetadataProvider(metadataProvider, onLaunched)"));
+    assert!(js.contains("static createWithFluentResources(onLaunched)"));
+    assert!(js.contains("const _callback_d = DynWinRtDelegate.create("));
+    assert!(js.contains("IID_ApplicationInitializationCallback"));
+    assert!(js.contains("f81c4e72-7a18-4a30-9126-6f62b6bdac83"));
+    assert!(js.contains("DynWinRtValue.createXamlApplication"));
+    assert!(js.contains("let _resourcesInitialized = false"));
+    assert!(
+        js.contains(
+            "resources.mergedDictionaries.append((__get_XamlControlsResources()).create())"
+        )
+    );
+    assert!(dts.contains(
+        "static createWithMetadataProvider(metadataProvider: XamlControlsXamlMetaDataProvider, onLaunched?: () => void): Application;"
+    ));
+    assert!(
+        dts.contains("static createWithFluentResources(onLaunched?: () => void): Application;")
+    );
+}


### PR DESCRIPTION
## Summary

Adds first-class WinUI 3 `Application + Window` hosting to dynwinrt.

- Compose `Application` with an outer implementing `IApplicationOverrides` and `IXamlMetadataProvider`
- Generate `createWithMetadataProvider()` and `createWithFluentResources()`
- Automatically include WinUI metadata and Fluent resources when `Application` is selected
- Fix composable factory return handling and delegate wrapping
- Enable Per-Monitor V2 DPI awareness for crisp rendering