### PR TITLE
Fix FillArray ABI and support multi-output projections

### DIFF
--- a/PYTHON_CHECKLIST.md
+++ b/PYTHON_CHECKLIST.md
@@ -46,8 +46,8 @@ to a distributable, typed, and reliable WinRT projection.
 - [ ] Ship a `.pyi` and `py.typed` marker for the `dynwinrt_py` extension.
 - [x] Return declared enum members as generated `IntEnum` instances while
       preserving unknown values as integers.
-- [ ] Use `invoke_all()` for arbitrary multiple-out methods.
-- [ ] Add Python E2E for `IVector.IndexOf` and other multiple-out methods.
+- [x] Use `invoke_all()` for arbitrary multiple-out methods.
+- [x] Add Python E2E for `IVector.IndexOf` and other multiple-out methods.
 - [ ] Model nullable and `IReference<T>` positions as `T | None`.
 - [ ] Make Python stubs part of E2E and run a static type checker.
 - [ ] Make `.pyi` generation the default for `--lang py`.
@@ -133,4 +133,6 @@ to a distributable, typed, and reliable WinRT projection.
 3. [x] Re-run Python snapshots, codegen tests, and generated Python E2E.
 4. [x] Return known enum values as generated `IntEnum` instances.
 5. [x] Verify `Calendar.day_of_week` is a `DayOfWeek` at runtime.
-6. [ ] Use `invoke_all()` for arbitrary multiple-out methods.
+6. [x] Use `invoke_all()` for arbitrary multiple-out methods.
+7. [x] Model FillArray as caller-owned `(capacity, buffer)` ABI.
+8. [x] Verify Python and JavaScript `IndexOf` and `GetMany`, including zero items.

--- a/crates/dynwinrt/src/call.rs
+++ b/crates/dynwinrt/src/call.rs
@@ -101,19 +101,18 @@ pub fn call_1in_1out(
 }
 
 /// Direct call for 1 scalar in + FillArray out.
-/// fn(this, val, u32 capacity, *mut u8 items, *mut u32 actual) -> HRESULT
+/// fn(this, val, u32 capacity, *mut u8 items) -> HRESULT
 pub fn call_fill_array_1in(
     fptr: *mut c_void,
     obj: *mut c_void,
     in_val: &WinRTValue,
     capacity: u32,
     buffer: *mut u8,
-    actual: *mut u32,
 ) -> HRESULT {
     dispatch_scalar!(in_val, |v| unsafe {
-        let method: unsafe extern "system" fn(*mut c_void, _, u32, *mut u8, *mut u32) -> HRESULT =
+        let method: unsafe extern "system" fn(*mut c_void, _, u32, *mut u8) -> HRESULT =
             std::mem::transmute(fptr);
-        method(obj, v, capacity, buffer, actual)
+        method(obj, v, capacity, buffer)
     })
 }
 
@@ -161,7 +160,6 @@ impl Drop for ArrayOutSlot {
 struct FillArraySlot {
     capacity: u32,
     buffer_ptr: *mut u8, // CoTaskMemAlloc'd
-    actual_count: u32,   // callee writes the actual number of elements filled
     element_type: TypeHandle,
 }
 
@@ -171,15 +169,10 @@ impl Drop for FillArraySlot {
         // Buffer was zero-initialized before the call, so null slots are safe to release.
         // Use capacity as cleanup length — ArrayData::Drop skips null elements.
         if !self.buffer_ptr.is_null() {
-            let cleanup_len = if self.actual_count == 0 && self.capacity > 0 {
-                self.capacity as usize
-            } else {
-                std::cmp::min(self.actual_count, self.capacity) as usize
-            };
             let _ = crate::array::ArrayData::from_cotaskmem(
                 self.element_type.clone(),
                 self.buffer_ptr as *mut c_void,
-                cleanup_len,
+                self.capacity as usize,
             );
             self.buffer_ptr = std::ptr::null_mut();
         }
@@ -217,9 +210,6 @@ pub fn call_winrt_method_dynamic<A: ArgumentList + ?Sized>(
     // FillArray storage: caller-allocated buffers
     let mut fill_array_slots: Vec<Box<FillArraySlot>> = Vec::new();
     let mut fill_array_map: Vec<Option<usize>> = Vec::with_capacity(out_count);
-    // Pre-computed pointers to actual_count fields (must outlive ffi call)
-    let mut fill_array_actual_ptrs: Vec<*mut u32> = Vec::new();
-
     ffi_args.push(arg(&obj));
 
     // Phase 1a: Pre-allocate all out parameters
@@ -228,7 +218,7 @@ pub fn call_winrt_method_dynamic<A: ArgumentList + ?Sized>(
             if p.is_fill_array() {
                 // FillArray: caller allocates buffer. Use the capacity from args.
                 let array_data = args
-                    .get_value(p.value_index)
+                    .get_value(p.input_index.expect("FillArray input index"))
                     .as_array()
                     .expect("Expected WinRTValue::Array with capacity for FillArray parameter");
                 let elem_type = p.typ.array_element_type();
@@ -242,14 +232,11 @@ pub fn call_winrt_method_dynamic<A: ArgumentList + ?Sized>(
                 let slot = Box::new(FillArraySlot {
                     capacity,
                     buffer_ptr,
-                    actual_count: 0,
                     element_type: elem_type,
                 });
                 let slot_idx = fill_array_slots.len();
                 fill_array_map.push(Some(slot_idx));
                 fill_array_slots.push(slot);
-                let slot_ref = &mut *fill_array_slots[slot_idx];
-                fill_array_actual_ptrs.push(&mut slot_ref.actual_count);
                 // Placeholders for index alignment
                 out_values.push(AbiValue::Pointer(std::ptr::null_mut()));
                 out_ptrs.push(std::ptr::null());
@@ -311,11 +298,10 @@ pub fn call_winrt_method_dynamic<A: ArgumentList + ?Sized>(
     for p in parameters {
         if p.is_out() {
             if let Some(slot_idx) = fill_array_map[p.value_index] {
-                // FillArray: push THREE args (capacity, buffer pointer, actual count pointer)
+                // FillArray: push capacity and caller-allocated buffer.
                 let slot = &*fill_array_slots[slot_idx];
                 ffi_args.push(arg(&slot.capacity));
                 ffi_args.push(arg(&slot.buffer_ptr));
-                ffi_args.push(arg(&fill_array_actual_ptrs[slot_idx]));
             } else if array_out_map[p.value_index].is_some() {
                 // ReceiveArray out: push TWO args (pointer-to-length, pointer-to-data_ptr)
                 ffi_args.push(arg(&array_out_len_ptrs[array_out_idx]));
@@ -339,6 +325,22 @@ pub fn call_winrt_method_dynamic<A: ArgumentList + ?Sized>(
     let hr: windows_core::HRESULT = unsafe { cif.call(CodePtr(fptr), &ffi_args) };
     hr.ok()?;
 
+    // Counted FillArray methods (for example GetMany) carry the actual count
+    // as their UInt32 retval. Other FillArray methods write the full capacity.
+    let fill_array_actual_count = if fill_array_slots.is_empty() {
+        None
+    } else {
+        parameters
+            .iter()
+            .rev()
+            .find(|param| param.is_out() && !param.is_fill_array())
+            .filter(|param| matches!(param.typ.kind(), TypeKind::U32))
+            .and_then(|param| match out_values[param.value_index] {
+                AbiValue::U32(value) => Some(value),
+                _ => None,
+            })
+    };
+
     // Phase 4: Extract results
     let mut result_values: Vec<WinRTValue> = Vec::with_capacity(out_count);
     for p in parameters {
@@ -346,20 +348,15 @@ pub fn call_winrt_method_dynamic<A: ArgumentList + ?Sized>(
             if let Some(slot_idx) = fill_array_map[p.value_index] {
                 // FillArray: transfer CoTaskMem buffer ownership to ArrayData
                 let slot = &mut fill_array_slots[slot_idx];
-                // If callee didn't set actual_count (left as 0), assume full buffer.
-                let raw_count = if slot.actual_count == 0 && slot.capacity > 0 {
-                    slot.capacity
-                } else {
-                    slot.actual_count
-                };
-                // Clamp to capacity to prevent OOB reads if callee misbehaves.
-                let actual = std::cmp::min(raw_count as usize, slot.capacity as usize);
+                let length = fill_array_actual_count
+                    .map(|count| count.min(slot.capacity))
+                    .unwrap_or(slot.capacity) as usize;
                 let ptr = slot.buffer_ptr as *mut c_void;
                 slot.buffer_ptr = std::ptr::null_mut(); // prevent FillArraySlot::drop from freeing
                 result_values.push(WinRTValue::Array(crate::array::ArrayData::from_cotaskmem(
                     slot.element_type.clone(),
                     ptr,
-                    actual,
+                    length,
                 )));
             } else if let Some(slot_idx) = array_out_map[p.value_index] {
                 // ReceiveArray: wrap callee-allocated CoTaskMem buffer directly.

--- a/crates/dynwinrt/src/signature.rs
+++ b/crates/dynwinrt/src/signature.rs
@@ -18,14 +18,18 @@ pub enum ParamKind {
     In,
     Out,
     /// FillArray: caller allocates buffer, callee fills it.
-    /// ABI expands to 3 params: (u32 capacity, T* items, u32* actual_count).
+    /// ABI expands to 2 params: (u32 capacity, T* items).
     OutFillArray,
 }
 
 #[derive(Debug, Clone)]
 pub struct Parameter {
     pub typ: TypeHandle,
+    /// Index in the method result vector for out and FillArray parameters.
     pub value_index: usize,
+    /// Index in the caller-provided argument slice. FillArray parameters have
+    /// both an input index (capacity buffer) and an output index (filled data).
+    pub input_index: Option<usize>,
     pub kind: ParamKind,
 }
 
@@ -42,6 +46,7 @@ impl Parameter {
 #[derive(Debug, Clone)]
 pub struct MethodSignature {
     out_count: usize,
+    input_count: usize,
     parameters: Vec<Parameter>,
     return_type: TypeHandle,
     #[allow(dead_code)]
@@ -54,6 +59,7 @@ impl MethodSignature {
     pub fn new(table: &Arc<MetadataTable>) -> Self {
         MethodSignature {
             out_count: 0,
+            input_count: 0,
             parameters: Vec::new(),
             return_type: table.hresult(),
             is_opaque: false,
@@ -66,10 +72,13 @@ impl MethodSignature {
     }
 
     pub fn add_in(mut self, typ: TypeHandle) -> Self {
+        let input_index = self.input_count;
+        self.input_count += 1;
         self.parameters.push(Parameter {
             kind: ParamKind::In,
             typ,
-            value_index: self.parameters.len() - self.out_count,
+            value_index: input_index,
+            input_index: Some(input_index),
         });
         self
     }
@@ -79,18 +88,22 @@ impl MethodSignature {
             kind: ParamKind::Out,
             typ,
             value_index: self.out_count,
+            input_index: None,
         });
         self.out_count += 1;
         self
     }
 
     /// Add a FillArray out parameter: caller allocates buffer, callee fills it.
-    /// ABI expands to (u32 capacity, T* items, u32* actual_count).
+    /// ABI expands to (u32 capacity, T* items).
     pub fn add_out_fill(mut self, typ: TypeHandle) -> Self {
+        let input_index = self.input_count;
+        self.input_count += 1;
         self.parameters.push(Parameter {
             kind: ParamKind::OutFillArray,
             typ,
             value_index: self.out_count,
+            input_index: Some(input_index),
         });
         self.out_count += 1;
         self
@@ -102,9 +115,8 @@ impl MethodSignature {
         types.push(Type::pointer()); // com object's this pointer
         for param in &self.parameters {
             if param.is_fill_array() {
-                // FillArray: UINT32 capacity, T* items, UINT32* actual_count
+                // FillArray: UINT32 capacity, T* items
                 types.push(Type::u32());
-                types.push(Type::pointer());
                 types.push(Type::pointer());
             } else if param.typ.is_array() {
                 if param.is_out() {
@@ -240,9 +252,9 @@ enum CallStrategy {
     DirectReceiveArray,
     /// PassArray + 1 out: fn(this, u32, *const u8, out) -> HRESULT.
     DirectPassArray1Out,
-    /// FillArray only: fn(this, u32, *mut u8, *mut u32) -> HRESULT.
+    /// FillArray only: fn(this, u32, *mut u8) -> HRESULT.
     DirectFillArray,
-    /// 1 scalar in + FillArray: fn(this, val, u32, *mut u8, *mut u32) -> HRESULT.
+    /// 1 scalar in + FillArray: fn(this, val, u32, *mut u8) -> HRESULT.
     Direct1InFillArray,
     /// General case → libffi via cached Cif.
     Libffi(Cif),
@@ -361,10 +373,6 @@ impl<'a> InvocationArgs<'a> {
                 .take(self.original.len())
                 .collect()
         })[index] = Some(value);
-    }
-
-    fn is_empty(&self) -> bool {
-        self.original.is_empty()
     }
 }
 
@@ -572,38 +580,37 @@ impl Method {
                 Ok(vec![out])
             }
             CallStrategy::DirectFillArray => {
-                // fn(this, u32, *mut u8, *mut u32) -> HRESULT
+                // fn(this, u32, *mut u8) -> HRESULT
                 // FillArray: caller provides buffer of known capacity, callee fills it.
                 let param = &self.info.parameters[0];
                 let elem_type = param.typ.array_element_type();
                 let fptr = call::get_vtable_function_ptr(obj, self.info.index);
 
                 assert!(
-                    !args.is_empty() && args.get_value(param.value_index).as_array().is_some(),
+                    param
+                        .input_index
+                        .is_some_and(|index| { args.get_value(index).as_array().is_some() }),
                     "DirectFillArray requires a pre-allocated array argument with the desired capacity. \
                      Pass an ArrayData with the expected number of elements."
                 );
-                let array_data = args.get_value(param.value_index).as_array().unwrap();
+                let array_data = args
+                    .get_value(param.input_index.unwrap())
+                    .as_array()
+                    .unwrap();
                 let capacity = array_data.len() as u32;
                 let total_bytes = capacity as usize * elem_type.element_size();
                 let buffer_ptr =
                     unsafe { windows::Win32::System::Com::CoTaskMemAlloc(total_bytes) as *mut u8 };
                 assert!(!buffer_ptr.is_null(), "CoTaskMemAlloc failed for FillArray");
                 unsafe { std::ptr::write_bytes(buffer_ptr, 0, total_bytes) };
-                // Use sentinel to detect if callee actually wrote actual_count.
-                // WinRT FillArray contract requires callee to write the count,
-                // but some implementations don't — sentinel lets us distinguish
-                // "callee wrote 0" from "callee didn't write at all".
-                let mut actual_count: u32 = 0;
                 let hr: windows_core::HRESULT = unsafe {
                     let method: unsafe extern "system" fn(
                         *mut std::ffi::c_void,
                         u32,
                         *mut u8,
-                        *mut u32,
                     )
                         -> windows_core::HRESULT = std::mem::transmute(fptr);
-                    method(obj, capacity, buffer_ptr, &mut actual_count)
+                    method(obj, capacity, buffer_ptr)
                 };
                 if hr.is_err() {
                     // Callee may have written elements before failing.
@@ -616,21 +623,15 @@ impl Method {
                     );
                     hr.ok()?;
                 }
-                // If callee didn't set actual_count (left as 0) and capacity > 0, assume full buffer.
-                if actual_count == 0 && capacity > 0 {
-                    actual_count = capacity;
-                }
-                // Clamp to capacity to prevent OOB if callee misbehaves
-                actual_count = std::cmp::min(actual_count, capacity);
                 let array = crate::array::ArrayData::from_cotaskmem(
                     elem_type,
                     buffer_ptr as _,
-                    actual_count as usize,
+                    capacity as usize,
                 );
                 Ok(vec![WinRTValue::Array(array)])
             }
             CallStrategy::Direct1InFillArray => {
-                // fn(this, val, u32, *mut u8, *mut u32) -> HRESULT
+                // fn(this, val, u32, *mut u8) -> HRESULT
                 let in_param = self.info.parameters.iter().find(|p| !p.is_out()).unwrap();
                 let fill_param = self
                     .info
@@ -638,7 +639,10 @@ impl Method {
                     .iter()
                     .find(|p| p.is_fill_array())
                     .unwrap();
-                let array_data = args.get_value(fill_param.value_index).as_array().unwrap();
+                let array_data = args
+                    .get_value(fill_param.input_index.unwrap())
+                    .as_array()
+                    .unwrap();
                 let elem_type = fill_param.typ.array_element_type();
                 let capacity = array_data.len() as u32;
                 let total_bytes = capacity as usize * elem_type.element_size();
@@ -646,8 +650,6 @@ impl Method {
                     unsafe { windows::Win32::System::Com::CoTaskMemAlloc(total_bytes) as *mut u8 };
                 assert!(!buffer_ptr.is_null(), "CoTaskMemAlloc failed for FillArray");
                 unsafe { std::ptr::write_bytes(buffer_ptr, 0, total_bytes) };
-                // Use sentinel to detect if callee actually wrote actual_count.
-                let mut actual_count: u32 = 0;
                 let fptr = call::get_vtable_function_ptr(obj, self.info.index);
                 let hr = call::call_fill_array_1in(
                     fptr,
@@ -655,7 +657,6 @@ impl Method {
                     args.get_value(in_param.value_index),
                     capacity,
                     buffer_ptr,
-                    &mut actual_count,
                 );
                 if hr.is_err() {
                     // Buffer was zero-initialized; use capacity for cleanup.
@@ -666,16 +667,10 @@ impl Method {
                     );
                     hr.ok()?;
                 }
-                // If callee didn't set actual_count (left as 0) and capacity > 0, assume full buffer.
-                if actual_count == 0 && capacity > 0 {
-                    actual_count = capacity;
-                }
-                // Clamp to capacity to prevent OOB if callee misbehaves
-                actual_count = std::cmp::min(actual_count, capacity);
                 let array = crate::array::ArrayData::from_cotaskmem(
                     elem_type,
                     buffer_ptr as _,
-                    actual_count as usize,
+                    capacity as usize,
                 );
                 Ok(vec![WinRTValue::Array(array)])
             }
@@ -750,6 +745,23 @@ mod tests {
     use windows::Foundation::{IStringable, IUriRuntimeClass, Uri};
     use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize};
     use windows_core::{IInspectable, Interface, h};
+
+    #[test]
+    fn fill_array_tracks_distinct_input_and_output_indices() {
+        let table = MetadataTable::new();
+        let method = MethodSignature::new(&table)
+            .add_in(table.u32_type())
+            .add_out_fill(table.array(&table.hstring()))
+            .add_out(table.u32_type())
+            .build(6);
+
+        assert_eq!(method.info.parameters[0].value_index, 0);
+        assert_eq!(method.info.parameters[0].input_index, Some(0));
+        assert_eq!(method.info.parameters[1].value_index, 0);
+        assert_eq!(method.info.parameters[1].input_index, Some(1));
+        assert_eq!(method.info.parameters[2].value_index, 1);
+        assert_eq!(method.info.parameters[2].input_index, None);
+    }
 
     #[test]
     fn coerces_object_inputs_to_the_expected_interface() -> windows_core::Result<()> {

--- a/tests/e2e_specs.json
+++ b/tests/e2e_specs.json
@@ -339,6 +339,17 @@
       ]
     },
     {
+      "id": "calendar_languages_get_many",
+      "namespace": "Windows.Globalization",
+      "class": "Calendar",
+      "langs": ["py", "ts"],
+      "instantiate": { "kind": "activate" },
+      "checks": [
+        { "kind": "vector_get_many", "member": "languages", "capacity": 4 },
+        { "kind": "vector_get_many", "member": "languages", "capacity": 4, "at_end": true }
+      ]
+    },
+    {
       "id": "memory_buffer_closed_event",
       "namespace": "Windows.Foundation",
       "class": "MemoryBuffer",
@@ -374,7 +385,7 @@
       "id": "vector_index_of_found",
       "namespace": "Windows.Globalization",
       "class": "Calendar",
-      "langs": ["ts"],
+      "langs": ["py", "ts"],
       "instantiate": { "kind": "activate" },
       "checks": [
         { "kind": "vector_index_of", "member": "languages", "search_value": null, "expected_index": 0 }
@@ -384,7 +395,7 @@
       "id": "vector_index_of_not_found",
       "namespace": "Windows.Globalization",
       "class": "Calendar",
-      "langs": ["ts"],
+      "langs": ["py", "ts"],
       "instantiate": { "kind": "activate" },
       "checks": [
         { "kind": "vector_index_of", "member": "languages", "search_value": "xx-NONEXISTENT", "expected_index": -1 }

--- a/tests/e2e_specs.schema.json
+++ b/tests/e2e_specs.schema.json
@@ -68,6 +68,7 @@
              "property_set_equals",
              "vector_view_access",
              "vector_index_of",
+             "vector_get_many",
              "event_callback",
              "method_then_property_equals"
            ]
@@ -109,6 +110,8 @@
          "min_size": { "type": "integer", "description": "Minimum vector size for vector_view_access" },
          "search_value": { "description": "Value to search for in vector_index_of" },
          "expected_index": { "type": "integer", "description": "Expected indexOf result (-1 if not found)" },
+         "capacity": { "type": "integer", "description": "FillArray capacity used by vector_get_many" },
+         "at_end": { "type": "boolean", "description": "Start vector_get_many at Size and expect no items" },
          "event_name": { "type": "string", "description": "Event name for event_callback (PascalCase, e.g. Closed)" },
          "trigger": { "type": "string", "description": "Method to call to trigger the event (snake_case)" },
          "property_path": {

--- a/tests/runners/py_runner.py
+++ b/tests/runners/py_runner.py
@@ -263,6 +263,36 @@ def run_check(check: dict, cls, obj, generated_dir: str, pkg_name: str) -> dict:
                 else:
                     cr['pass'] = True
 
+        elif kind == 'vector_index_of':
+            vec = getattr(obj, member)
+            search_value = check.get('search_value')
+            if search_value is None:
+                search_value = vec.get_at(0)
+            index, found = vec.index_of(search_value)
+            actual = index if found else -1
+            expected = check['expected_index']
+            if actual != expected:
+                cr['error'] = f'index_of returned {actual}, expected {expected}'
+            else:
+                cr['pass'] = True
+
+        elif kind == 'vector_get_many':
+            import dynwinrt_py as dw
+
+            vec = getattr(obj, member)
+            capacity = min(check.get('capacity', 4), vec.size)
+            buffer = dw.DynWinRTArray.from_string_values([''] * capacity)
+            at_end = check.get('at_end', False)
+            items = vec.get_many(vec.size if at_end else 0, buffer)
+            if at_end and len(items) != 0:
+                cr['error'] = f'get_many at Size returned {len(items)} items'
+            elif not at_end and len(items) == 0:
+                cr['error'] = 'get_many returned no items'
+            elif not at_end and items[0] != vec.get_at(0):
+                cr['error'] = f'first item {items[0]!r} does not match get_at(0)'
+            else:
+                cr['pass'] = True
+
         elif kind == 'struct_roundtrip':
             struct_mod = importlib.import_module(f"{pkg_name}.{check['struct_module']}")
             struct_cls = getattr(struct_mod, check['struct_class'])

--- a/tests/runners/ts_runner.ts
+++ b/tests/runners/ts_runner.ts
@@ -290,6 +290,20 @@ async function runCheck(
       } else {
         cr.pass = true;
       }
+    } else if (kind === 'vector_get_many') {
+      const vec = obj[member];
+      const capacity = Math.min((check as any).capacity ?? 4, vec.size);
+      const atEnd = (check as any).at_end ?? false;
+      const items = vec.getMany(atEnd ? vec.size : 0, capacity);
+      if (atEnd && items.length !== 0) {
+        cr.error = `getMany at Size returned ${items.length} items`;
+      } else if (!atEnd && items.length === 0) {
+        cr.error = 'getMany returned no items';
+      } else if (!atEnd && items[0] !== vec.getAt(0)) {
+        cr.error = `first item ${JSON.stringify(items[0])} does not match getAt(0)`;
+      } else {
+        cr.pass = true;
+      }
     } else if (kind === 'struct_roundtrip') {
       const structClass = check.struct_class as string;
       const structModule = check.struct_module as string;

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/collections.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/collections.rs
@@ -165,25 +165,26 @@ pub(super) fn project_collection_helpers(
             // High-level getMany: T[] wrapper over the raw FillArray-based method
             let iface_var = format!("_{}", iface.name);
             let elem = &iface.generic_args[0];
-            if let Some(get_many_idx) = iface
-                .methods
-                .iter()
-                .find(|m| m.name == "GetMany")
-                .map(|m| m.vtable_index)
-            {
+            if let Some(get_many) = iface.methods.iter().find(|m| m.name == "GetMany") {
                 if let Some(fill_expr) = ts_fill_array_create("count", elem) {
+                    let fill_index =
+                        fill_array_output_index(get_many).expect("GetMany FillArray output");
+                    let count_index = method_abi_output_count(get_many) - 1;
                     let invoke = format!(
-                        "{iface_var}.method({get_many_idx}).invoke(this._obj, \
-                         [DynWinRtValue.u32(startIndex), _a.toValue()])"
+                        "{iface_var}.method({get_many_idx}).invokeAll(this._obj, \
+                         [DynWinRtValue.u32(startIndex), _a.toValue()])",
+                        get_many_idx = get_many.vtable_index
                     );
                     let arr_convert = convert_array_return(
-                        &format!("{invoke}.asArray()"),
+                        &format!("_r[{fill_index}].asArray()"),
                         elem,
                         known_types,
                         &NO_DEFERRED,
                     );
-                    let return_expr =
-                        format!("(() => {{ const _a = {fill_expr}; return {arr_convert}; }})()");
+                    let return_expr = format!(
+                        "(() => {{ const _a = {fill_expr}; const _r = {invoke}; \
+                         return {arr_convert}.slice(0, _r[{count_index}].toNumber()); }})()"
+                    );
                     members.push(ProjectedMember::Method(ProjectedMethod {
                         name: "getMany".into(),
                         doc: Some(DocInfo {

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/methods.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/methods.rs
@@ -5,6 +5,97 @@
 
 use super::*;
 
+fn projected_method_outputs(method: &MethodMeta) -> Vec<(usize, &TypeMeta)> {
+    let mut result_index = 0;
+    let mut outputs = Vec::new();
+    for param in &method.params {
+        match param.direction {
+            ParamDirection::Out | ParamDirection::OutFill => {
+                outputs.push((result_index, &param.typ));
+                result_index += 1;
+            }
+            ParamDirection::In => {}
+        }
+    }
+    if !fill_array_uses_retval_count(method)
+        && let Some(return_type) = method.return_type.as_ref()
+    {
+        outputs.push((result_index, return_type));
+    }
+    outputs
+}
+
+fn output_ts_type(typ: &TypeMeta, known_types: &HashSet<String>) -> String {
+    match typ {
+        TypeMeta::Array(inner) => ts_array_element_type(inner, known_types),
+        _ => ts_return_type_safe(Some(typ), false, known_types),
+    }
+}
+
+fn convert_output(
+    expr: &str,
+    typ: &TypeMeta,
+    known_types: &HashSet<String>,
+    deferred: &HashSet<String>,
+) -> String {
+    match typ {
+        TypeMeta::Array(inner) => {
+            convert_array_return(&format!("{}.asArray()", expr), inner, known_types, deferred)
+        }
+        _ => convert_return(expr, Some(typ), false, known_types, deferred),
+    }
+}
+
+fn project_multi_output(
+    method: &MethodMeta,
+    invoke_expr: &str,
+    known_types: &HashSet<String>,
+) -> (String, String) {
+    let outputs = projected_method_outputs(method);
+    let return_type = match outputs.as_slice() {
+        [(_, typ)] => output_ts_type(typ, known_types),
+        _ => format!(
+            "[{}]",
+            outputs
+                .iter()
+                .map(|(_, typ)| output_ts_type(typ, known_types))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+
+    let converted = outputs
+        .iter()
+        .map(|(index, typ)| {
+            let converted =
+                convert_output(&format!("_r[{}]", index), typ, known_types, &NO_DEFERRED);
+            if fill_array_uses_retval_count(method)
+                && fill_array_output_index(method) == Some(*index)
+            {
+                format!(
+                    "{}.slice(0, _r[{}].toNumber())",
+                    converted,
+                    method_abi_output_count(method) - 1
+                )
+            } else {
+                converted
+            }
+        })
+        .collect::<Vec<_>>();
+    let result = if converted.len() == 1 {
+        converted[0].clone()
+    } else {
+        format!("[{}]", converted.join(", "))
+    };
+    (
+        return_type,
+        format!(
+            "(() => {{ const _r = {}; return {}; }})()",
+            invoke_expr, result
+        ),
+    )
+}
+
 // ======================================================================
 // Method projection helpers
 // ======================================================================
@@ -139,6 +230,7 @@ pub(super) fn project_static_method(
         )
     });
     let is_async = return_type_meta.is_some_and(|rt| rt.is_async()) && !is_with_progress;
+    let is_multi_output = method_abi_output_count(method) > 1;
 
     let statics_call = format!("{cls}.s_{iface}()", cls = class.name, iface = iface.name);
 
@@ -169,7 +261,7 @@ pub(super) fn project_static_method(
         });
     }
 
-    let ts_return = ts_return_type_safe(return_type_meta, is_async, known_types);
+    let mut ts_return = ts_return_type_safe(return_type_meta, is_async, known_types);
     let params = project_params(
         &in_params,
         known_types,
@@ -178,9 +270,14 @@ pub(super) fn project_static_method(
         delegate_param_wraps,
     );
     let args_expr = build_args_expr(&in_params);
+    let invoke = if is_multi_output {
+        "invokeAll"
+    } else {
+        "invoke"
+    };
     let mut invoke_expr = format!(
-        "_{}.method({}).invoke({}, [{}])",
-        iface.name, method.vtable_index, statics_call, args_expr
+        "_{}.method({}).{}({}, [{}])",
+        iface.name, method.vtable_index, invoke, statics_call, args_expr
     );
     invoke_expr = rewrite_delegate_args_in_expr(&invoke_expr, &params);
 
@@ -230,6 +327,12 @@ pub(super) fn project_static_method(
             async_convert_v = Some(convert_v);
         }
         sync_return_expr = None;
+    } else if is_multi_output {
+        async_kind = AsyncKind::None;
+        let (multi_return, multi_expr) = project_multi_output(method, &invoke_expr, known_types);
+        ts_return = multi_return;
+        sync_return_expr = Some(multi_expr);
+        async_convert_v = None;
     } else {
         async_kind = AsyncKind::None;
         let converted = convert_return(
@@ -314,11 +417,12 @@ pub(super) fn project_instance_method(
         )
     });
     let is_async = return_type_meta.is_some_and(|rt| rt.is_async()) && !is_with_progress;
+    let is_multi_output = method_abi_output_count(method) > 1;
     let has_array_out = method.params.iter().any(|p| {
         (p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill)
             && matches!(p.typ, TypeMeta::Array(_))
     });
-    let has_return = return_type_meta.is_some() || has_array_out;
+    let has_return = method_abi_output_count(method) > 0;
 
     let is_delegate_type = |typ: Option<&TypeMeta>| -> bool {
         match typ {
@@ -458,32 +562,38 @@ pub(super) fn project_instance_method(
         delegate_sigs,
         delegate_param_wraps,
     );
-    let array_out_elem = if has_array_out && return_type_meta.is_none() {
-        method.params.iter().find_map(|p| {
-            if p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill {
-                if let TypeMeta::Array(inner) = &p.typ {
-                    Some(inner.as_ref())
+    let array_out_elem =
+        if has_array_out && (return_type_meta.is_none() || fill_array_uses_retval_count(method)) {
+            method.params.iter().find_map(|p| {
+                if p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill {
+                    if let TypeMeta::Array(inner) = &p.typ {
+                        Some(inner.as_ref())
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
-            } else {
-                None
-            }
-        })
-    } else {
-        None
-    };
+            })
+        } else {
+            None
+        };
 
-    let ts_return = if let Some(elem) = array_out_elem {
+    let mut ts_return = if let Some(elem) = array_out_elem {
         ts_array_element_type(elem, known_types)
     } else {
         ts_return_type_safe(return_type_meta, is_async, known_types)
     };
 
     let args_expr = build_args_expr(&in_params);
+    let invoke = if is_multi_output {
+        "invokeAll"
+    } else {
+        "invoke"
+    };
     let mut invoke_expr = format!(
-        "{}.method({}).invoke({}, [{}])",
-        iface_var, method.vtable_index, obj_expr, args_expr
+        "{}.method({}).{}({}, [{}])",
+        iface_var, method.vtable_index, invoke, obj_expr, args_expr
     );
     invoke_expr = rewrite_delegate_args_in_expr(&invoke_expr, &params);
 
@@ -535,13 +645,36 @@ pub(super) fn project_instance_method(
         }
         sync_return_expr = None;
         array_return_expr = None;
+    } else if is_multi_output && !fill_array_uses_retval_count(method) {
+        async_kind = AsyncKind::None;
+        let (multi_return, multi_expr) = project_multi_output(method, &invoke_expr, known_types);
+        ts_return = multi_return;
+        sync_return_expr = Some(multi_expr);
+        async_convert_v = None;
+        array_return_expr = None;
     } else if let Some(elem) = array_out_elem {
         async_kind = AsyncKind::None;
-        let arr_expr = format!("{}.asArray()", invoke_expr);
+        let arr_expr = if fill_array_uses_retval_count(method) {
+            format!(
+                "_r[{}].asArray()",
+                fill_array_output_index(method).expect("FillArray output index")
+            )
+        } else {
+            format!("{}.asArray()", invoke_expr)
+        };
         let converted = convert_array_return(&arr_expr, elem, known_types, &NO_DEFERRED);
         sync_return_expr = None;
         async_convert_v = None;
-        array_return_expr = Some(converted);
+        array_return_expr = if fill_array_uses_retval_count(method) {
+            Some(format!(
+                "(() => {{ const _r = {}; return {}.slice(0, _r[{}].toNumber()); }})()",
+                invoke_expr,
+                converted,
+                method_abi_output_count(method) - 1
+            ))
+        } else {
+            Some(converted)
+        };
     } else {
         async_kind = AsyncKind::None;
         if has_return {
@@ -723,4 +856,77 @@ fn find_setter_for_property(
         "{}.method({}).invoke({}, [{}]);",
         iface_var, setter.vtable_index, obj_expr, arg
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meta::ParamMeta;
+
+    fn fill_array_with_boolean_result() -> MethodMeta {
+        MethodMeta {
+            name: "TryGetValues".into(),
+            raw_name: "TryGetValues".into(),
+            vtable_index: 6,
+            params: vec![ParamMeta {
+                name: "values".into(),
+                typ: TypeMeta::Array(Box::new(TypeMeta::F32)),
+                direction: ParamDirection::OutFill,
+            }],
+            return_type: Some(TypeMeta::Bool),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn projects_non_counted_multi_outputs_for_instance_and_static_methods() {
+        let method = fill_array_with_boolean_result();
+        let delegate_sigs: HashMap<String, String> = HashMap::new();
+        let delegate_wraps: HashMap<String, Vec<String>> = HashMap::new();
+        let instance = project_instance_method(
+            "_IWidget",
+            "this._obj",
+            &method,
+            &HashSet::new(),
+            &HashSet::new(),
+            None,
+            &delegate_sigs,
+            &delegate_wraps,
+        )
+        .expect("instance method");
+        let ProjectedMember::Method(instance) = instance else {
+            panic!("expected method");
+        };
+        assert_eq!(instance.return_type, "[number[], boolean]");
+        let instance_expr = instance.sync_return_expr.expect("instance return");
+        assert!(instance_expr.contains(".invokeAll("));
+        assert!(instance_expr.contains("_r[0].asArray().toF32Vec()"));
+        assert!(instance_expr.contains("_r[1].toBool()"));
+
+        let iface = InterfaceMeta {
+            name: "IWidgetStatics".into(),
+            methods: vec![method.clone()],
+            ..Default::default()
+        };
+        let class = ClassMeta {
+            name: "Widget".into(),
+            ..Default::default()
+        };
+        let ProjectedMember::Method(static_method) = project_static_method(
+            &class,
+            &iface,
+            &method,
+            &HashSet::new(),
+            &HashSet::new(),
+            &delegate_sigs,
+            &delegate_wraps,
+        ) else {
+            panic!("expected static method");
+        };
+        assert_eq!(static_method.return_type, "[number[], boolean]");
+        let static_expr = static_method.sync_return_expr.expect("static return");
+        assert!(static_expr.contains(".invokeAll("));
+        assert!(static_expr.contains("_r[0].asArray().toF32Vec()"));
+        assert!(static_expr.contains("_r[1].toBool()"));
+    }
 }

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
@@ -34,7 +34,8 @@ pub fn get_import_name() -> String {
 
 use crate::codegen::shared::imports::{
     NO_DEFERRED, collect_iface_type_imports, collect_type_imports,
-    collect_used_generics_from_class, collect_used_generics_from_methods, get_in_params,
+    collect_used_generics_from_class, collect_used_generics_from_methods, fill_array_output_index,
+    fill_array_uses_retval_count, get_in_params, method_abi_output_count,
 };
 use crate::codegen::shared::structs::{
     collect_used_structs_from_class, collect_used_structs_from_iface,

--- a/tools/dynwinrt-codegen/src/codegen/python/generator/class.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/generator/class.rs
@@ -275,6 +275,7 @@ pub fn generate_class(
                 iface,
                 method,
                 known_types,
+                &delegate_names,
             ));
         }
     }

--- a/tools/dynwinrt-codegen/src/codegen/python/generator/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/generator/mod.rs
@@ -56,6 +56,11 @@ def _dynwinrt_enum(module, name, value):
         return enum_type(value)
     except ValueError:
         return value
+
+
+def _dynwinrt_wait_action(value):
+    value.wait()
+    return None
 \n";
 
 pub use class::generate_class;

--- a/tools/dynwinrt-codegen/src/codegen/python/method.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/method.rs
@@ -3,18 +3,113 @@
 
 use std::collections::HashSet;
 
-use crate::meta::{ClassMeta, InterfaceMeta, MethodMeta, ParamDirection};
+use crate::meta::{ClassMeta, InterfaceMeta, MethodMeta};
 use crate::types::TypeMeta;
 
-use crate::codegen::shared::imports::get_in_params;
+use crate::codegen::shared::imports::{
+    fill_array_output_index, fill_array_uses_retval_count, get_in_params,
+};
 
 use super::naming::to_snake_case;
-use super::signature::{
-    py_build_args_expr, py_convert_array_return, py_convert_return, py_runtime_symbol, py_wrap_arg,
-};
+use super::signature::{py_build_args_expr, py_convert_return, py_runtime_symbol, py_wrap_arg};
 use super::type_helpers::{
-    method_pydoc, py_array_element_type, py_param_list, py_param_type_safe, py_return_type_safe,
+    method_pydoc, py_method_abi_output_count, py_method_outputs, py_method_return_type,
+    py_param_list, py_param_type_safe, py_return_type_safe,
 };
+
+fn is_delegate_type(typ: &TypeMeta, delegate_type_names: &HashSet<String>) -> bool {
+    matches!(typ, TypeMeta::Delegate { .. })
+        || matches!(
+            typ,
+            TypeMeta::Interface { name, .. } if delegate_type_names.contains(name)
+        )
+}
+
+fn convert_method_output(
+    expr: &str,
+    typ: &TypeMeta,
+    known_types: &HashSet<String>,
+    delegate_type_names: &HashSet<String>,
+) -> String {
+    if is_delegate_type(typ, delegate_type_names) {
+        return expr.to_string();
+    }
+    if matches!(
+        typ,
+        TypeMeta::AsyncAction | TypeMeta::AsyncActionWithProgress(_)
+    ) {
+        return format!("_dynwinrt_wait_action({})", expr);
+    }
+
+    py_convert_return(expr, Some(typ), typ.is_async(), known_types)
+}
+
+fn method_call_expr(
+    iface_var: &str,
+    method: &MethodMeta,
+    obj_expr: &str,
+    args_expr: &str,
+) -> String {
+    let invoke = if py_method_abi_output_count(method) > 1 {
+        "invoke_all"
+    } else {
+        "invoke"
+    };
+    format!(
+        "{}.method({}).{}({}, [{}])",
+        iface_var, method.vtable_index, invoke, obj_expr, args_expr
+    )
+}
+
+fn emit_method_result(
+    out: &mut String,
+    call_expr: &str,
+    method: &MethodMeta,
+    known_types: &HashSet<String>,
+    delegate_type_names: &HashSet<String>,
+) {
+    let outputs = py_method_outputs(method);
+    if outputs.is_empty() {
+        out.push_str(&format!("        {}\n", call_expr));
+        return;
+    }
+
+    if py_method_abi_output_count(method) == 1 {
+        let converted =
+            convert_method_output(call_expr, outputs[0].1, known_types, delegate_type_names);
+        out.push_str(&format!("        return {}\n", converted));
+        return;
+    }
+
+    out.push_str(&format!("        _results = {}\n", call_expr));
+    let converted = outputs
+        .iter()
+        .map(|(index, typ)| {
+            let converted = convert_method_output(
+                &format!("_results[{}]", index),
+                typ,
+                known_types,
+                delegate_type_names,
+            );
+            if fill_array_uses_retval_count(method)
+                && fill_array_output_index(method) == Some(*index)
+            {
+                format!(
+                    "{}[:_results[{}].to_number()]",
+                    converted,
+                    py_method_abi_output_count(method) - 1
+                )
+            } else {
+                converted
+            }
+        })
+        .collect::<Vec<_>>();
+    if converted.len() == 1 {
+        out.push_str(&format!("        return {}\n", converted[0]));
+    } else {
+        out.push_str(&format!("        return ({})\n", converted.join(", ")));
+    }
+}
 
 // ======================================================================
 // Method generation — Python call pattern
@@ -27,7 +122,6 @@ pub(crate) fn generate_factory_method_invoke(
     let in_params = get_in_params(method);
     let py_params = py_param_list(&in_params, known_types);
 
-    let is_async = method.return_type.as_ref().is_some_and(|rt| rt.is_async());
     let return_py_type = format!("'{}'", class.name);
 
     let mut out = String::new();
@@ -48,22 +142,24 @@ pub(crate) fn generate_factory_method_invoke(
     out.push_str(&method_pydoc(method, &in_params));
 
     let args_expr = py_build_args_expr(&in_params);
-    let call_expr = format!(
-        "_{iface}.method({idx}).invoke({cls}._get_f_{iface}(), [{args}])",
-        iface = iface.name,
-        idx = method.vtable_index,
-        cls = class.name,
-        args = args_expr
+    let call_expr = method_call_expr(
+        &format!("_{}", iface.name),
+        method,
+        &format!("{}._get_f_{}()", class.name, iface.name),
+        &args_expr,
     );
-
-    if is_async {
-        out.push_str(&format!(
-            "        return {}({}.wait())\n",
-            class.name, call_expr
-        ));
+    let result_expr = if py_method_abi_output_count(method) > 1 {
+        out.push_str(&format!("        _results = {}\n", call_expr));
+        format!("_results[{}]", py_method_abi_output_count(method) - 1)
     } else {
-        out.push_str(&format!("        return {}({})\n", class.name, call_expr));
-    }
+        call_expr
+    };
+    let result_expr = if method.return_type.as_ref().is_some_and(TypeMeta::is_async) {
+        format!("{}.wait()", result_expr)
+    } else {
+        result_expr
+    };
+    out.push_str(&format!("        return {}({})\n", class.name, result_expr));
     out
 }
 
@@ -72,19 +168,12 @@ pub(crate) fn generate_static_method_invoke(
     iface: &InterfaceMeta,
     method: &MethodMeta,
     known_types: &HashSet<String>,
+    delegate_type_names: &HashSet<String>,
 ) -> String {
     let in_params = get_in_params(method);
     let py_params = py_param_list(&in_params, known_types);
 
-    let return_type = method.return_type.as_ref();
-    let is_with_progress = return_type.is_some_and(|rt| {
-        matches!(
-            rt,
-            TypeMeta::AsyncOperationWithProgress(_, _) | TypeMeta::AsyncActionWithProgress(_)
-        )
-    });
-    let is_async = return_type.is_some_and(|rt| rt.is_async()) && !is_with_progress;
-    let py_return = py_return_type_safe(return_type, known_types);
+    let py_return = py_method_return_type(method, known_types, delegate_type_names);
 
     let mut out = String::new();
 
@@ -104,12 +193,14 @@ pub(crate) fn generate_static_method_invoke(
             prop_name, py_return
         ));
         out.push_str(&method_pydoc(method, &in_params));
-        let call_expr = format!(
-            "_{}.method({}).invoke({}, [])",
-            iface.name, method.vtable_index, statics_call
+        let call_expr = method_call_expr(&format!("_{}", iface.name), method, &statics_call, "");
+        emit_method_result(
+            &mut out,
+            &call_expr,
+            method,
+            known_types,
+            delegate_type_names,
         );
-        let converted = py_convert_return(&call_expr, return_type, false, known_types);
-        out.push_str(&format!("        return {}\n", converted));
     } else {
         out.push_str("    @staticmethod\n");
         let method_name = to_snake_case(&method.name);
@@ -123,38 +214,19 @@ pub(crate) fn generate_static_method_invoke(
         }
         out.push_str(&method_pydoc(method, &in_params));
         let args_expr = py_build_args_expr(&in_params);
-        let call_expr = format!(
-            "_{}.method({}).invoke({}, [{}])",
-            iface.name, method.vtable_index, statics_call, args_expr
+        let call_expr = method_call_expr(
+            &format!("_{}", iface.name),
+            method,
+            &statics_call,
+            &args_expr,
         );
-        if is_with_progress {
-            let inner_type = match return_type {
-                Some(TypeMeta::AsyncOperationWithProgress(inner, _)) => Some(inner.as_ref()),
-                _ => None,
-            };
-            // For progress pattern in Python: call, optionally set progress callback, then .wait()
-            let call_expr_no_idx = format!(
-                "_{}.method({}).invoke({}, [{}])",
-                iface.name, method.vtable_index, statics_call, args_expr
-            );
-            let inner_convert = py_convert_return("_op.wait()", inner_type, false, known_types);
-            out.push_str(&format!("        _op = {}\n", call_expr_no_idx));
-            out.push_str(&format!("        return {}\n", inner_convert));
-        } else if is_async
-            && matches!(
-                return_type,
-                Some(TypeMeta::AsyncAction) | Some(TypeMeta::AsyncActionWithProgress(_))
-            )
-        {
-            let call_expr_void = format!(
-                "_{}.method({}).invoke({}, [{}])",
-                iface.name, method.vtable_index, statics_call, args_expr
-            );
-            out.push_str(&format!("        {}.wait()\n", call_expr_void));
-        } else {
-            let converted = py_convert_return(&call_expr, return_type, is_async, known_types);
-            out.push_str(&format!("        return {}\n", converted));
-        }
+        emit_method_result(
+            &mut out,
+            &call_expr,
+            method,
+            known_types,
+            delegate_type_names,
+        );
     }
     out
 }
@@ -187,18 +259,6 @@ pub(crate) fn generate_method_body(
 ) -> String {
     let in_params = get_in_params(method);
     let return_type = method.return_type.as_ref();
-    let is_with_progress = return_type.is_some_and(|rt| {
-        matches!(
-            rt,
-            TypeMeta::AsyncOperationWithProgress(_, _) | TypeMeta::AsyncActionWithProgress(_)
-        )
-    });
-    let is_async = return_type.is_some_and(|rt| rt.is_async()) && !is_with_progress;
-    let has_array_out = method.params.iter().any(|p| {
-        (p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill)
-            && matches!(p.typ, TypeMeta::Array(_))
-    });
-    let has_return = return_type.is_some() || has_array_out;
 
     let mut out = String::new();
 
@@ -250,17 +310,10 @@ pub(crate) fn generate_method_body(
         return out;
     }
 
-    let is_delegate_type = |typ: Option<&TypeMeta>| -> bool {
-        match typ {
-            Some(TypeMeta::Delegate { .. }) => true,
-            Some(TypeMeta::Interface { name, .. }) => delegate_type_names.contains(name),
-            _ => false,
-        }
-    };
-
     if method.is_property_getter && in_params.is_empty() {
         let prop_name = to_snake_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
-        let py_return = if is_delegate_type(return_type) {
+        let py_return = if return_type.is_some_and(|typ| is_delegate_type(typ, delegate_type_names))
+        {
             "'DynWinRTValue'".to_string()
         } else {
             py_return_type_safe(return_type, known_types)
@@ -268,21 +321,19 @@ pub(crate) fn generate_method_body(
         out.push_str("    @property\n");
         out.push_str(&format!("    def {}(self) -> {}:\n", prop_name, py_return));
         out.push_str(&method_pydoc(method, &in_params));
-        let call_expr = format!(
-            "{}.method({}).invoke({}, [])",
-            iface_var, method.vtable_index, obj_expr
+        let call_expr = method_call_expr(iface_var, method, obj_expr, "");
+        emit_method_result(
+            &mut out,
+            &call_expr,
+            method,
+            known_types,
+            delegate_type_names,
         );
-        let converted = if is_delegate_type(return_type) {
-            call_expr.clone()
-        } else {
-            py_convert_return(&call_expr, return_type, false, known_types)
-        };
-        out.push_str(&format!("        return {}\n", converted));
     } else if method.is_property_setter {
         let prop_name = to_snake_case(method.name.strip_prefix("put_").unwrap_or(&method.name));
         let param_type = if in_params
             .first()
-            .is_some_and(|p| is_delegate_type(Some(&p.typ)))
+            .is_some_and(|p| is_delegate_type(&p.typ, delegate_type_names))
         {
             "'DynWinRTValue'".to_string()
         } else {
@@ -307,26 +358,7 @@ pub(crate) fn generate_method_body(
         ));
     } else {
         let py_params = py_param_list(&in_params, known_types);
-        let array_out_elem = if has_array_out && return_type.is_none() {
-            method.params.iter().find_map(|p| {
-                if p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill {
-                    if let TypeMeta::Array(inner) = &p.typ {
-                        Some(inner.as_ref())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-        } else {
-            None
-        };
-        let py_return = if let Some(elem) = array_out_elem {
-            py_array_element_type(elem, known_types)
-        } else {
-            py_return_type_safe(return_type, known_types)
-        };
+        let py_return = py_method_return_type(method, known_types, delegate_type_names);
         let method_name = name_override
             .map(|s| s.to_string())
             .unwrap_or_else(|| to_snake_case(&method.name));
@@ -343,37 +375,55 @@ pub(crate) fn generate_method_body(
         out.push_str(&method_pydoc(method, &in_params));
 
         let args_expr = py_build_args_expr(&in_params);
-        let call_expr = format!(
-            "{}.method({}).invoke({}, [{}])",
-            iface_var, method.vtable_index, obj_expr, args_expr
+        let call_expr = method_call_expr(iface_var, method, obj_expr, &args_expr);
+        emit_method_result(
+            &mut out,
+            &call_expr,
+            method,
+            known_types,
+            delegate_type_names,
         );
-
-        if is_with_progress {
-            let inner_type = match return_type {
-                Some(TypeMeta::AsyncOperationWithProgress(inner, _)) => Some(inner.as_ref()),
-                _ => None,
-            };
-            let inner_convert = py_convert_return("_op.wait()", inner_type, false, known_types);
-            out.push_str(&format!("        _op = {}\n", call_expr));
-            out.push_str(&format!("        return {}\n", inner_convert));
-        } else if !has_return && !is_async {
-            out.push_str(&format!("        {}\n", call_expr));
-        } else if is_async
-            && matches!(
-                return_type,
-                Some(TypeMeta::AsyncAction) | Some(TypeMeta::AsyncActionWithProgress(_))
-            )
-        {
-            out.push_str(&format!("        {}.wait()\n", call_expr));
-        } else if let Some(elem) = array_out_elem {
-            let arr_expr = format!("{}.as_array()", call_expr);
-            let converted = py_convert_array_return(&arr_expr, elem, known_types);
-            out.push_str(&format!("        return {}\n", converted));
-        } else {
-            let converted = py_convert_return(&call_expr, return_type, is_async, known_types);
-            out.push_str(&format!("        return {}\n", converted));
-        }
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_delegate_return_stays_raw() {
+        let method = MethodMeta {
+            name: "GetHandler".into(),
+            raw_name: "GetHandler".into(),
+            vtable_index: 6,
+            return_type: Some(TypeMeta::Interface {
+                namespace: "Contoso".into(),
+                name: "Handler".into(),
+                iid: "11111111-1111-1111-1111-111111111111".into(),
+            }),
+            ..Default::default()
+        };
+        let iface = InterfaceMeta {
+            name: "IWidgetStatics".into(),
+            methods: vec![method.clone()],
+            ..Default::default()
+        };
+        let class = ClassMeta {
+            name: "Widget".into(),
+            ..Default::default()
+        };
+        let code = generate_static_method_invoke(
+            &class,
+            &iface,
+            &method,
+            &HashSet::from(["Handler".into()]),
+            &HashSet::from(["Handler".into()]),
+        );
+
+        assert!(code.contains("def get_handler() -> 'DynWinRTValue':"));
+        assert!(code.contains("return _IWidgetStatics.method(6).invoke("));
+        assert!(!code.contains("_dynwinrt_symbol('handler', 'Handler')"));
+    }
 }

--- a/tools/dynwinrt-codegen/src/codegen/python/stub_helpers.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/stub_helpers.rs
@@ -6,12 +6,12 @@
 use std::collections::HashSet;
 
 use crate::codegen::shared::imports::get_in_params;
-use crate::meta::{MethodMeta, ParamDirection};
+use crate::meta::MethodMeta;
 use crate::types::{TypeKind, TypeMeta};
 
 use super::naming::{to_snake_case, to_snake_case_filename};
 use super::type_helpers::{
-    py_array_element_type, py_param_list, py_param_type_safe, py_return_type_safe,
+    py_method_return_type, py_param_list, py_param_type_safe, py_return_type_safe,
 };
 
 pub(super) fn format_py_type_import(name: &str, kind: TypeKind) -> String {
@@ -119,10 +119,6 @@ pub(super) fn emit_method_stub(
     let indent = " ".repeat(indent_spaces);
     let in_params = get_in_params(method);
     let return_type = method.return_type.as_ref();
-    let has_array_out = method.params.iter().any(|p| {
-        (p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill)
-            && matches!(p.typ, TypeMeta::Array(_))
-    });
 
     let is_delegate_type = |typ: Option<&TypeMeta>| -> bool {
         match typ {
@@ -184,26 +180,7 @@ pub(super) fn emit_method_stub(
         ));
     } else {
         let py_params = py_param_list(&in_params, known_types);
-        let array_out_elem = if has_array_out && return_type.is_none() {
-            method.params.iter().find_map(|p| {
-                if p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill {
-                    if let TypeMeta::Array(inner) = &p.typ {
-                        Some(inner.as_ref())
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
-        } else {
-            None
-        };
-        let py_return = if let Some(elem) = array_out_elem {
-            py_array_element_type(elem, known_types)
-        } else {
-            py_return_type_safe(return_type, known_types)
-        };
+        let py_return = py_method_return_type(method, known_types, delegate_type_names);
         let method_name = to_snake_case(&method.name);
         let self_and_params = if py_params.is_empty() {
             "self".to_string()
@@ -220,31 +197,24 @@ pub(super) fn emit_method_stub(
 }
 
 pub(super) fn emit_static_method_stub(
-    class_name: &str,
+    _class_name: &str,
     method: &MethodMeta,
     known_types: &HashSet<String>,
     is_factory: bool,
+    delegate_type_names: &HashSet<String>,
 ) -> String {
     let in_params = get_in_params(method);
     let py_params = py_param_list(&in_params, known_types);
 
-    let return_type = method.return_type.as_ref();
     let py_return = if is_factory {
-        format!("'{}'", class_name)
+        format!("'{}'", _class_name)
     } else {
-        py_return_type_safe(return_type, known_types)
+        py_method_return_type(method, known_types, delegate_type_names)
     };
 
     let mut out = String::new();
 
-    if !is_factory && method.is_property_getter && in_params.is_empty() {
-        let prop_name = to_snake_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
-        out.push_str("    @classmethod\n");
-        out.push_str(&format!(
-            "    def get_{}(cls) -> {}: ...\n",
-            prop_name, py_return
-        ));
-    } else {
+    if is_factory || !method.is_property_getter || !in_params.is_empty() {
         let method_name = to_snake_case(&method.name);
         out.push_str("    @staticmethod\n");
         if py_params.is_empty() {
@@ -258,6 +228,13 @@ pub(super) fn emit_static_method_stub(
                 method_name, py_params, py_return
             ));
         }
+    } else {
+        let prop_name = to_snake_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
+        out.push_str("    @classmethod\n");
+        out.push_str(&format!(
+            "    def get_{}(cls) -> {}: ...\n",
+            prop_name, py_return
+        ));
     }
     out
 }

--- a/tools/dynwinrt-codegen/src/codegen/python/stubs.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/stubs.rs
@@ -303,6 +303,7 @@ pub fn generate_class_stub(
                 method,
                 known_types,
                 true,
+                delegate_type_names,
             ));
         }
     }
@@ -315,6 +316,7 @@ pub fn generate_class_stub(
                 method,
                 known_types,
                 false,
+                delegate_type_names,
             ));
         }
     }

--- a/tools/dynwinrt-codegen/src/codegen/python/type_helpers.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/type_helpers.rs
@@ -6,6 +6,7 @@
 use std::collections::HashSet;
 
 use crate::codegen::shared::docs::{DocText, find_param_doc};
+use crate::codegen::shared::imports::{fill_array_uses_retval_count, method_abi_output_count};
 use crate::meta::MethodMeta;
 use crate::types::TypeMeta;
 
@@ -107,6 +108,75 @@ pub(super) fn py_return_type_safe(typ: Option<&TypeMeta>, known: &HashSet<String
     }
 }
 
+pub(super) fn py_method_abi_output_count(method: &MethodMeta) -> usize {
+    method_abi_output_count(method)
+}
+
+pub(super) fn py_method_outputs(method: &MethodMeta) -> Vec<(usize, &TypeMeta)> {
+    let mut result_index = 0;
+    let mut outputs = Vec::new();
+
+    for param in &method.params {
+        match param.direction {
+            crate::meta::ParamDirection::Out => {
+                outputs.push((result_index, &param.typ));
+                result_index += 1;
+            }
+            crate::meta::ParamDirection::OutFill => {
+                // The runtime allocates a distinct filled result buffer; the
+                // caller-provided array supplies capacity and is not mutated.
+                outputs.push((result_index, &param.typ));
+                result_index += 1;
+            }
+            crate::meta::ParamDirection::In => {}
+        }
+    }
+
+    if let Some(return_type) = method
+        .return_type
+        .as_ref()
+        .filter(|_| !fill_array_uses_retval_count(method))
+    {
+        outputs.push((result_index, return_type));
+    }
+
+    outputs
+}
+
+fn py_output_type(
+    typ: &TypeMeta,
+    known_types: &HashSet<String>,
+    delegate_type_names: &HashSet<String>,
+) -> String {
+    match typ {
+        TypeMeta::Delegate { .. } => "'DynWinRTValue'".to_string(),
+        TypeMeta::Interface { name, .. } if delegate_type_names.contains(name) => {
+            "'DynWinRTValue'".to_string()
+        }
+        _ => py_return_type_safe(Some(typ), known_types),
+    }
+}
+
+pub(super) fn py_method_return_type(
+    method: &MethodMeta,
+    known_types: &HashSet<String>,
+    delegate_type_names: &HashSet<String>,
+) -> String {
+    let outputs = py_method_outputs(method);
+    match outputs.as_slice() {
+        [] => "None".to_string(),
+        [(_, typ)] => py_output_type(typ, known_types, delegate_type_names),
+        _ => format!(
+            "tuple[{}]",
+            outputs
+                .iter()
+                .map(|(_, typ)| py_output_type(typ, known_types, delegate_type_names))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
 fn py_return_type(typ: Option<&TypeMeta>) -> String {
     match typ {
         Some(TypeMeta::String) | Some(TypeMeta::Guid) => "str".to_string(),
@@ -184,4 +254,82 @@ pub(super) fn py_param_list(
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::meta::{ParamDirection, ParamMeta};
+
+    #[test]
+    fn multi_out_returns_typed_tuple_in_abi_order() {
+        let method = MethodMeta {
+            name: "IndexOf".into(),
+            params: vec![
+                ParamMeta {
+                    name: "value".into(),
+                    typ: TypeMeta::String,
+                    direction: ParamDirection::In,
+                },
+                ParamMeta {
+                    name: "index".into(),
+                    typ: TypeMeta::U32,
+                    direction: ParamDirection::Out,
+                },
+            ],
+            return_type: Some(TypeMeta::Bool),
+            ..Default::default()
+        };
+
+        assert_eq!(py_method_abi_output_count(&method), 2);
+        let outputs = py_method_outputs(&method);
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0], (0, &TypeMeta::U32));
+        assert_eq!(outputs[1], (1, &TypeMeta::Bool));
+        assert_eq!(
+            py_method_return_type(&method, &HashSet::new(), &HashSet::new()),
+            "tuple[int, bool]"
+        );
+    }
+
+    #[test]
+    fn fill_array_count_retval_is_not_registered_twice() {
+        let method = MethodMeta {
+            name: "GetMany".into(),
+            params: vec![
+                ParamMeta {
+                    name: "startIndex".into(),
+                    typ: TypeMeta::U32,
+                    direction: ParamDirection::In,
+                },
+                ParamMeta {
+                    name: "items".into(),
+                    typ: TypeMeta::Array(Box::new(TypeMeta::String)),
+                    direction: ParamDirection::OutFill,
+                },
+            ],
+            return_type: Some(TypeMeta::U32),
+            ..Default::default()
+        };
+
+        assert_eq!(py_method_abi_output_count(&method), 2);
+        let outputs = py_method_outputs(&method);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(
+            outputs[0],
+            (0, &TypeMeta::Array(Box::new(TypeMeta::String)))
+        );
+        assert_eq!(
+            py_method_return_type(&method, &HashSet::new(), &HashSet::new()),
+            "list[str]"
+        );
+        assert_eq!(
+            crate::codegen::python::signature::py_build_method_sig(&method),
+            "DynWinRTMethodSig().add_in(DynWinRTType.u32_type()).add_out_fill(DynWinRTType.array_type(DynWinRTType.hstring())).add_out(DynWinRTType.u32_type())"
+        );
+        assert_eq!(
+            crate::codegen::javascript::signature::build_method_sig(&method),
+            "new DynWinRtMethodSig().addIn(DynWinRtType.u32()).addOutFill(DynWinRtType.arrayType(DynWinRtType.hstring())).addOut(DynWinRtType.u32())"
+        );
+    }
 }

--- a/tools/dynwinrt-codegen/src/codegen/shared/imports.rs
+++ b/tools/dynwinrt-codegen/src/codegen/shared/imports.rs
@@ -182,3 +182,40 @@ pub(crate) fn get_in_params(method: &MethodMeta) -> Vec<&crate::meta::ParamMeta>
         .filter(|p| p.direction == ParamDirection::In || p.direction == ParamDirection::OutFill)
         .collect()
 }
+
+/// WinRT FillArray methods encode the number of filled items as a UInt32
+/// retval. The FillArray ABI already carries that value in its actual-count
+/// pointer, so it must not be registered as a second out parameter.
+pub(crate) fn fill_array_uses_retval_count(method: &MethodMeta) -> bool {
+    method
+        .params
+        .iter()
+        .any(|param| param.direction == ParamDirection::OutFill)
+        && matches!(method.return_type, Some(TypeMeta::U32))
+}
+
+pub(crate) fn method_abi_output_count(method: &MethodMeta) -> usize {
+    method
+        .params
+        .iter()
+        .filter(|param| {
+            matches!(
+                param.direction,
+                ParamDirection::Out | ParamDirection::OutFill
+            )
+        })
+        .count()
+        + usize::from(method.return_type.is_some())
+}
+
+pub(crate) fn fill_array_output_index(method: &MethodMeta) -> Option<usize> {
+    let mut result_index = 0;
+    for param in &method.params {
+        match param.direction {
+            ParamDirection::Out => result_index += 1,
+            ParamDirection::OutFill => return Some(result_index),
+            ParamDirection::In => {}
+        }
+    }
+    None
+}

--- a/tools/dynwinrt-codegen/tests/composable_factory_test.rs
+++ b/tools/dynwinrt-codegen/tests/composable_factory_test.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use dynwinrt_codegen::codegen::{project, render_dts, render_js};
+use dynwinrt_codegen::codegen::{project, python, python_stub, render_dts, render_js};
 use dynwinrt_codegen::meta::{
     ClassMeta, ConstructorKind, ConstructorMeta, InterfaceMeta, MethodMeta, ParamDirection,
     ParamMeta,
@@ -90,6 +90,25 @@ fn composable_factory_returns_public_instance() {
         dts.contains("static createInstance(outer: unknown): Widget;"),
         "factory declaration must return the runtime class:\n{dts}"
     );
+
+    let py = python::generate_class(
+        &class,
+        &HashSet::from(["Widget".into()]),
+        &HashSet::new(),
+        &HashSet::new(),
+    );
+    let pyi = python_stub::generate_class_stub(
+        &class,
+        &HashSet::from(["Widget".into()]),
+        &HashSet::new(),
+        &HashSet::new(),
+    );
+    assert!(
+        py.contains("_IWidgetFactory.method(6).invoke_all(")
+            && py.contains("return Widget(_results[1])"),
+        "Python composable factory must select the final public-instance output:\n{py}"
+    );
+    assert!(pyi.contains("def create_instance(outer: 'DynWinRTValue') -> 'Widget': ..."));
 
     let mut protected = class.clone();
     protected.constructors[0].kind = ConstructorKind::ProtectedComposition;

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_stringable.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_stringable.py
@@ -27,6 +27,11 @@ def _dynwinrt_enum(module, name, value):
         return value
 
 
+def _dynwinrt_wait_action(value):
+    value.wait()
+    return None
+
+
 IID_IStringable = WinGUID.parse('96369f54-8eb6-48f0-abce-c1b211e627c3')
 
 _IStringable = DynWinRTType.register_interface(

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_uri_runtime_class_with_absolute_canonical_uri.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/i_uri_runtime_class_with_absolute_canonical_uri.py
@@ -27,6 +27,11 @@ def _dynwinrt_enum(module, name, value):
         return value
 
 
+def _dynwinrt_wait_action(value):
+    value.wait()
+    return None
+
+
 IID_IUriRuntimeClassWithAbsoluteCanonicalUri = WinGUID.parse('758d9661-221c-480f-a339-50656673f46f')
 
 _IUriRuntimeClassWithAbsoluteCanonicalUri = DynWinRTType.register_interface(

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/uri.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/uri.py
@@ -27,6 +27,11 @@ def _dynwinrt_enum(module, name, value):
         return value
 
 
+def _dynwinrt_wait_action(value):
+    value.wait()
+    return None
+
+
 if TYPE_CHECKING:
     from .www_form_url_decoder import WwwFormUrlDecoder  # noqa: F401
 

--- a/tools/dynwinrt-codegen/tests/snapshots/uri_py/www_form_url_decoder.py
+++ b/tools/dynwinrt-codegen/tests/snapshots/uri_py/www_form_url_decoder.py
@@ -27,6 +27,11 @@ def _dynwinrt_enum(module, name, value):
         return value
 
 
+def _dynwinrt_wait_action(value):
+    value.wait()
+    return None
+
+
 IID_IWwwFormUrlDecoderRuntimeClass = WinGUID.parse('d45a0451-f225-4542-9296-0e1df5d254df')
 IID_IWwwFormUrlDecoderRuntimeClassFactory = WinGUID.parse('5b8c6b3d-24ae-41b5-a1bf-f0c3d544845b')
 


### PR DESCRIPTION
## Summary

Correct the WinRT FillArray ABI and project methods with multiple outputs consistently in Python and JavaScript.

This change:

- Models FillArray as `(capacity, mutable buffer)` without a synthetic count pointer
- Keeps the method’s normal `u32` retval as the actual filled-item count
- Tracks caller argument indexes separately from result indexes
- Preserves valid zero-item `GetMany` results
- Uses `invoke_all()` / `invokeAll()` for methods with multiple outputs
- Returns typed Python and TypeScript tuples in ABI output order
- Trims `GetMany` buffers using the returned item count
- Keeps composable factories returning only the public instance
- Preserves raw delegate outputs where no wrapper class exists
- Updates generated stubs, snapshots, checklist, and E2E coverage