### PR TITLE
Return typed enums from generated Python bindings

### DIFF
--- a/PYTHON_CHECKLIST.md
+++ b/PYTHON_CHECKLIST.md
@@ -44,7 +44,8 @@ to a distributable, typed, and reliable WinRT projection.
 ## P0: runtime and generated API agreement
 
 - [ ] Ship a `.pyi` and `py.typed` marker for the `dynwinrt_py` extension.
-- [ ] Return generated enum instances when stubs declare enum return types.
+- [x] Return declared enum members as generated `IntEnum` instances while
+      preserving unknown values as integers.
 - [ ] Use `invoke_all()` for arbitrary multiple-out methods.
 - [ ] Add Python E2E for `IVector.IndexOf` and other multiple-out methods.
 - [ ] Model nullable and `IReference<T>` positions as `T | None`.
@@ -130,3 +131,6 @@ to a distributable, typed, and reliable WinRT projection.
 1. [x] Make generated runtime imports cycle-safe.
 2. [x] Add a real cyclic-package import regression.
 3. [x] Re-run Python snapshots, codegen tests, and generated Python E2E.
+4. [x] Return known enum values as generated `IntEnum` instances.
+5. [x] Verify `Calendar.day_of_week` is a `DayOfWeek` at runtime.
+6. [ ] Use `invoke_all()` for arbitrary multiple-out methods.

--- a/tests/e2e_specs.json
+++ b/tests/e2e_specs.json
@@ -87,7 +87,13 @@
       "langs": ["py", "ts"],
       "instantiate": { "kind": "activate" },
       "checks": [
-        { "kind": "property_in_range", "member": "day_of_week", "min": 0, "max": 6 }
+        {
+          "kind": "property_in_range",
+          "member": "day_of_week",
+          "expected_type": "DayOfWeek",
+          "min": 0,
+          "max": 6
+        }
       ]
     },
     {

--- a/tests/e2e_specs.schema.json
+++ b/tests/e2e_specs.schema.json
@@ -105,6 +105,7 @@
          },
          "write_value": { "type": "integer", "description": "Integer value used by async memory roundtrip" },
          "set_value": { "description": "Value to set for property_set_equals check" },
+         "expected_type": { "type": "string", "description": "Expected Python runtime type name" },
          "min_size": { "type": "integer", "description": "Minimum vector size for vector_view_access" },
          "search_value": { "description": "Value to search for in vector_index_of" },
          "expected_index": { "type": "integer", "description": "Expected indexOf result (-1 if not found)" },

--- a/tests/runners/py_runner.py
+++ b/tests/runners/py_runner.py
@@ -207,6 +207,13 @@ def run_check(check: dict, cls, obj, generated_dir: str, pkg_name: str) -> dict:
 
         elif kind == 'property_in_range':
             actual = getattr(obj, member)
+            expected_type = check.get('expected_type')
+            if expected_type and type(actual).__name__ != expected_type:
+                cr['error'] = (
+                    f'expected type {expected_type}, '
+                    f'got {type(actual).__name__}'
+                )
+                return cr
             min_val = check.get('min', float('-inf'))
             max_val = check.get('max', float('inf'))
             # Handle enum: extract .value if it's an IntEnum

--- a/tools/dynwinrt-codegen/src/codegen/common.rs
+++ b/tools/dynwinrt-codegen/src/codegen/common.rs
@@ -469,6 +469,28 @@ mod tests {
     }
 
     #[test]
+    fn py_convert_return_with_enum() {
+        let en = TypeMeta::Enum {
+            namespace: "Windows.Globalization".into(),
+            name: "DayOfWeek".into(),
+            underlying: Box::new(TypeMeta::I32),
+            members: Vec::new(),
+            doc: None,
+            deprecated: None,
+        };
+        assert_eq!(
+            py_convert_return("r", Some(&en), false, &HashSet::new()),
+            "r.to_number()"
+        );
+
+        let known = HashSet::from(["DayOfWeek".to_string()]);
+        assert_eq!(
+            py_convert_return("r", Some(&en), false, &known),
+            "_dynwinrt_enum('day_of_week', 'DayOfWeek', r.to_number())"
+        );
+    }
+
+    #[test]
     fn py_build_method_sig_empty() {
         let m = MethodMeta {
             name: "DoSomething".into(),

--- a/tools/dynwinrt-codegen/src/codegen/python/generator/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/generator/mod.rs
@@ -48,6 +48,14 @@ def _dynwinrt_symbol(module, name):
 def _dynwinrt_wrap_values(module, name, values):
     wrapper = _dynwinrt_symbol(module, name)
     return [wrapper(value) for value in values]
+
+
+def _dynwinrt_enum(module, name, value):
+    enum_type = _dynwinrt_symbol(module, name)
+    try:
+        return enum_type(value)
+    except ValueError:
+        return value
 \n";
 
 pub use class::generate_class;

--- a/tools/dynwinrt-codegen/src/codegen/python/signature.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/signature.rs
@@ -240,6 +240,14 @@ pub(crate) fn py_convert_return(
         Some(TypeMeta::I64 | TypeMeta::U64) => format!("{}.to_i64()", expr),
         Some(TypeMeta::F32 | TypeMeta::F64) => format!("{}.to_f64()", expr),
         Some(TypeMeta::Bool) => format!("{}.to_bool()", expr),
+        Some(TypeMeta::Enum { name, .. }) if known_types.contains(name) => {
+            format!(
+                "_dynwinrt_enum('{}', '{}', {}.to_number())",
+                to_snake_case_filename(name),
+                name,
+                expr
+            )
+        }
         Some(TypeMeta::Enum { .. }) => format!("{}.to_number()", expr),
         Some(TypeMeta::RuntimeClass { name, .. }) if known_types.contains(name) => {
             format!("{}({})", py_runtime_symbol(name, name), expr)

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_stringable.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_stringable.py
@@ -19,6 +19,14 @@ def _dynwinrt_wrap_values(module, name, values):
     return [wrapper(value) for value in values]
 
 
+def _dynwinrt_enum(module, name, value):
+    enum_type = _dynwinrt_symbol(module, name)
+    try:
+        return enum_type(value)
+    except ValueError:
+        return value
+
+
 IID_IStringable = WinGUID.parse('96369f54-8eb6-48f0-abce-c1b211e627c3')
 
 _IStringable = DynWinRTType.register_interface(

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_uri_runtime_class_with_absolute_canonical_uri.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_uri_runtime_class_with_absolute_canonical_uri.py
@@ -19,6 +19,14 @@ def _dynwinrt_wrap_values(module, name, values):
     return [wrapper(value) for value in values]
 
 
+def _dynwinrt_enum(module, name, value):
+    enum_type = _dynwinrt_symbol(module, name)
+    try:
+        return enum_type(value)
+    except ValueError:
+        return value
+
+
 IID_IUriRuntimeClassWithAbsoluteCanonicalUri = WinGUID.parse('758d9661-221c-480f-a339-50656673f46f')
 
 _IUriRuntimeClassWithAbsoluteCanonicalUri = DynWinRTType.register_interface(

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/uri.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/uri.py
@@ -19,6 +19,14 @@ def _dynwinrt_wrap_values(module, name, values):
     return [wrapper(value) for value in values]
 
 
+def _dynwinrt_enum(module, name, value):
+    enum_type = _dynwinrt_symbol(module, name)
+    try:
+        return enum_type(value)
+    except ValueError:
+        return value
+
+
 if TYPE_CHECKING:
     from .www_form_url_decoder import WwwFormUrlDecoder  # noqa: F401
 

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/www_form_url_decoder.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/www_form_url_decoder.py
@@ -19,6 +19,14 @@ def _dynwinrt_wrap_values(module, name, values):
     return [wrapper(value) for value in values]
 
 
+def _dynwinrt_enum(module, name, value):
+    enum_type = _dynwinrt_symbol(module, name)
+    try:
+        return enum_type(value)
+    except ValueError:
+        return value
+
+
 IID_IWwwFormUrlDecoderRuntimeClass = WinGUID.parse('d45a0451-f225-4542-9296-0e1df5d254df')
 IID_IWwwFormUrlDecoderRuntimeClassFactory = WinGUID.parse('5b8c6b3d-24ae-41b5-a1bf-f0c3d544845b')
 


### PR DESCRIPTION
## Summary

Generated Python stubs declared enum return types, but runtime implementations returned raw integers.

This change:

- Converts declared enum values to their generated `IntEnum` types
- Preserves unknown, future, or flag-combination values as integers instead of raising `ValueError`
- Reuses cycle-safe lazy symbol resolution
- Verifies `Calendar.day_of_week` returns `DayOfWeek`
- Updates unit coverage, E2E specs, snapshots, and the Python checklist

The JavaScript/TypeScript generation path is unchanged.