### PR TITLE
Support Fluent resources in unpackaged WinUI applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ Generated bindings include async + progress support, generic collections (`IVect
 When `Microsoft.UI.Xaml.Application` is selected, JavaScript codegen also emits `XamlControlsXamlMetaDataProvider` and `XamlControlsResources`. Use the generated helper to compose the application outer, register WinUI metadata, and install the default Fluent resources before creating controls:
 
 ```js
-const { roInitialize } = require('@microsoft/dynwinrt');
+const { initWinappsdk, roInitialize } = require('@microsoft/dynwinrt');
 const { Application, Button, Window } = require('./generated');
 
+initWinappsdk(2, 2);
 roInitialize(0); // STA
 
 let app;
 Application.start(() => {
-  app = Application.createWithFluentResources(() => {
+  app = Application.create(() => {
     const window = Window.createInstance(null);
     window.content = Button.createInstance(null);
     window.activate();
@@ -73,7 +74,12 @@ Application.start(() => {
 });
 ```
 
-`Application.start()` runs the WinUI dispatcher loop. `createWithFluentResources()` also configures its UI thread for Per-Monitor V2 DPI awareness so WinUI content renders at the monitor's native scale. Launch this from a packaged or otherwise correctly initialized WinAppSDK process.
+`Application.start()` runs the WinUI dispatcher loop. In an unpackaged process,
+set `WINAPPSDK_BOOTSTRAP_DLL_PATH` to the architecture-matched
+`Microsoft.WindowsAppRuntime.Bootstrap.dll` before calling `initWinappsdk()`.
+`Application.create()` resolves the bootstrapped framework resources and
+configures its UI thread for Per-Monitor V2 DPI awareness. Packaged processes
+can omit the bootstrap call.
 
 ## Repository layout
 

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -14,7 +14,7 @@ If you've ever tried to call a Windows API from an Electron or Node app, you've 
 
 `dynwinrt` removes all of that. It reads the `.winmd` metadata that ships with the Windows SDK (and WinAppSDK NuGet packages) at **runtime**, resolves the COM vtables, and invokes WinRT methods dynamically. There is no native build step in your Electron project. There is no version pinning — the same generated bindings work across Windows SDK / WinAppSDK revisions as long as the metadata is forward-compatible. You just install `@microsoft/dynwinrt` from npm and call the API.
 
-The runtime primarily targets **data-style WinRT APIs** (AI, storage, notifications, networking, globalization, …). It also supports WinUI `Application + Window` hosting through the generated `Application.createWithFluentResources()` helper when the caller supplies an STA UI thread, package identity, and application lifecycle. The helper enables Per-Monitor V2 DPI awareness on that UI thread.
+The runtime primarily targets **data-style WinRT APIs** (AI, storage, notifications, networking, globalization, …). It also supports WinUI `Application + Window` hosting through the generated `Application.create()` helper when the caller supplies an STA UI thread, an initialized Windows App SDK runtime, and application lifecycle. Unpackaged callers can initialize the runtime with `initWinappsdk()`; the helper resolves the framework resources from that package graph. It also enables Per-Monitor V2 DPI awareness on the UI thread.
 
 ## Quick start
 

--- a/bindings/js/__test__/index.spec.ts
+++ b/bindings/js/__test__/index.spec.ts
@@ -13,6 +13,7 @@ import {
   httpClientGetSync,
   asyncProgressHstringToPromiseString,
   initWinappsdk,
+  roInitialize,
   DynWinRtValue,
   WinIIds,
   DynWinRtType,
@@ -81,6 +82,7 @@ test('HttpClient Sync', async (t) => {
 
 test('file open picker', async (t) => {
   initWinappsdk(1, 8)
+  roInitialize(1)
   const factory = DynWinRtValue.activationFactory('Microsoft.Windows.Storage.Pickers.FileOpenPicker')
   const FileOpenPicker = factory.cast(WinIIds.iFileOpenPickerFactoryIid())
   const picker = FileOpenPicker.callSingleOut1(

--- a/bindings/js/samples/picker.ts
+++ b/bindings/js/samples/picker.ts
@@ -3,6 +3,7 @@
 
 import {
     initWinappsdk,
+    roInitialize,
     DynWinRtValue,
     DynWinRtType,
     DynWinRtMethodSig,
@@ -48,6 +49,7 @@ const iPickResult = DynWinRtType.registerInterface("IPickFileResult", iPickResul
 
 async function main() {
     initWinappsdk(1, 8)
+    roInitialize(1)
 
     const factory = DynWinRtValue.activationFactory('Microsoft.Windows.Storage.Pickers.FileOpenPicker')
     const pickerFactory = factory.cast(WinGuid.parse("315E86D7-D7A2-5D81-B379-7AF78207B1AF"))

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::all)]
 #![allow(clippy::missing_safety_doc)]
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use dynwinrt;
 use napi_derive::napi;
@@ -20,14 +20,63 @@ static TABLE: std::sync::LazyLock<Arc<dynwinrt::MetadataTable>> =
 // Runtime initialization
 // ======================================================================
 
-#[napi]
-struct WinAppSDKContext(dynwinrt::WinAppSdkContext);
+struct InitializedWinAppSdk {
+  major: u32,
+  minor: u32,
+  context: dynwinrt::WinAppSdkContext,
+}
 
+static WINAPP_SDK: OnceLock<InitializedWinAppSdk> = OnceLock::new();
+
+/// Add Windows App SDK to the process package graph without changing the calling thread's apartment.
 #[napi]
 pub fn init_winappsdk(major: u32, minor: u32) -> napi::Result<()> {
-  dynwinrt::initialize_winappsdk(major, minor)
-    .map(|ctx| { WinAppSDKContext(ctx); })
-    .map_err(|e| napi::Error::from_reason(e.message()))
+  if let Some(initialized) = WINAPP_SDK.get() {
+    return ensure_winappsdk_version(initialized, major, minor);
+  }
+
+  let context = dynwinrt::initialize_winappsdk(major, minor)
+    .map_err(|e| napi::Error::from_reason(e.message()))?;
+  let initialized = InitializedWinAppSdk {
+    major,
+    minor,
+    context,
+  };
+
+  match WINAPP_SDK.set(initialized) {
+    Ok(()) => Ok(()),
+    Err(_) => ensure_winappsdk_version(WINAPP_SDK.get().unwrap(), major, minor),
+  }
+}
+
+fn ensure_winappsdk_version(
+  initialized: &InitializedWinAppSdk,
+  major: u32,
+  minor: u32,
+) -> napi::Result<()> {
+  if initialized.major == major && initialized.minor == minor {
+    Ok(())
+  } else {
+    Err(napi::Error::from_reason(format!(
+      "Windows App SDK is already initialized for {}.{}; cannot reinitialize for {major}.{minor}",
+      initialized.major, initialized.minor
+    )))
+  }
+}
+
+/// Return the framework resources.pri path selected by initWinappsdk.
+#[napi]
+pub fn get_winappsdk_resource_pri_path() -> napi::Result<String> {
+  let initialized = WINAPP_SDK.get().ok_or_else(|| {
+    napi::Error::from_reason(
+      "Windows App SDK is not initialized; call initWinappsdk before requesting its resources",
+    )
+  })?;
+
+  initialized
+    .context
+    .resource_pri_path()
+    .map_err(|e| napi::Error::from_reason(e.to_string()))
 }
 
 #[napi]

--- a/crates/dynwinrt/Cargo.toml
+++ b/crates/dynwinrt/Cargo.toml
@@ -30,6 +30,7 @@ features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_System_WinRT",
+    "Win32_Storage_Packaging_Appx",
     "Win32_UI_HiDpi",
     "Management_Deployment",
 ]

--- a/crates/dynwinrt/src/winapp.rs
+++ b/crates/dynwinrt/src/winapp.rs
@@ -1,16 +1,26 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::ffi::CString;
+use std::mem::size_of;
+use std::path::Path;
 
 use windows::ApplicationModel::PackageVersion;
+use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, FreeLibrary};
+use windows::Win32::Storage::Packaging::Appx::{
+    GetCurrentPackageInfo2, PACKAGE_FILTER_DIRECT, PACKAGE_FILTER_DYNAMIC, PACKAGE_INFO,
+    PackagePathType_Install,
+};
 use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
-use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize};
 use windows::core::PCSTR;
 use windows::core::PCWSTR;
-use windows_core::{HRESULT, HSTRING, h};
+use windows_core::{Error, HRESULT, HSTRING};
 
 pub struct WinAppSdkContext;
+
+const E_FAIL: HRESULT = HRESULT(0x80004005_u32 as i32);
+const E_INVALIDARG: HRESULT = HRESULT(0x80070057_u32 as i32);
+const WINAPPSDK_BOOTSTRAP_DLL_PATH_ENV: &str = "WINAPPSDK_BOOTSTRAP_DLL_PATH";
+const WINAPPSDK_RUNTIME_PACKAGE_PREFIX: &str = "Microsoft.WindowsAppRuntime.";
 
 #[derive(Debug, Clone)]
 pub struct WinAppSdkBootstrapOptions {
@@ -32,51 +42,142 @@ pub fn initialize_winappsdk(major: u32, minor: u32) -> crate::result::Result<Win
     initialize(options).map_err(|e| e.into())
 }
 
-// use MddBootstrapInitialize from WinAppSDK to initialize the WinAppSDK
 pub fn initialize(options: WinAppSdkBootstrapOptions) -> windows::core::Result<WinAppSdkContext> {
-    const WINAPPSDK_BOOTSTRAP_DLL_PATH_ENV: &str = "WINAPPSDK_BOOTSTRAP_DLL_PATH";
-
-    let dll_path = HSTRING::from(
-        options
-            .bootstrap_dll_path
-            .or_else(|| std::env::var(WINAPPSDK_BOOTSTRAP_DLL_PATH_ENV).ok())
-            .expect("WinAppSDK Bootstrap dll path is requires, set WINAPPSDK_BOOTSTRAP_DLL_PATH env variable or provide in options")
-            .to_string(),
-    );
+    let (major_minor_version, min_version) = bootstrap_version(&options)?;
+    let dll_path = options
+        .bootstrap_dll_path
+        .or_else(|| std::env::var(WINAPPSDK_BOOTSTRAP_DLL_PATH_ENV).ok())
+        .filter(|path| !path.trim().is_empty())
+        .ok_or_else(|| {
+            Error::new(
+                E_INVALIDARG,
+                format!(
+                    "Windows App SDK bootstrap DLL path is required; set {WINAPPSDK_BOOTSTRAP_DLL_PATH_ENV} or provide bootstrap_dll_path"
+                ),
+            )
+        })?;
+    let dll_path = HSTRING::from(dll_path);
 
     let dp = PCWSTR::from_raw(dll_path.as_ptr());
-
     let module = unsafe { LoadLibraryW(dp) }?;
-
-    let method_name = CString::new(h!("MddBootstrapInitialize2").to_string()).unwrap();
-    let proc = unsafe { GetProcAddress(module, PCSTR::from_raw(method_name.as_ptr() as _)) };
-    if proc.is_none() {
-        panic!("MddBootstrapInitialize2 not found in bootstrap DLL");
-    }
-
-    let init: MddBootstrapInitialize2 = unsafe { std::mem::transmute(proc) };
-
-    // Initialize WinRT first (ok if already initialized in a different mode)
-    unsafe { RoInitialize(RO_INIT_MULTITHREADED) }?;
-
-    let major_minor_version = (options.major_version << 16) | options.minor_version;
-    let min_version = PackageVersion {
-        Major: options.major_version as u16,
-        Minor: options.minor_version as u16,
-        Build: options.build_version as u16,
-        Revision: options.revision_version as u16,
-    };
-
-    let hr = unsafe {
-        init(
-            major_minor_version,
-            PCWSTR::from_raw(h!("").as_ptr()),
-            min_version,
-            0,
+    let proc = unsafe {
+        GetProcAddress(
+            module,
+            PCSTR::from_raw(b"MddBootstrapInitialize2\0".as_ptr()),
         )
     };
-    hr.ok()?;
+    let Some(proc) = proc else {
+        unsafe {
+            let _ = FreeLibrary(module);
+        }
+        return Err(Error::new(
+            E_FAIL,
+            "MddBootstrapInitialize2 was not found in the Windows App SDK bootstrap DLL",
+        ));
+    };
+
+    let init: MddBootstrapInitialize2 = unsafe { std::mem::transmute(proc) };
+    let hr = unsafe { init(major_minor_version, PCWSTR::null(), min_version, 0) };
+    if let Err(error) = hr.ok() {
+        unsafe {
+            let _ = FreeLibrary(module);
+        }
+        return Err(error);
+    }
+
+    // The package graph remains active for the process lifetime, so the bootstrap DLL
+    // must remain loaded after this function returns.
     Ok(WinAppSdkContext {})
+}
+
+impl WinAppSdkContext {
+    pub fn resource_pri_path(&self) -> windows::core::Result<String> {
+        let (buffer, count) = current_package_graph()?;
+        let package_info = buffer.as_ptr().cast::<PACKAGE_INFO>();
+
+        for index in 0..count {
+            let info = unsafe { package_info.add(index).read_unaligned() };
+            let package_full_name_ptr = info.packageFullName;
+            let package_full_name = unsafe { package_full_name_ptr.to_string() }?;
+            if !package_full_name.starts_with(WINAPPSDK_RUNTIME_PACKAGE_PREFIX) {
+                continue;
+            }
+
+            let package_path_ptr = info.path;
+            let package_path = unsafe { package_path_ptr.to_string() }?;
+            let resource_pri = Path::new(&package_path).join("resources.pri");
+            if resource_pri.is_file() {
+                return Ok(resource_pri.to_string_lossy().into_owned());
+            }
+        }
+
+        Err(Error::new(
+            E_FAIL,
+            "The initialized Windows App SDK runtime package was not found in the current package graph",
+        ))
+    }
+}
+
+fn current_package_graph() -> windows::core::Result<(Vec<usize>, usize)> {
+    // Identityless bootstrap dependencies are visible only through the dynamic filter.
+    let flags = PACKAGE_FILTER_DIRECT | PACKAGE_FILTER_DYNAMIC;
+    let mut buffer_length = 0;
+    let mut count = 0;
+    let status = unsafe {
+        GetCurrentPackageInfo2(
+            flags,
+            PackagePathType_Install,
+            &mut buffer_length,
+            None,
+            Some(&mut count),
+        )
+    };
+    if status != ERROR_INSUFFICIENT_BUFFER {
+        status.ok()?;
+    }
+
+    let word_count = (buffer_length as usize).div_ceil(size_of::<usize>());
+    let mut buffer = vec![0usize; word_count];
+    let status = unsafe {
+        GetCurrentPackageInfo2(
+            flags,
+            PackagePathType_Install,
+            &mut buffer_length,
+            Some(buffer.as_mut_ptr().cast()),
+            Some(&mut count),
+        )
+    };
+    status.ok()?;
+
+    Ok((buffer, count as usize))
+}
+
+fn bootstrap_version(
+    options: &WinAppSdkBootstrapOptions,
+) -> windows::core::Result<(u32, PackageVersion)> {
+    let major = version_component(options.major_version, "major")?;
+    let minor = version_component(options.minor_version, "minor")?;
+    let build = version_component(options.build_version, "build")?;
+    let revision = version_component(options.revision_version, "revision")?;
+
+    Ok((
+        (u32::from(major) << 16) | u32::from(minor),
+        PackageVersion {
+            Major: major,
+            Minor: minor,
+            Build: build,
+            Revision: revision,
+        },
+    ))
+}
+
+fn version_component(value: u32, name: &str) -> windows::core::Result<u16> {
+    u16::try_from(value).map_err(|_| {
+        Error::new(
+            E_INVALIDARG,
+            format!("Windows App SDK {name} version component must be between 0 and 65535"),
+        )
+    })
 }
 
 #[allow(dead_code)]
@@ -107,6 +208,38 @@ mod tests {
     use super::*;
 
     #[test]
+    fn bootstrap_version_preserves_release_and_minimum_version() {
+        let options = WinAppSdkBootstrapOptions {
+            major_version: 2,
+            minor_version: 2,
+            build_version: 3,
+            revision_version: 4,
+            bootstrap_dll_path: None,
+        };
+
+        let (major_minor, minimum) = bootstrap_version(&options).unwrap();
+
+        assert_eq!(major_minor, 0x0002_0002);
+        assert_eq!(minimum.Major, 2);
+        assert_eq!(minimum.Minor, 2);
+        assert_eq!(minimum.Build, 3);
+        assert_eq!(minimum.Revision, 4);
+    }
+
+    #[test]
+    fn bootstrap_version_rejects_components_larger_than_u16() {
+        let options = WinAppSdkBootstrapOptions {
+            major_version: u16::MAX as u32 + 1,
+            minor_version: 0,
+            build_version: 0,
+            revision_version: 0,
+            bootstrap_dll_path: None,
+        };
+
+        assert!(bootstrap_version(&options).is_err());
+    }
+
+    #[test]
     #[ignore] // Requires WINAPPSDK_BOOTSTRAP_DLL_PATH env variable
     fn test_initialize() {
         let options = WinAppSdkBootstrapOptions {
@@ -116,7 +249,7 @@ mod tests {
             revision_version: 0,
             bootstrap_dll_path: None,
         };
-        let result = initialize(options);
-        assert!(result.is_ok());
+        let context = initialize(options).unwrap();
+        assert!(Path::new(&context.resource_pri_path().unwrap()).is_file());
     }
 }

--- a/tools/dynwinrt-codegen/E2E_TEST.md
+++ b/tools/dynwinrt-codegen/E2E_TEST.md
@@ -77,12 +77,13 @@ Parameterized collection interfaces (e.g. `IVector<String>`) are automatically i
 Create `test_picker.ts` in the test project (TypeScript here — the same imports work from plain `.js` too, since the generated modules are ESM JavaScript with adjacent `.d.ts` declarations):
 
 ```typescript
-import { initWinappsdk, DynWinRtValue } from '@microsoft/dynwinrt'
+import { initWinappsdk, roInitialize, DynWinRtValue } from '@microsoft/dynwinrt'
 import { FileOpenPicker } from './generated/FileOpenPicker.js'
 import { PickerViewMode } from './generated/PickerViewMode.js'
 
 async function main() {
     initWinappsdk(1, 8)
+    roInitialize(1)
 
     // Create picker (hwnd=0 for console app)
     const picker = FileOpenPicker.createInstance(DynWinRtValue.i64(0))
@@ -160,5 +161,4 @@ A file picker dialog will open. Select a file (filtered to .png/.jpg/.txt) to co
 |---|---|---|
 | **test-http** | `Windows.Foundation` + `Windows.Web.Http` | Uri properties, HttpClient.getStringAsync (async with progress), response status code, content.readAsStringAsync |
 | **test-geo** | `Windows.Devices.Geolocation` | Struct pass-by-value (BasicGeoposition → Geopoint.create), struct out-param (Geopoint.position) |
-
 

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
@@ -68,6 +68,7 @@ const ISTRINGABLE_IID: &str = "96369f54-8eb6-48f0-abce-c1b211e627c3";
 const XAML_APPLICATION: &str = "Microsoft.UI.Xaml.Application";
 const XAML_METADATA_PROVIDER: &str = "XamlControlsXamlMetaDataProvider";
 const XAML_CONTROLS_RESOURCES: &str = "XamlControlsResources";
+const MRT_RESOURCE_MANAGER: &str = "ResourceManager";
 const XAML_LAUNCHED_CALLBACK_IID: &str = "f81c4e72-7a18-4a30-9126-6f62b6bdac83";
 
 // ======================================================================
@@ -151,6 +152,11 @@ pub fn project_class(
     delegate_param_wraps: &HashMap<String, Vec<String>>,
 ) -> ProjectedFile {
     let used_structs = collect_used_structs_from_class(class);
+    let has_xaml_fluent_bootstrap = class.full_name == XAML_APPLICATION
+        && known_types.contains(XAML_METADATA_PROVIDER)
+        && known_types.contains(XAML_CONTROLS_RESOURCES);
+    let supports_unpackaged_xaml =
+        has_xaml_fluent_bootstrap && known_types.contains(MRT_RESOURCE_MANAGER);
 
     // Collect delegate names only from interfaces of THIS class (not the entire batch)
     // for delegate imports; but also include global delegate_type_names for type filtering
@@ -187,7 +193,14 @@ pub fn project_class(
 
     // Runtime import
     let has_structs = !used_structs.is_empty();
-    imports.push(build_runtime_import(has_structs));
+    let mut runtime_import = build_runtime_import(has_structs);
+    if supports_unpackaged_xaml {
+        runtime_import.symbols.extend([
+            "getWinappsdkResourcePriPath".into(),
+            "hasPackageIdentity".into(),
+        ]);
+    }
+    imports.push(runtime_import);
 
     // Collection generics imports
     let collection_names = collect_used_generics_from_class(class);
@@ -263,11 +276,12 @@ pub fn project_class(
         }
     }
 
-    let has_xaml_fluent_bootstrap = class.full_name == XAML_APPLICATION
-        && known_types.contains(XAML_METADATA_PROVIDER)
-        && known_types.contains(XAML_CONTROLS_RESOURCES);
     if has_xaml_fluent_bootstrap {
-        for name in [XAML_METADATA_PROVIDER, XAML_CONTROLS_RESOURCES] {
+        let mut names = vec![XAML_METADATA_PROVIDER, XAML_CONTROLS_RESOURCES];
+        if supports_unpackaged_xaml {
+            names.push(MRT_RESOURCE_MANAGER);
+        }
+        for name in names {
             if imported_names.insert(name.into()) {
                 imports.push(format_type_import_projected(name, TypeKind::Class));
             }
@@ -520,6 +534,14 @@ pub fn project_class(
     }
 
     if has_xaml_fluent_bootstrap {
+        let unpackaged_resource_setup = if supports_unpackaged_xaml {
+            format!(
+                "if (!hasPackageIdentity()) {{ const _resourceManager = (__get_{resource_manager}()).createInstance(getWinappsdkResourcePriPath()); _app.onResourceManagerRequested((_sender, args) => {{ if (args === null) throw new Error('WinUI ResourceManagerRequested did not supply event arguments'); args.customResourceManager = _resourceManager; }}); }}",
+                resource_manager = MRT_RESOURCE_MANAGER,
+            )
+        } else {
+            String::new()
+        };
         members.push(ProjectedMember::Method(ProjectedMethod {
             name: "createWithMetadataProvider".into(),
             doc: Some(DocInfo {
@@ -567,10 +589,10 @@ pub fn project_class(
             overload_of: None,
         }));
         members.push(ProjectedMember::Method(ProjectedMethod {
-            name: "createWithFluentResources".into(),
+            name: "create".into(),
             doc: Some(DocInfo {
                 summary: Some(
-                    "Create a composed `Application` and install WinUI's default Fluent resources before the launch callback."
+                    "Create a composed `Application`, configure unpackaged resource resolution, and install WinUI's default Fluent resources before the launch callback."
                         .into(),
                 ),
                 deprecated: None,
@@ -592,7 +614,7 @@ pub fn project_class(
             is_static: true,
             invoke_expr: String::new(),
             sync_return_expr: Some(format!(
-                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); return new {class_name}(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); }})()",
+                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); const _app = new {class_name}(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); {unpackaged_resource_setup} return _app; }})()",
                 callback_iid = XAML_LAUNCHED_CALLBACK_IID,
                 provider = XAML_METADATA_PROVIDER,
                 resources = XAML_CONTROLS_RESOURCES,

--- a/tools/dynwinrt-codegen/tests/composable_factory_test.rs
+++ b/tools/dynwinrt-codegen/tests/composable_factory_test.rs
@@ -114,6 +114,7 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
         "ApplicationInitializationCallback".into(),
         "XamlControlsXamlMetaDataProvider".into(),
         "XamlControlsResources".into(),
+        "ResourceManager".into(),
     ]);
     let delegate_names = HashSet::from(["ApplicationInitializationCallback".into()]);
     let delegate_sigs = HashMap::from([(
@@ -137,12 +138,16 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
     let dts = render_dts::render(&projected);
 
     assert!(js.contains("static createWithMetadataProvider(metadataProvider, onLaunched)"));
-    assert!(js.contains("static createWithFluentResources(onLaunched)"));
+    assert!(js.contains("static create(onLaunched)"));
     assert!(js.contains("const _callback_d = DynWinRtDelegate.create("));
     assert!(js.contains("IID_ApplicationInitializationCallback"));
     assert!(js.contains("f81c4e72-7a18-4a30-9126-6f62b6bdac83"));
     assert!(js.contains("DynWinRtValue.createXamlApplication"));
     assert!(js.contains("let _resourcesInitialized = false"));
+    assert!(js.contains("getWinappsdkResourcePriPath"));
+    assert!(js.contains("hasPackageIdentity"));
+    assert!(js.contains("onResourceManagerRequested"));
+    assert!(js.contains("(__get_ResourceManager()).createInstance"));
     assert!(
         js.contains(
             "resources.mergedDictionaries.append((__get_XamlControlsResources()).create())"
@@ -152,6 +157,6 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
         "static createWithMetadataProvider(metadataProvider: XamlControlsXamlMetaDataProvider, onLaunched?: () => void): Application;"
     ));
     assert!(
-        dts.contains("static createWithFluentResources(onLaunched?: () => void): Application;")
+        dts.contains("static create(onLaunched?: () => void): Application;")
     );
 }


### PR DESCRIPTION
### Summary

- Separate process-wide Windows App SDK bootstrap from per-thread WinRT apartment initialization.
- Keep the bootstrap context alive and reject conflicting runtime versions.
- Discover the selected Runtime’s  resources.pri  through the dynamic process package graph.
- Configure  Application.ResourceManagerRequested  automatically for unpackaged apps.
- Preserve the existing packaged-app resource path.
- Update documentation, samples, and codegen tests.