### PR TITLE
Project WinRT activations as idiomatic JavaScript constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,17 @@ const { roInitialize } = require('@microsoft/dynwinrt');
 const { Uri } = require('./generated');
 
 roInitialize(1);                                       // MTA
-const uri = Uri.createUri('https://example.com/path?q=1');
+const uri = new Uri('https://example.com/path?q=1');
 console.log(uri.host);                                 // "example.com"
 ```
 
-Generated bindings include async + progress support, generic collections (`IVector<T>`, `IMap<K,V>`), structs, enums, and delegates — see `tools/dynwinrt-codegen/npm/README.md` for the full feature list.
+Generated bindings project unambiguous public WinRT activation metadata as JavaScript
+constructors, including overloads such as `new Uri(base, relative)`. Existing
+static factory methods remain available. Classes that can only be returned by
+the system, or that expose only protected composition, remain non-constructible.
+Bindings also include async + progress support, generic collections
+(`IVector<T>`, `IMap<K,V>`), structs, enums, and delegates — see
+`tools/dynwinrt-codegen/npm/README.md` for the full feature list.
 
 ### WinUI `Application + Window`
 
@@ -66,8 +72,8 @@ roInitialize(0); // STA
 let app;
 Application.start(() => {
   app = Application.create(() => {
-    const window = Window.createInstance(null);
-    window.content = Button.createInstance(null);
+    const window = new Window();
+    window.content = new Button();
     window.activate();
   });
   app.requestedTheme = 1; // Dark

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -36,10 +36,15 @@ const { roInitialize } = require('@microsoft/dynwinrt');
 const { Uri } = require('./generated');
 
 roInitialize(1);                                      // MTA
-const uri = Uri.createUri('https://example.com/path?q=1');
+const uri = new Uri('https://example.com/path?q=1');
 console.log(uri.host);                                // "example.com"
 console.log(uri.port);                                // 443
 ```
+
+Unambiguous public WinRT activation metadata is projected as JavaScript constructors.
+Parameterized and composable activations support idiomatic forms such as
+`new Uri(base, relative)` and `new StackPanel()`. The generated static factory
+methods remain available for compatibility.
 
 ## Platform support
 

--- a/tools/dynwinrt-codegen/E2E_TEST.md
+++ b/tools/dynwinrt-codegen/E2E_TEST.md
@@ -86,7 +86,7 @@ async function main() {
     roInitialize(1)
 
     // Create picker (hwnd=0 for console app)
-    const picker = FileOpenPicker.createInstance(DynWinRtValue.i64(0))
+    const picker = new FileOpenPicker(DynWinRtValue.i64(0))
     console.log('FileOpenPicker created')
 
     // Set properties
@@ -161,4 +161,3 @@ A file picker dialog will open. Select a file (filtered to .png/.jpg/.txt) to co
 |---|---|---|
 | **test-http** | `Windows.Foundation` + `Windows.Web.Http` | Uri properties, HttpClient.getStringAsync (async with progress), response status code, content.readAsStringAsync |
 | **test-geo** | `Windows.Devices.Geolocation` | Struct pass-by-value (BasicGeoposition → Geopoint.create), struct out-param (Geopoint.position) |
-

--- a/tools/dynwinrt-codegen/README.md
+++ b/tools/dynwinrt-codegen/README.md
@@ -82,7 +82,8 @@ For each WinRT class, the tool generates:
 
 - **Interface registration** -- `DynWinRtType.registerInterface()` with all methods and type signatures
 - **Wrapper class** -- typed class with properties and methods
-- **Factory methods** -- static methods for object creation via activation factory
+- **Constructors** -- unambiguous public WinRT activations projected as idiomatic JavaScript constructors
+- **Factory methods** -- original static activation methods retained for compatibility
 - **Enums** -- enum declarations
 - **Collection types** -- `IVector<T>`, `IVectorView<T>`, `IMap<K,V>`, etc.
 - **Index file** -- re-exporting all generated types
@@ -125,4 +126,3 @@ cargo test -p dynwinrt-codegen
 Tests include:
 - Unit tests for type mapping, dependency resolution, and code generation helpers
 - Snapshot test for `Windows.Foundation.Uri` (regenerate with `cargo run -p dynwinrt-codegen -- generate --namespace Windows.Foundation --class-name Uri --lang js --output tests/snapshots/uri`)
-

--- a/tools/dynwinrt-codegen/npm/README.md
+++ b/tools/dynwinrt-codegen/npm/README.md
@@ -63,7 +63,8 @@ npx dynwinrt-codegen generate \
 For each WinRT class, the codegen emits:
 
 - **A typed wrapper class** with properties and methods using camelCase JS conventions
-- **A factory** (`.create(...)`, `.createInstance(...)`) for activation
+- **JavaScript constructors** for unambiguous public default, factory, and composable activations
+- **The original factory methods** (`.create(...)`, `.createInstance(...)`) for compatibility
 - **An interface registration** (`DynWinRtType.registerInterface()`) wired to the COM vtable
 - **`IAsyncOperation<T>` awaitables** with `.progress(cb)` for streaming results
 - **Generic collections** (`IVector<T>`, `IMap<K,V>`, `IIterable<T>`)

--- a/tools/dynwinrt-codegen/src/codegen/common.rs
+++ b/tools/dynwinrt-codegen/src/codegen/common.rs
@@ -255,7 +255,7 @@ mod tests {
         // Refs come out as `__DWRT_REF__<name>__`; render layer rewrites.
         assert_eq!(
             convert_return("r", Some(&rt), false, &known, &deferred),
-            "((v) => v.isNull() ? null : new __DWRT_REF__Uri__(v))(r)"
+            "((v) => v.isNull() ? null : __DWRT_REF__Uri__._fromNative(v))(r)"
         );
     }
 

--- a/tools/dynwinrt-codegen/src/codegen/javascript/ir.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/ir.rs
@@ -73,14 +73,15 @@ pub struct DelegateWrapInfo {
     pub delegate_name: String,
     pub callback_type: String,
     /// Per-param conversion expressions for wrapping DynWinRtValue → high-level types
-    /// e.g. ["new StreamedFileDataRequest(__a0__)"]
+    /// e.g. ["StreamedFileDataRequest._fromNative(__a0__)"]
     /// Empty if no wrapping needed (all params are primitives/DynWinRtValue)
     pub param_wraps: Vec<String>,
 }
 
 #[derive(Clone)]
 pub struct ProjectedConstructor {
-    pub params: Vec<ProjectedParam>,
+    /// Public TypeScript constructor overloads. Empty means the constructor is internal-only.
+    pub overloads: Vec<Vec<ProjectedParam>>,
     /// Lines for the constructor body (JS only)
     pub body_lines: Vec<String>,
 }

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/constructors.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/constructors.rs
@@ -1,0 +1,447 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Runtime class constructor projection.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::meta::{ConstructorKind, ConstructorMeta, InterfaceMeta, MethodMeta, ParamMeta};
+use crate::types::TypeMeta;
+
+use super::*;
+use crate::codegen::javascript::signature::ref_marker;
+
+struct ConstructorCandidate {
+    params: Vec<ProjectedParam>,
+    param_types: Vec<TypeMeta>,
+    call_expr: String,
+}
+
+pub(super) fn default_activation_method_name(class: &ClassMeta) -> &'static str {
+    let has_create_factory = class.factory_interfaces.iter().any(|iface| {
+        iface.methods.iter().any(|method| {
+            let name = to_camel_case(&method.name);
+            name == "create" || name.starts_with("create")
+        })
+    });
+    if has_create_factory {
+        "createDefault"
+    } else {
+        "create"
+    }
+}
+
+pub(super) fn project_constructor(
+    class: &ClassMeta,
+    known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
+    delegate_sigs: &HashMap<String, String>,
+    delegate_param_wraps: &HashMap<String, Vec<String>>,
+) -> ProjectedConstructor {
+    if class.full_name == XAML_APPLICATION {
+        return inaccessible_constructor(class);
+    }
+
+    let mut candidates = Vec::new();
+    for constructor in &class.constructors {
+        match constructor.kind {
+            ConstructorKind::DefaultActivation => {
+                candidates.push(ConstructorCandidate {
+                    params: Vec::new(),
+                    param_types: Vec::new(),
+                    call_expr: format!(
+                        "{}.{}()",
+                        class.name,
+                        default_activation_method_name(class)
+                    ),
+                });
+            }
+            ConstructorKind::FactoryActivation => {
+                let Some(factory) = find_factory(class, constructor) else {
+                    continue;
+                };
+                for method in &factory.methods {
+                    if !method_constructs_class(method, class) {
+                        continue;
+                    }
+                    let in_params = get_in_params(method);
+                    candidates.push(factory_candidate(
+                        class,
+                        method,
+                        &in_params,
+                        &in_params,
+                        None,
+                        known_types,
+                        delegate_names,
+                        delegate_sigs,
+                        delegate_param_wraps,
+                    ));
+                }
+            }
+            ConstructorKind::PublicComposition => {
+                let Some(factory) = find_factory(class, constructor) else {
+                    continue;
+                };
+                for method in &factory.methods {
+                    if !method_constructs_class(method, class) {
+                        continue;
+                    }
+                    let in_params = get_in_params(method);
+                    let Some((outer_index, public_params)) =
+                        split_composable_params(method, &in_params)
+                    else {
+                        continue;
+                    };
+                    candidates.push(factory_candidate(
+                        class,
+                        method,
+                        &public_params,
+                        &in_params,
+                        Some(outer_index),
+                        known_types,
+                        delegate_names,
+                        delegate_sigs,
+                        delegate_param_wraps,
+                    ));
+                }
+            }
+            ConstructorKind::ProtectedComposition => {}
+        }
+    }
+
+    let candidates = deduplicate_candidates(candidates);
+    let supported = supported_candidate_indices(&candidates);
+    if supported.is_empty() {
+        return inaccessible_constructor(class);
+    }
+
+    let overloads = supported
+        .iter()
+        .map(|&index| candidates[index].params.clone())
+        .collect();
+    let body_lines = constructor_dispatch_body(class, &candidates, &supported);
+    ProjectedConstructor {
+        overloads,
+        body_lines,
+    }
+}
+
+fn inaccessible_constructor(class: &ClassMeta) -> ProjectedConstructor {
+    ProjectedConstructor {
+        overloads: Vec::new(),
+        body_lines: vec![format!(
+            "throw new TypeError('{} cannot be constructed directly.');",
+            class.name
+        )],
+    }
+}
+
+fn find_factory<'a>(
+    class: &'a ClassMeta,
+    constructor: &ConstructorMeta,
+) -> Option<&'a InterfaceMeta> {
+    let reference = constructor.factory_interface.as_ref()?;
+    class.factory_interfaces.iter().find(|interface| {
+        interface.namespace == reference.namespace && interface.name == reference.name
+    })
+}
+
+fn method_constructs_class(method: &MethodMeta, class: &ClassMeta) -> bool {
+    matches!(
+        method.return_type.as_ref(),
+        Some(TypeMeta::RuntimeClass {
+            namespace,
+            name,
+            ..
+        }) if namespace == &class.namespace && name == &class.name
+    )
+}
+
+fn split_composable_params<'a>(
+    method: &MethodMeta,
+    in_params: &[&'a ParamMeta],
+) -> Option<(usize, Vec<&'a ParamMeta>)> {
+    // MIDL composable factories append baseInterface and innerInterface to the public parameters.
+    let outer = *in_params.last()?;
+    let outer_name = outer.name.to_ascii_lowercase();
+    let is_outer_name = outer_name == "outer"
+        || outer_name == "base"
+        || outer_name == "baseinterface"
+        || outer_name == "outerinterface";
+    let has_inner_output = method.params.iter().any(|param| {
+        param.direction == ParamDirection::Out
+            && matches!(param.typ, TypeMeta::Object)
+            && param.name.to_ascii_lowercase().contains("inner")
+    });
+    if !is_outer_name || !matches!(outer.typ, TypeMeta::Object) || !has_inner_output {
+        return None;
+    }
+
+    Some((
+        in_params.len() - 1,
+        in_params[..in_params.len() - 1].to_vec(),
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn factory_candidate(
+    class: &ClassMeta,
+    method: &MethodMeta,
+    public_params: &[&ParamMeta],
+    in_params: &[&ParamMeta],
+    outer_index: Option<usize>,
+    known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
+    delegate_sigs: &HashMap<String, String>,
+    delegate_param_wraps: &HashMap<String, Vec<String>>,
+) -> ConstructorCandidate {
+    ConstructorCandidate {
+        params: project_params(
+            public_params,
+            known_types,
+            delegate_names,
+            delegate_sigs,
+            delegate_param_wraps,
+        ),
+        param_types: public_params
+            .iter()
+            .map(|param| param.typ.clone())
+            .collect(),
+        call_expr: factory_call_expr(class, method, in_params, outer_index),
+    }
+}
+
+fn factory_call_expr(
+    class: &ClassMeta,
+    method: &MethodMeta,
+    in_params: &[&ParamMeta],
+    outer_index: Option<usize>,
+) -> String {
+    let mut public_index = 0;
+    let args = in_params
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            if outer_index == Some(index) {
+                "null".to_string()
+            } else {
+                let arg = format!("args[{}]", public_index);
+                public_index += 1;
+                arg
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("{}.{}({})", class.name, to_camel_case(&method.name), args)
+}
+
+fn deduplicate_candidates(candidates: Vec<ConstructorCandidate>) -> Vec<ConstructorCandidate> {
+    let mut signatures = HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|candidate| {
+            signatures.insert(
+                candidate
+                    .params
+                    .iter()
+                    .map(|param| param.ts_type.clone())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect()
+}
+
+fn supported_candidate_indices(candidates: &[ConstructorCandidate]) -> Vec<usize> {
+    let mut by_arity: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (index, candidate) in candidates.iter().enumerate() {
+        by_arity
+            .entry(candidate.params.len())
+            .or_default()
+            .push(index);
+    }
+
+    let mut supported = Vec::new();
+    for indices in by_arity.values() {
+        if indices.len() == 1 {
+            supported.push(indices[0]);
+            continue;
+        }
+
+        let mut predicate_counts = HashMap::new();
+        for &index in indices {
+            let predicate = candidate_type_predicate(&candidates[index]);
+            *predicate_counts.entry(predicate).or_insert(0usize) += 1;
+        }
+        for &index in indices {
+            let predicate = candidate_type_predicate(&candidates[index]);
+            if !predicate.is_empty() && predicate_counts[&predicate] == 1 {
+                supported.push(index);
+            }
+        }
+    }
+    supported
+}
+
+fn constructor_dispatch_body(
+    class: &ClassMeta,
+    candidates: &[ConstructorCandidate],
+    supported: &[usize],
+) -> Vec<String> {
+    let mut indices = supported.to_vec();
+    indices.sort_by_key(|&index| {
+        let candidate = &candidates[index];
+        (
+            candidate.params.len(),
+            std::cmp::Reverse(predicate_specificity(candidate)),
+        )
+    });
+
+    let mut arity_counts = HashMap::new();
+    for candidate in candidates {
+        *arity_counts.entry(candidate.params.len()).or_insert(0usize) += 1;
+    }
+
+    let mut body = Vec::new();
+    for index in indices {
+        let candidate = &candidates[index];
+        let mut conditions = vec![format!("args.length === {}", candidate.params.len())];
+        if arity_counts[&candidate.params.len()] > 1 {
+            conditions.extend(candidate_type_conditions(candidate));
+        }
+        body.push(format!("if ({}) {{", conditions.join(" && ")));
+        body.push(format!("    this._obj = {}._obj;", candidate.call_expr));
+        body.push("    return;".into());
+        body.push("}".into());
+    }
+    body.push(format!(
+        "throw new TypeError('No matching constructor for {}.');",
+        class.name
+    ));
+    body
+}
+
+fn candidate_type_predicate(candidate: &ConstructorCandidate) -> String {
+    candidate_type_conditions(candidate).join(" && ")
+}
+
+fn candidate_type_conditions(candidate: &ConstructorCandidate) -> Vec<String> {
+    candidate
+        .param_types
+        .iter()
+        .enumerate()
+        .filter_map(|(index, typ)| js_type_condition(index, typ))
+        .collect()
+}
+
+fn predicate_specificity(candidate: &ConstructorCandidate) -> usize {
+    candidate
+        .param_types
+        .iter()
+        .map(|typ| match typ {
+            TypeMeta::RuntimeClass { .. } | TypeMeta::Array(_) => 3,
+            TypeMeta::String
+            | TypeMeta::Bool
+            | TypeMeta::I8
+            | TypeMeta::U8
+            | TypeMeta::I16
+            | TypeMeta::U16
+            | TypeMeta::I32
+            | TypeMeta::U32
+            | TypeMeta::F32
+            | TypeMeta::F64
+            | TypeMeta::Char16
+            | TypeMeta::I64
+            | TypeMeta::U64
+            | TypeMeta::Enum { .. }
+            | TypeMeta::Delegate { .. } => 2,
+            _ => 1,
+        })
+        .sum()
+}
+
+fn js_type_condition(index: usize, typ: &TypeMeta) -> Option<String> {
+    let arg = format!("args[{}]", index);
+    match typ {
+        TypeMeta::String => Some(format!("typeof {} === 'string'", arg)),
+        TypeMeta::Bool => Some(format!("typeof {} === 'boolean'", arg)),
+        TypeMeta::I64 | TypeMeta::U64 => Some(format!("typeof {} === 'bigint'", arg)),
+        TypeMeta::I8
+        | TypeMeta::U8
+        | TypeMeta::I16
+        | TypeMeta::U16
+        | TypeMeta::I32
+        | TypeMeta::U32
+        | TypeMeta::F32
+        | TypeMeta::F64
+        | TypeMeta::Char16
+        | TypeMeta::Enum { .. } => Some(format!("typeof {} === 'number'", arg)),
+        TypeMeta::RuntimeClass { name, .. } => {
+            Some(format!("{} instanceof {}", arg, ref_marker(name)))
+        }
+        TypeMeta::Array(_) => Some(format!("Array.isArray({})", arg)),
+        TypeMeta::Delegate { .. } => Some(format!("typeof {} === 'function'", arg)),
+        TypeMeta::Object
+        | TypeMeta::Interface { .. }
+        | TypeMeta::Guid
+        | TypeMeta::Struct { .. }
+        | TypeMeta::Parameterized { .. } => Some(format!(
+            "({0} === null || (typeof {0} === 'object' && !Array.isArray({0})))",
+            arg
+        )),
+        TypeMeta::AsyncAction
+        | TypeMeta::AsyncActionWithProgress(_)
+        | TypeMeta::AsyncOperation(_)
+        | TypeMeta::AsyncOperationWithProgress(_, _) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(ts_type: &str, typ: TypeMeta) -> ConstructorCandidate {
+        ConstructorCandidate {
+            params: vec![ProjectedParam {
+                name: "value".into(),
+                ts_type: ts_type.into(),
+                optional: false,
+                delegate_wrap: None,
+            }],
+            param_types: vec![typ],
+            call_expr: String::new(),
+        }
+    }
+
+    #[test]
+    fn same_arity_primitive_overloads_are_distinguished() {
+        let candidates = vec![
+            candidate("string", TypeMeta::String),
+            candidate("boolean", TypeMeta::Bool),
+        ];
+        assert_eq!(supported_candidate_indices(&candidates), [0, 1]);
+    }
+
+    #[test]
+    fn indistinguishable_overloads_are_not_exposed() {
+        let candidates = vec![
+            candidate("FirstEnum", TypeMeta::I32),
+            candidate("SecondEnum", TypeMeta::U32),
+        ];
+        assert!(supported_candidate_indices(&candidates).is_empty());
+    }
+
+    #[test]
+    fn runtime_class_dispatch_uses_lazy_reference_marker() {
+        assert_eq!(
+            js_type_condition(
+                0,
+                &TypeMeta::RuntimeClass {
+                    namespace: "Contoso".into(),
+                    name: "Widget".into(),
+                    default_iid: String::new(),
+                }
+            ),
+            Some("args[0] instanceof __DWRT_REF__Widget__".into())
+        );
+    }
+}

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/methods.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/methods.rs
@@ -65,11 +65,11 @@ pub(super) fn project_factory_method(
         return_type = format!("Promise<{}>", class.name);
         async_kind = AsyncKind::Operation(class.name.clone());
         sync_return_expr = None;
-        async_convert_v = Some(format!("new {}(_v)", class.name));
+        async_convert_v = Some(format!("{}._fromNative(_v)", class.name));
     } else {
         return_type = class.name.clone();
         async_kind = AsyncKind::None;
-        sync_return_expr = Some(format!("new {}({})", class.name, invoke_expr));
+        sync_return_expr = Some(format!("{}._fromNative({})", class.name, invoke_expr));
         async_convert_v = None;
     }
 

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
@@ -8,6 +8,7 @@
 //! here. The renderers consume the IR and only format.
 
 mod collections;
+mod constructors;
 mod methods;
 mod structs;
 
@@ -51,6 +52,7 @@ use super::signature::{
 use super::structs::{struct_field_getter, struct_field_setter, ts_struct_field_type};
 
 use collections::{project_collection_create, project_collection_helpers};
+use constructors::{default_activation_method_name, project_constructor};
 use methods::{project_factory_method, project_instance_method, project_static_method};
 use structs::project_struct_helpers;
 
@@ -423,40 +425,52 @@ pub fn project_class(
     // Build class members
     let mut members = Vec::new();
 
-    // Constructor
-    let mut ctor_body = Vec::new();
-    if let Some(ref iface) = class.default_interface {
-        if !iface.iid.is_empty() {
-            ctor_body.push(format!("this._obj = obj.cast(IID_{});", iface.name));
+    // Public activation constructor, or an inaccessible constructor for system-returned classes.
+    members.push(ProjectedMember::Constructor(project_constructor(
+        class,
+        known_types,
+        &delegate_names,
+        delegate_sigs,
+        delegate_param_wraps,
+    )));
+    let wrapped_obj = if let Some(ref iface) = class.default_interface {
+        if iface.iid.is_empty() {
+            "obj".to_string()
         } else {
-            ctor_body.push("this._obj = obj;".into());
+            format!("obj.cast(IID_{})", iface.name)
         }
     } else {
-        ctor_body.push("this._obj = obj;".into());
-    }
-    members.push(ProjectedMember::Constructor(ProjectedConstructor {
+        "obj".to_string()
+    };
+    members.push(ProjectedMember::Method(ProjectedMethod {
+        name: "_fromNative".into(),
+        doc: None,
         params: vec![ProjectedParam {
             name: "obj".into(),
             ts_type: "DynWinRtValue".into(),
             optional: false,
             delegate_wrap: None,
         }],
-        body_lines: ctor_body,
+        return_type: class.name.clone(),
+        async_kind: AsyncKind::None,
+        is_static: true,
+        invoke_expr: String::new(),
+        sync_return_expr: Some(format!(
+            "Object.assign(Object.create({}.prototype), {{ _obj: {} }})",
+            class.name, wrapped_obj
+        )),
+        async_convert_v: None,
+        progress_convert: None,
+        is_void: false,
+        array_return_expr: None,
+        delegate_wraps: vec![],
+        js_only: true,
+        overload_of: None,
     }));
 
     // Default constructor (static create/createDefault)
     if class.has_default_constructor {
-        let has_create_factory = class.factory_interfaces.iter().any(|iface| {
-            iface.methods.iter().any(|m| {
-                let camel = to_camel_case(&m.name);
-                camel == "create" || camel.starts_with("create")
-            })
-        });
-        let ctor_name = if has_create_factory {
-            "createDefault"
-        } else {
-            "create"
-        };
+        let ctor_name = default_activation_method_name(class);
         members.push(ProjectedMember::Method(ProjectedMethod {
             name: ctor_name.into(),
             doc: Some(DocInfo {
@@ -474,7 +488,7 @@ pub fn project_class(
                 class.full_name
             ),
             sync_return_expr: Some(format!(
-                "new {}(_IActivationFactory.method(6).invoke(DynWinRtValue.activationFactory('{}'), []))",
+                "{}._fromNative(_IActivationFactory.method(6).invoke(DynWinRtValue.activationFactory('{}'), []))",
                 class.name, class.full_name
             )),
             async_convert_v: None,
@@ -576,7 +590,7 @@ pub fn project_class(
             is_static: true,
             invoke_expr: String::new(),
             sync_return_expr: Some(format!(
-                "(() => {{ const _launched = onLaunched == null ? null : DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], onLaunched).toValue(); return new {class_name}(DynWinRtValue.createXamlApplication(_unwrap(metadataProvider), _launched)); }})()",
+                "(() => {{ const _launched = onLaunched == null ? null : DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], onLaunched).toValue(); return {class_name}._fromNative(DynWinRtValue.createXamlApplication(_unwrap(metadataProvider), _launched)); }})()",
                 callback_iid = XAML_LAUNCHED_CALLBACK_IID,
                 class_name = class.name,
             )),
@@ -614,7 +628,7 @@ pub fn project_class(
             is_static: true,
             invoke_expr: String::new(),
             sync_return_expr: Some(format!(
-                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); const _app = new {class_name}(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); {unpackaged_resource_setup} return _app; }})()",
+                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); const _app = {class_name}._fromNative(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); {unpackaged_resource_setup} return _app; }})()",
                 callback_iid = XAML_LAUNCHED_CALLBACK_IID,
                 provider = XAML_METADATA_PROVIDER,
                 resources = XAML_CONTROLS_RESOURCES,

--- a/tools/dynwinrt-codegen/src/codegen/javascript/render/declarations.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/render/declarations.rs
@@ -371,9 +371,25 @@ fn render_required_iface_dts(out: &mut String, ri: &ProjectedRequiredIface) {
 
 fn render_member_dts(out: &mut String, member: &ProjectedMember) {
     match member {
-        ProjectedMember::Constructor(_ctor) => {
-            // Private constructor — users should use static factory methods
-            out.push_str("    private constructor();\n");
+        ProjectedMember::Constructor(ctor) => {
+            if ctor.overloads.is_empty() {
+                out.push_str("    private constructor();\n");
+            } else {
+                for overload in &ctor.overloads {
+                    let params = overload
+                        .iter()
+                        .map(|param| {
+                            if param.optional {
+                                format!("{}?: {}", param.name, param.ts_type)
+                            } else {
+                                format!("{}: {}", param.name, param.ts_type)
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    out.push_str(&format!("    constructor({});\n", params));
+                }
+            }
         }
         ProjectedMember::Property(prop) => {
             if let Some(ref doc) = prop.doc {

--- a/tools/dynwinrt-codegen/src/codegen/javascript/render/javascript/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/render/javascript/mod.rs
@@ -359,12 +359,11 @@ fn render_required_iface_js(out: &mut String, ri: &ProjectedRequiredIface) {
 fn render_member_js(out: &mut String, member: &ProjectedMember, _class_name: &str) {
     match member {
         ProjectedMember::Constructor(ctor) => {
-            let params_str = ctor
-                .params
-                .iter()
-                .map(|p| p.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ");
+            let params_str = if ctor.overloads.is_empty() {
+                ""
+            } else {
+                "...args"
+            };
             out.push_str(&format!("    constructor({}) {{\n", params_str));
             for line in &ctor.body_lines {
                 out.push_str(&format!("        {}\n", line));

--- a/tools/dynwinrt-codegen/src/codegen/javascript/signature.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/signature.rs
@@ -390,7 +390,14 @@ pub(crate) fn resolve_type_name(name: &str, _deferred: &HashSet<String>) -> Stri
     ref_marker(name)
 }
 
-fn wrap_nullable_return(expr: &str, wrapper: &str) -> String {
+fn wrap_nullable_class_return(expr: &str, wrapper: &str) -> String {
+    format!(
+        "((v) => v.isNull() ? null : {}._fromNative(v))({})",
+        wrapper, expr
+    )
+}
+
+fn wrap_nullable_interface_return(expr: &str, wrapper: &str) -> String {
     format!("((v) => v.isNull() ? null : new {}(v))({})", wrapper, expr)
 }
 
@@ -430,7 +437,7 @@ pub(crate) fn convert_array_return(
         TypeMeta::RuntimeClass { name, .. } if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
             format!(
-                "{}.toValues().map(v => v.isNull() ? null : new {}(v))",
+                "{}.toValues().map(v => v.isNull() ? null : {}._fromNative(v))",
                 arr_expr, r
             )
         }
@@ -496,20 +503,20 @@ pub(crate) fn convert_return(
         Some(TypeMeta::Enum { .. }) => format!("{}.toNumber()", expr),
         Some(TypeMeta::RuntimeClass { name, .. }) if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
-            wrap_nullable_return(expr, &r)
+            wrap_nullable_class_return(expr, &r)
         }
         Some(TypeMeta::Struct { name, .. }) if name == "HResult" => format!("{}.toNumber()", expr),
         Some(TypeMeta::Struct { name, .. }) => format!("_unpack{}({})", name, expr),
         Some(TypeMeta::Object | TypeMeta::Delegate { .. }) => unwrap_nullable_return(expr),
         Some(TypeMeta::Interface { name, .. }) if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
-            wrap_nullable_return(expr, &r)
+            wrap_nullable_interface_return(expr, &r)
         }
         Some(TypeMeta::Parameterized { name, args, .. }) => {
             let concrete = crate::meta::make_parameterized_name(name, args);
             if known_types.contains(&concrete) {
                 let r = resolve_type_name(&concrete, deferred);
-                wrap_nullable_return(expr, &r)
+                wrap_nullable_interface_return(expr, &r)
             } else {
                 unwrap_nullable_return(expr)
             }

--- a/tools/dynwinrt-codegen/src/meta.rs
+++ b/tools/dynwinrt-codegen/src/meta.rs
@@ -79,6 +79,28 @@ pub enum InterfaceRole {
     Other,
 }
 
+/// The WinMD activation metadata that defines a runtime-class constructor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConstructorKind {
+    DefaultActivation,
+    FactoryActivation,
+    PublicComposition,
+    ProtectedComposition,
+}
+
+/// A constructor declared by ActivatableAttribute or ComposableAttribute.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstructorMeta {
+    pub kind: ConstructorKind,
+    pub factory_interface: Option<TypeRef>,
+}
+
+impl ConstructorMeta {
+    pub fn is_public(&self) -> bool {
+        self.kind != ConstructorKind::ProtectedComposition
+    }
+}
+
 /// A WinRT RuntimeClass with all its interfaces.
 #[derive(Debug, Clone, Default)]
 pub struct ClassMeta {
@@ -91,6 +113,7 @@ pub struct ClassMeta {
     pub factory_interfaces: Vec<InterfaceMeta>,
     pub static_interfaces: Vec<InterfaceMeta>,
     pub has_default_constructor: bool,
+    pub constructors: Vec<ConstructorMeta>,
     /// XML doc summary (populated from sibling .xml).
     pub doc: Option<String>,
     /// XML `<deprecated>` text.
@@ -694,6 +717,7 @@ fn parse_class_from_index(index: &reader::Index, namespace: &str, name: &str) ->
     let mut factory_interfaces = Vec::new();
     let mut static_interfaces = Vec::new();
     let mut has_default_constructor = false;
+    let mut constructors = Vec::new();
 
     // 1. Find default interface and collect all required interfaces
     let mut required_iface_names: Vec<(String, String)> = Vec::new();
@@ -782,6 +806,17 @@ fn parse_class_from_index(index: &reader::Index, namespace: &str, name: &str) ->
                     if let Some((ns, n)) = split_full_name(iface_full_name) {
                         if let Some(iface_meta) = parse_interface(index, ns, n) {
                             factory_interfaces.push(iface_meta);
+                            push_unique_constructor(
+                                &mut constructors,
+                                ConstructorMeta {
+                                    kind: ConstructorKind::FactoryActivation,
+                                    factory_interface: Some(TypeRef {
+                                        namespace: ns.to_string(),
+                                        name: n.to_string(),
+                                        kind: TypeKind::Interface,
+                                    }),
+                                },
+                            );
                         }
                     }
                 }
@@ -789,9 +824,23 @@ fn parse_class_from_index(index: &reader::Index, namespace: &str, name: &str) ->
                 | Some((_, windows_metadata::Value::I32(_))) => {
                     // No factory interface — this is a default (parameterless) constructor
                     has_default_constructor = true;
+                    push_unique_constructor(
+                        &mut constructors,
+                        ConstructorMeta {
+                            kind: ConstructorKind::DefaultActivation,
+                            factory_interface: None,
+                        },
+                    );
                 }
                 _ => {
                     has_default_constructor = true;
+                    push_unique_constructor(
+                        &mut constructors,
+                        ConstructorMeta {
+                            kind: ConstructorKind::DefaultActivation,
+                            factory_interface: None,
+                        },
+                    );
                 }
             }
         } else if attr_name == "StaticAttribute" {
@@ -808,6 +857,19 @@ fn parse_class_from_index(index: &reader::Index, namespace: &str, name: &str) ->
                 if let Some((ns, n)) = split_full_name(iface_full_name) {
                     if let Some(iface_meta) = parse_interface(index, ns, n) {
                         factory_interfaces.push(iface_meta);
+                        push_unique_constructor(
+                            &mut constructors,
+                            ConstructorMeta {
+                                kind: composable_constructor_kind(
+                                    values.get(1).map(|(_, value)| value),
+                                ),
+                                factory_interface: Some(TypeRef {
+                                    namespace: ns.to_string(),
+                                    name: n.to_string(),
+                                    kind: TypeKind::Interface,
+                                }),
+                            },
+                        );
                     }
                 }
             }
@@ -823,9 +885,30 @@ fn parse_class_from_index(index: &reader::Index, namespace: &str, name: &str) ->
         factory_interfaces,
         static_interfaces,
         has_default_constructor,
+        constructors,
         doc: None,
         deprecated: None,
     })
+}
+
+fn push_unique_constructor(constructors: &mut Vec<ConstructorMeta>, constructor: ConstructorMeta) {
+    if !constructors.contains(&constructor) {
+        constructors.push(constructor);
+    }
+}
+
+fn composable_constructor_kind(value: Option<&windows_metadata::Value>) -> ConstructorKind {
+    let value = match value {
+        Some(windows_metadata::Value::I32(value)) => Some(*value),
+        Some(windows_metadata::Value::U32(value)) => i32::try_from(*value).ok(),
+        Some(windows_metadata::Value::AttributeEnum(_, value)) => Some(*value),
+        _ => None,
+    };
+
+    match value {
+        Some(2) => ConstructorKind::PublicComposition,
+        _ => ConstructorKind::ProtectedComposition,
+    }
 }
 
 fn split_full_name(full_name: &str) -> Option<(&str, &str)> {
@@ -1399,6 +1482,13 @@ mod tests {
         assert_eq!(class.namespace, "Windows.Foundation");
         assert!(class.default_interface.is_some());
         assert!(!class.factory_interfaces.is_empty());
+        assert!(class.constructors.iter().any(|constructor| {
+            constructor.kind == ConstructorKind::FactoryActivation
+                && constructor
+                    .factory_interface
+                    .as_ref()
+                    .is_some_and(|interface| interface.name == "IUriRuntimeClassFactory")
+        }));
     }
 
     #[test]
@@ -1468,6 +1558,89 @@ mod tests {
             class.has_default_constructor,
             "HttpClient should have a default constructor"
         );
+        assert!(class.constructors.iter().any(|constructor| {
+            constructor.kind == ConstructorKind::DefaultActivation
+                && constructor.factory_interface.is_none()
+        }));
+    }
+
+    #[test]
+    fn test_system_returned_class_has_no_constructor() {
+        let class = parse_class(WINDOWS_WINMD, "Windows.System", "User").unwrap();
+        assert!(class.constructors.is_empty());
+    }
+
+    #[test]
+    fn test_composition_visibility_values() {
+        assert_eq!(
+            composable_constructor_kind(Some(&windows_metadata::Value::I32(2))),
+            ConstructorKind::PublicComposition
+        );
+        assert_eq!(
+            composable_constructor_kind(Some(&windows_metadata::Value::I32(1))),
+            ConstructorKind::ProtectedComposition
+        );
+        assert_eq!(
+            composable_constructor_kind(None),
+            ConstructorKind::ProtectedComposition
+        );
+    }
+
+    #[test]
+    fn test_winui_composition_visibility_when_metadata_is_available() {
+        let Some(winui_winmd) = find_winui_winmd() else {
+            eprintln!("WinUI metadata not installed; skipping composition metadata test");
+            return;
+        };
+        let winmd_paths = format!("{};{}", WINDOWS_WINMD, winui_winmd.display());
+
+        let stack_panel =
+            parse_class(&winmd_paths, "Microsoft.UI.Xaml.Controls", "StackPanel").unwrap();
+        assert!(stack_panel.constructors.iter().any(|constructor| {
+            constructor.kind == ConstructorKind::PublicComposition && constructor.is_public()
+        }));
+
+        let automation_peer = parse_class(
+            &winmd_paths,
+            "Microsoft.UI.Xaml.Automation.Peers",
+            "AutomationPeer",
+        )
+        .unwrap();
+        assert!(automation_peer.constructors.iter().any(|constructor| {
+            constructor.kind == ConstructorKind::ProtectedComposition && !constructor.is_public()
+        }));
+    }
+
+    fn find_winui_winmd() -> Option<std::path::PathBuf> {
+        if let Some(path) = std::env::var_os("DYNWINRT_WINUI_WINMD") {
+            let path = std::path::PathBuf::from(path);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+
+        let packages = std::path::PathBuf::from(std::env::var_os("USERPROFILE")?)
+            .join(".winapp")
+            .join("packages");
+        let mut candidates: Vec<_> = std::fs::read_dir(packages)
+            .ok()?
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("Microsoft.WindowsAppSDK.WinUI.")
+            })
+            .map(|entry| {
+                entry
+                    .path()
+                    .join("metadata")
+                    .join("Microsoft.UI.Xaml.winmd")
+            })
+            .filter(|path| path.is_file())
+            .collect();
+        candidates.sort();
+        candidates.pop()
     }
 
     #[test]

--- a/tools/dynwinrt-codegen/tests/composable_factory_test.rs
+++ b/tools/dynwinrt-codegen/tests/composable_factory_test.rs
@@ -4,8 +4,11 @@
 use std::collections::{HashMap, HashSet};
 
 use dynwinrt_codegen::codegen::{project, render_dts, render_js};
-use dynwinrt_codegen::meta::{ClassMeta, InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
-use dynwinrt_codegen::types::TypeMeta;
+use dynwinrt_codegen::meta::{
+    ClassMeta, ConstructorKind, ConstructorMeta, InterfaceMeta, MethodMeta, ParamDirection,
+    ParamMeta,
+};
+use dynwinrt_codegen::types::{TypeKind, TypeMeta, TypeRef};
 
 #[test]
 fn composable_factory_returns_public_instance() {
@@ -49,6 +52,14 @@ fn composable_factory_returns_public_instance() {
             ..Default::default()
         }),
         factory_interfaces: vec![factory],
+        constructors: vec![ConstructorMeta {
+            kind: ConstructorKind::PublicComposition,
+            factory_interface: Some(TypeRef {
+                namespace: "Contoso".into(),
+                name: "IWidgetFactory".into(),
+                kind: TypeKind::Interface,
+            }),
+        }],
         ..Default::default()
     };
 
@@ -65,13 +76,37 @@ fn composable_factory_returns_public_instance() {
     let dts = render_dts::render(&projected);
 
     assert!(
-        js.contains("new Widget(_IWidgetFactory.method(6).invokeAll(") && js.contains("])[1])"),
+        js.contains("Widget._fromNative(_IWidgetFactory.method(6).invokeAll(")
+            && js.contains("])[1])"),
         "composable factory must select the final public-instance output:\n{js}"
     );
+    assert!(js.contains("static _fromNative(obj)"));
+    assert!(js.contains("Object.assign(Object.create(Widget.prototype)"));
+    assert!(js.contains("constructor(...args)"));
+    assert!(js.contains("this._obj = Widget.createInstance(null)._obj;"));
+    assert!(!dts.contains("_fromNative"));
+    assert!(dts.contains("constructor();"));
     assert!(
         dts.contains("static createInstance(outer: unknown): Widget;"),
         "factory declaration must return the runtime class:\n{dts}"
     );
+
+    let mut protected = class.clone();
+    protected.constructors[0].kind = ConstructorKind::ProtectedComposition;
+    let projected = project::project_class(
+        &protected,
+        &HashSet::from(["Widget".into()]),
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let protected_js = render_js::render(&projected);
+    let protected_dts = render_dts::render(&projected);
+    assert!(protected_js.contains("Widget cannot be constructed directly."));
+    assert!(protected_dts.contains("private constructor();"));
+    assert!(protected_dts.contains("static createInstance(outer: unknown): Widget;"));
 }
 
 #[test]
@@ -106,6 +141,10 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
                 ..Default::default()
             }],
             ..Default::default()
+        }],
+        constructors: vec![ConstructorMeta {
+            kind: ConstructorKind::DefaultActivation,
+            factory_interface: None,
         }],
         ..Default::default()
     };
@@ -157,4 +196,5 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
         "static createWithMetadataProvider(metadataProvider: XamlControlsXamlMetaDataProvider, onLaunched?: () => void): Application;"
     ));
     assert!(dts.contains("static create(onLaunched?: () => void): Application;"));
+    assert!(dts.contains("private constructor();"));
 }

--- a/tools/dynwinrt-codegen/tests/nullable_return_test.rs
+++ b/tools/dynwinrt-codegen/tests/nullable_return_test.rs
@@ -76,7 +76,7 @@ fn nullable_runtime_class_returns_are_guarded_without_type_changes() {
     let js = render_js::render(&projected);
     let dts = render_dts::render(&projected);
 
-    assert!(js.contains("v.isNull() ? null : new Accelerometer(v)"));
+    assert!(js.contains("v.isNull() ? null : Accelerometer._fromNative(v)"));
     assert!(dts.contains("static getDefault(): Accelerometer;"));
     assert!(dts.contains("Promise<Accelerometer>"));
     assert!(dts.contains("getCurrentReading(): AccelerometerReading;"));

--- a/tools/dynwinrt-codegen/tests/snapshots/uri/Uri.d.ts
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri/Uri.d.ts
@@ -4,7 +4,8 @@ import { WwwFormUrlDecoder } from './WwwFormUrlDecoder.js';
 
 export declare const IID_Uri: WinGuid;
 export declare class Uri {
-    private constructor();
+    constructor(uri: string);
+    constructor(baseUri: string, relativeUri: string);
     static createUri(uri: string): Uri;
     static createWithRelativeUri(baseUri: string, relativeUri: string): Uri;
     static unescapeComponent(toUnescape: string): string;

--- a/tools/dynwinrt-codegen/tests/snapshots/uri/Uri.js
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri/Uri.js
@@ -94,14 +94,25 @@ class Uri {
     static f_IUriRuntimeClassFactory() { return Uri._f_IUriRuntimeClassFactory ??= DynWinRtValue.activationFactory('Windows.Foundation.Uri').cast(IID_IUriRuntimeClassFactory); }
     static s_IUriEscapeStatics() { return Uri._s_IUriEscapeStatics ??= DynWinRtValue.activationFactory('Windows.Foundation.Uri').cast(IID_IUriEscapeStatics); }
 
-    constructor(obj) {
-        this._obj = obj.cast(IID_IUriRuntimeClass);
+    constructor(...args) {
+        if (args.length === 1) {
+            this._obj = Uri.createUri(args[0])._obj;
+            return;
+        }
+        if (args.length === 2) {
+            this._obj = Uri.createWithRelativeUri(args[0], args[1])._obj;
+            return;
+        }
+        throw new TypeError('No matching constructor for Uri.');
+    }
+    static _fromNative(obj) {
+        return Object.assign(Object.create(Uri.prototype), { _obj: obj.cast(IID_IUriRuntimeClass) });
     }
     static createUri(uri) {
-        return new Uri(_IUriRuntimeClassFactory.method(6).invoke(Uri.f_IUriRuntimeClassFactory(), [DynWinRtValue.hstring(uri)]));
+        return Uri._fromNative(_IUriRuntimeClassFactory.method(6).invoke(Uri.f_IUriRuntimeClassFactory(), [DynWinRtValue.hstring(uri)]));
     }
     static createWithRelativeUri(baseUri, relativeUri) {
-        return new Uri(_IUriRuntimeClassFactory.method(7).invoke(Uri.f_IUriRuntimeClassFactory(), [DynWinRtValue.hstring(baseUri), DynWinRtValue.hstring(relativeUri)]));
+        return Uri._fromNative(_IUriRuntimeClassFactory.method(7).invoke(Uri.f_IUriRuntimeClassFactory(), [DynWinRtValue.hstring(baseUri), DynWinRtValue.hstring(relativeUri)]));
     }
     static unescapeComponent(toUnescape) {
         return _IUriEscapeStatics.method(6).invoke(Uri.s_IUriEscapeStatics(), [DynWinRtValue.hstring(toUnescape)]).toString();
@@ -137,7 +148,7 @@ class Uri {
         return _IUriRuntimeClass.method(14).invoke(this._obj, []).toString();
     }
     get queryParsed() {
-        return ((v) => v.isNull() ? null : new (__get_WwwFormUrlDecoder())(v))(_IUriRuntimeClass.method(15).invoke(this._obj, []));
+        return ((v) => v.isNull() ? null : (__get_WwwFormUrlDecoder())._fromNative(v))(_IUriRuntimeClass.method(15).invoke(this._obj, []));
     }
     get rawUri() {
         return _IUriRuntimeClass.method(16).invoke(this._obj, []).toString();
@@ -158,7 +169,7 @@ class Uri {
         return _IUriRuntimeClass.method(21).invoke(this._obj, [(pUri == null ? DynWinRtValue.nullValue() : _unwrap(pUri))]).toBool();
     }
     combineUri(relativeUri) {
-        return ((v) => v.isNull() ? null : new Uri(v))(_IUriRuntimeClass.method(22).invoke(this._obj, [DynWinRtValue.hstring(relativeUri)]));
+        return ((v) => v.isNull() ? null : Uri._fromNative(v))(_IUriRuntimeClass.method(22).invoke(this._obj, [DynWinRtValue.hstring(relativeUri)]));
     }
     toString() {
         return IStringable.from(this._obj).toString();

--- a/tools/dynwinrt-codegen/tests/snapshots/uri/WwwFormUrlDecoder.d.ts
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri/WwwFormUrlDecoder.d.ts
@@ -3,7 +3,7 @@ import { WinGuid } from '@microsoft/dynwinrt';
 
 export declare const IID_WwwFormUrlDecoder: WinGuid;
 export declare class WwwFormUrlDecoder {
-    private constructor();
+    constructor(query: string);
     static createWwwFormUrlDecoder(query: string): WwwFormUrlDecoder;
     getFirstValueByName(name: string): string;
 }

--- a/tools/dynwinrt-codegen/tests/snapshots/uri/WwwFormUrlDecoder.js
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri/WwwFormUrlDecoder.js
@@ -32,11 +32,18 @@ class WwwFormUrlDecoder {
     static _f_IWwwFormUrlDecoderRuntimeClassFactory;
     static f_IWwwFormUrlDecoderRuntimeClassFactory() { return WwwFormUrlDecoder._f_IWwwFormUrlDecoderRuntimeClassFactory ??= DynWinRtValue.activationFactory('Windows.Foundation.WwwFormUrlDecoder').cast(IID_IWwwFormUrlDecoderRuntimeClassFactory); }
 
-    constructor(obj) {
-        this._obj = obj.cast(IID_IWwwFormUrlDecoderRuntimeClass);
+    constructor(...args) {
+        if (args.length === 1) {
+            this._obj = WwwFormUrlDecoder.createWwwFormUrlDecoder(args[0])._obj;
+            return;
+        }
+        throw new TypeError('No matching constructor for WwwFormUrlDecoder.');
+    }
+    static _fromNative(obj) {
+        return Object.assign(Object.create(WwwFormUrlDecoder.prototype), { _obj: obj.cast(IID_IWwwFormUrlDecoderRuntimeClass) });
     }
     static createWwwFormUrlDecoder(query) {
-        return new WwwFormUrlDecoder(_IWwwFormUrlDecoderRuntimeClassFactory.method(6).invoke(WwwFormUrlDecoder.f_IWwwFormUrlDecoderRuntimeClassFactory(), [DynWinRtValue.hstring(query)]));
+        return WwwFormUrlDecoder._fromNative(_IWwwFormUrlDecoderRuntimeClassFactory.method(6).invoke(WwwFormUrlDecoder.f_IWwwFormUrlDecoderRuntimeClassFactory(), [DynWinRtValue.hstring(query)]));
     }
     getFirstValueByName(name) {
         return _IWwwFormUrlDecoderRuntimeClass.method(6).invoke(this._obj, [DynWinRtValue.hstring(name)]).toString();

--- a/tools/dynwinrt-codegen/tests/tsc_check_test.rs
+++ b/tools/dynwinrt-codegen/tests/tsc_check_test.rs
@@ -76,6 +76,38 @@ fn generated_dts_passes_tsc_no_emit() {
         status2
     );
 
+    // Generate User to cover a system-returned class with no public constructor.
+    let status3 = Command::new(exe)
+        .args([
+            "generate",
+            "--namespace",
+            "Windows.System",
+            "--class-name",
+            "User",
+            "--lang",
+            "js",
+            "--output",
+        ])
+        .arg(&tmp)
+        .status()
+        .expect("spawn dynwinrt-codegen");
+    assert!(status3.success(), "codegen failed (User): {:?}", status3);
+
+    fs::write(
+        tmp.join("constructor-usage.ts"),
+        r#"import { Uri } from "./Uri.js";
+import { User } from "./User.js";
+
+new Uri("https://example.com");
+new Uri("https://example.com/base/", "child");
+// @ts-expect-error Uri has no zero-argument activation.
+new Uri();
+// @ts-expect-error User instances can only be returned by the system.
+new User();
+"#,
+    )
+    .expect("write constructor usage");
+
     // Write a minimal tsconfig.json for tsc --noEmit
     let tsconfig = tmp.join("tsconfig.json");
     fs::write(
@@ -90,7 +122,7 @@ fn generated_dts_passes_tsc_no_emit() {
     "skipLibCheck": false,
     "types": []
   },
-  "include": ["*.d.ts"]
+  "include": ["*.d.ts", "*.ts"]
 }"#,
     )
     .expect("write tsconfig");


### PR DESCRIPTION
## Summary

Add idiomatic JavaScript constructors for constructible WinRT runtime classes.

Examples:

```
const uri = new Uri('https://example.com');
const panel = new StackPanel();
const client = new HttpClient(filter);
```

This change:

• Projects default, factory, and public composable activations as constructors.
• Adds matching TypeScript constructor overloads.
• Introduces internal  _fromNative()  wrapping for objects returned by WinRT.
• Keeps existing static factories such as  createUri()  and  createInstance()  for compatibility.
• Omits ambiguous constructor overloads rather than guessing.
• Keeps protected composable and system-returned classes nonconstructible.
• Preserves the specialized  Application.create()  lifecycle API.
• Updates documentation and generated snapshots.