### PR TITLE
 Project IReference values as native nullable types

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,9 +109,9 @@ These APIs are available on any Windows 10/11 machine without WinAppSDK:
 - Values: `DynWinRTValue.from_i32()`, `DynWinRTValue.from_hstring()`, `DynWinRTValue.from_bool()`
 - GUID: `WinGUID.parse('...')`
 - Method call: `method_handle.invoke(obj, [args])` → returns single `DynWinRTValue`
+- `IReference<T>` values project as native values plus `None`; generated `IReference_*` wrappers remain accepted for input compatibility
 
 ### Common Issues
 - `test_initialize` is `#[ignore]` — requires `WINAPPSDK_BOOTSTRAP_DLL_PATH` env var
 - Python `@property` must come before `@prop.setter` — codegen reorders methods for this
 - Windows SDK winmd is at `C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.26100.0\Windows.winmd`
-

--- a/PYTHON_CHECKLIST.md
+++ b/PYTHON_CHECKLIST.md
@@ -48,7 +48,8 @@ to a distributable, typed, and reliable WinRT projection.
       preserving unknown values as integers.
 - [x] Use `invoke_all()` for arbitrary multiple-out methods.
 - [x] Add Python E2E for `IVector.IndexOf` and other multiple-out methods.
-- [ ] Model nullable and `IReference<T>` positions as `T | None`.
+- [x] Project `IReference<T>` return positions as `T | None`.
+- [x] Accept `T | None` in `IReference<T>` input positions.
 - [x] Make Python stubs part of E2E and run a static type checker.
 - [x] Make `.pyi` generation the default for `--lang py`.
 
@@ -138,3 +139,5 @@ to a distributable, typed, and reliable WinRT projection.
 8. [x] Verify Python and JavaScript `IndexOf` and `GetMany`, including zero items.
 9. [x] Ship typed `dynwinrt_py` wheels and validate the native extension stubs.
 10. [x] Generate Python stubs by default and type-check generated E2E APIs.
+11. [x] Unbox `IReference<T>` returns as `T | None`.
+12. [x] Box native Python values and `None` for `IReference<T>` inputs.

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -46,6 +46,9 @@ Parameterized and composable activations support idiomatic forms such as
 `new Uri(base, relative)` and `new StackPanel()`. The generated static factory
 methods remain available for compatibility.
 
+Generated `IReference<T>` values use `T | null` in JavaScript. Native values,
+`null`, and generated `IReference_*` wrappers are accepted as inputs.
+
 Generated packages export `createProjectedLifetimeScope()`. WinUI/XAML hosts
 can create a scope after Application and Window setup, then dispose it before
 the native window and XAML core are destroyed. Projects that never create a

--- a/bindings/js/__test__/index.spec.ts
+++ b/bindings/js/__test__/index.spec.ts
@@ -62,6 +62,22 @@ test('round-trip WinRT values', (t) => {
   t.true(DynWinRtValue.nullValue().isNull())
 })
 
+test('box IReference values', (t) => {
+  const valueType = DynWinRtType.u32()
+  const referenceType = DynWinRtType.parameterized(
+    WinGuid.parse('61c17706-2d65-11e0-9ae8-d48564015472'),
+    [valueType],
+  )
+  const reference = DynWinRtType.registerInterface('IReference_UInt32_Test', referenceType.iid()).addMethod(
+    'get_Value',
+    new DynWinRtMethodSig().addOut(valueType),
+  )
+  const boxed = DynWinRtValue.boxReference(DynWinRtValue.u32(17), valueType)
+
+  t.is(reference.method(6).invoke(boxed, []).toNumber(), 17)
+  t.true(DynWinRtValue.boxReference(DynWinRtValue.nullValue(), valueType).isNull())
+})
+
 test('release WinRT object values deterministically', (t) => {
   const value = DynWinRtValue.activationFactory('Windows.Foundation.Uri')
   value.release()

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -624,6 +624,16 @@ impl DynWinRTValue {
     })
   }
 
+  #[napi]
+  pub fn box_reference(
+    value: &DynWinRTValue,
+    value_type: &DynWinRTType,
+  ) -> napi::Result<DynWinRTValue> {
+    dynwinrt::box_ireference(value.0.clone(), value_type.0.clone())
+      .map(DynWinRTValue)
+      .map_err(|e| napi::Error::from_reason(e.message()))
+  }
+
   /// Get the i32 value of an enum. Returns None if not an enum.
   #[napi]
   pub fn get_enum_int(&self) -> Option<i32> {

--- a/bindings/py/README.md
+++ b/bindings/py/README.md
@@ -10,3 +10,6 @@ Use `uv run pytest` to run the tests
 After modification `uv sync --reinstall` may be needed to reinstall the package
 
 The wheel includes `__init__.pyi` and `py.typed` for static type checking.
+
+Generated `IReference<T>` values are projected as `T | None`; native values,
+`None`, and generated `IReference_*` wrappers are accepted as inputs.

--- a/bindings/py/dynwinrt_py.pyi
+++ b/bindings/py/dynwinrt_py.pyi
@@ -163,6 +163,10 @@ class DynWinRTValue:
     @staticmethod
     def enum_value(enum_type: DynWinRTType, value: int) -> DynWinRTValue: ...
     @staticmethod
+    def box_reference(
+        value: DynWinRTValue, value_type: DynWinRTType
+    ) -> DynWinRTValue: ...
+    @staticmethod
     def create_vector(
         items: Sequence[DynWinRTValue], element_type: DynWinRTType
     ) -> DynWinRTValue: ...

--- a/bindings/py/src/runtime.rs
+++ b/bindings/py/src/runtime.rs
@@ -524,6 +524,13 @@ impl DynWinRTValue {
         })
     }
 
+    #[staticmethod]
+    fn box_reference(value: &DynWinRTValue, value_type: &DynWinRTType) -> PyResult<DynWinRTValue> {
+        dynwinrt::box_ireference(value.0.clone(), value_type.0.clone())
+            .map(DynWinRTValue)
+            .map_err(|e| PyRuntimeError::new_err(e.message()))
+    }
+
     /// Get the i32 value of an enum. Returns None if not an enum.
     fn get_enum_int(&self) -> Option<i32> {
         match &self.0 {

--- a/bindings/py/tests/test_basic.py
+++ b/bindings/py/tests/test_basic.py
@@ -38,6 +38,23 @@ def test_primitive_types():
     assert DynWinRTType.hresult() is not None
 
 
+def test_box_ireference_values():
+    value_type = DynWinRTType.u32_type()
+    reference_type = DynWinRTType.parameterized(
+        WinGUID.parse("61c17706-2d65-11e0-9ae8-d48564015472"),
+        [value_type],
+    )
+    reference = DynWinRTType.register_interface(
+        "IReference_UInt32_Test", reference_type.iid()
+    ).add_method("get_Value", DynWinRTMethodSig().add_out(value_type))
+    boxed = DynWinRTValue.box_reference(DynWinRTValue.from_u32(17), value_type)
+
+    assert reference.method(6).invoke(boxed, []).to_number() == 17
+    assert DynWinRTValue.box_reference(
+        DynWinRTValue.null_value(), value_type
+    ).is_null()
+
+
 def test_guid_parse():
     """WinGUID.parse should parse valid GUIDs."""
     guid = WinGUID.parse("9e365e57-48b2-4160-956f-c7385120bbfc")

--- a/crates/dynwinrt/src/lib.rs
+++ b/crates/dynwinrt/src/lib.rs
@@ -21,11 +21,13 @@ pub mod delegate;
 pub mod map;
 mod meta;
 pub mod metadata_table;
+mod reference;
 pub mod vector;
 
 pub use crate::array::ArrayData;
 pub use crate::dasync::{ProgressCallback, create_progress_handler};
 pub use crate::metadata_table::{MetadataTable, MethodHandle, TypeHandle, TypeKind, ValueTypeData};
+pub use crate::reference::box_ireference;
 pub use crate::result::{Error, Result};
 pub use crate::roapi::ro_get_activation_factory_2;
 pub use crate::signature::{InterfaceSignature, MethodSignature};

--- a/crates/dynwinrt/src/metadata_table/value_data.rs
+++ b/crates/dynwinrt/src/metadata_table/value_data.rs
@@ -142,6 +142,22 @@ impl ValueTypeData {
         self.ptr
     }
 
+    pub(crate) unsafe fn copy_to_abi(&self, result: *mut c_void) {
+        let layout = self.type_handle.layout();
+        if layout.size() == 0 {
+            return;
+        }
+
+        unsafe {
+            std::ptr::copy_nonoverlapping(self.ptr, result as *mut u8, layout.size());
+        }
+        if has_non_blittable_fields(&self.type_handle) {
+            unsafe {
+                duplicate_non_blittable_fields(&self.type_handle, result as *mut u8);
+            }
+        }
+    }
+
     pub fn get_field<T: Copy>(&self, index: usize) -> T {
         let h = &self.type_handle;
         let offset = h.field_offset(index);

--- a/crates/dynwinrt/src/reference.rs
+++ b/crates/dynwinrt/src/reference.rs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use core::ffi::c_void;
+
+use windows_core::{GUID, HRESULT, IUnknown, Interface};
+
+use crate::com_helpers::{E_FAIL, E_POINTER, IInspectableVtbl, S_OK};
+use crate::metadata_table::{IREFERENCE, TypeHandle, TypeKind};
+use crate::{Error, Result, WinRTValue};
+
+#[repr(C)]
+struct ReferenceVtbl {
+    base: IInspectableVtbl,
+    get_value: unsafe extern "system" fn(*mut c_void, *mut c_void) -> HRESULT,
+}
+
+#[repr(C)]
+struct DynamicReference {
+    vtable: *const ReferenceVtbl,
+    ref_count: windows_core::imp::RefCount,
+    iid: GUID,
+    value_type: TypeHandle,
+    value: WinRTValue,
+}
+
+unsafe impl Send for DynamicReference {}
+unsafe impl Sync for DynamicReference {}
+
+impl DynamicReference {
+    const VTBL: ReferenceVtbl = ReferenceVtbl {
+        base: IInspectableVtbl {
+            base: windows_core::IUnknown_Vtbl {
+                QueryInterface: Self::qi,
+                AddRef: Self::add_ref,
+                Release: Self::release,
+            },
+            get_iids: Self::get_iids_stub,
+            get_runtime_class_name: Self::get_runtime_class_name_stub,
+            get_trust_level: Self::get_trust_level_stub,
+        },
+        get_value: Self::get_value,
+    };
+
+    fn create(value: WinRTValue, value_type: TypeHandle, iid: GUID) -> IUnknown {
+        let reference = Box::new(Self {
+            vtable: &Self::VTBL,
+            ref_count: windows_core::imp::RefCount::new(1),
+            iid,
+            value_type,
+            value,
+        });
+        unsafe { IUnknown::from_raw(Box::into_raw(reference) as *mut c_void) }
+    }
+
+    single_vtable_com!(|me: &Self| me.iid);
+    inspectable_stubs!(stub);
+
+    unsafe extern "system" fn get_value(this: *mut c_void, result: *mut c_void) -> HRESULT {
+        if result.is_null() {
+            return E_POINTER;
+        }
+
+        let reference = &*(this as *const Self);
+        if write_abi_value(&reference.value_type, &reference.value, result) {
+            S_OK
+        } else {
+            E_FAIL
+        }
+    }
+}
+
+fn value_matches_type(value_type: &TypeHandle, value: &WinRTValue) -> bool {
+    match (value_type.kind(), value) {
+        (TypeKind::Bool, WinRTValue::Bool(_))
+        | (TypeKind::I8, WinRTValue::I8(_))
+        | (TypeKind::U8, WinRTValue::U8(_))
+        | (TypeKind::I16, WinRTValue::I16(_))
+        | (TypeKind::U16 | TypeKind::Char16, WinRTValue::U16(_))
+        | (TypeKind::I32, WinRTValue::I32(_))
+        | (TypeKind::U32, WinRTValue::U32(_))
+        | (TypeKind::I64, WinRTValue::I64(_))
+        | (TypeKind::U64, WinRTValue::U64(_))
+        | (TypeKind::F32, WinRTValue::F32(_))
+        | (TypeKind::F64, WinRTValue::F64(_))
+        | (TypeKind::Guid, WinRTValue::Guid(_))
+        | (TypeKind::HString, WinRTValue::HString(_))
+        | (TypeKind::HResult, WinRTValue::HResult(_))
+        | (TypeKind::HResult, WinRTValue::I32(_))
+        | (TypeKind::Enum(_), WinRTValue::I32(_)) => true,
+        (TypeKind::Enum(_), WinRTValue::Enum { type_handle, .. }) => type_handle == value_type,
+        (TypeKind::Struct(_), WinRTValue::Struct(data)) => data.type_handle() == value_type,
+        _ => false,
+    }
+}
+
+unsafe fn write_abi_value(
+    value_type: &TypeHandle,
+    value: &WinRTValue,
+    result: *mut c_void,
+) -> bool {
+    match (value_type.kind(), value) {
+        (TypeKind::Bool, WinRTValue::Bool(value)) => (result as *mut u8).write(u8::from(*value)),
+        (TypeKind::I8, WinRTValue::I8(value)) => (result as *mut i8).write(*value),
+        (TypeKind::U8, WinRTValue::U8(value)) => (result as *mut u8).write(*value),
+        (TypeKind::I16, WinRTValue::I16(value)) => (result as *mut i16).write(*value),
+        (TypeKind::U16 | TypeKind::Char16, WinRTValue::U16(value)) => {
+            (result as *mut u16).write(*value)
+        }
+        (TypeKind::I32, WinRTValue::I32(value)) | (TypeKind::Enum(_), WinRTValue::I32(value)) => {
+            (result as *mut i32).write(*value)
+        }
+        (TypeKind::Enum(_), WinRTValue::Enum { value, .. }) => (result as *mut i32).write(*value),
+        (TypeKind::U32, WinRTValue::U32(value)) => (result as *mut u32).write(*value),
+        (TypeKind::I64, WinRTValue::I64(value)) => (result as *mut i64).write(*value),
+        (TypeKind::U64, WinRTValue::U64(value)) => (result as *mut u64).write(*value),
+        (TypeKind::F32, WinRTValue::F32(value)) => (result as *mut f32).write(*value),
+        (TypeKind::F64, WinRTValue::F64(value)) => (result as *mut f64).write(*value),
+        (TypeKind::Guid, WinRTValue::Guid(value)) => (result as *mut GUID).write(*value),
+        (TypeKind::HResult, WinRTValue::HResult(value)) => (result as *mut HRESULT).write(*value),
+        (TypeKind::HResult, WinRTValue::I32(value)) => {
+            (result as *mut HRESULT).write(HRESULT(*value))
+        }
+        (TypeKind::HString, WinRTValue::HString(value)) => {
+            (result as *mut windows_core::HSTRING).write(value.clone())
+        }
+        (TypeKind::Struct(_), WinRTValue::Struct(data)) => data.copy_to_abi(result),
+        _ => return false,
+    }
+    true
+}
+
+/// Box a WinRT value as `IReference<T>`.
+///
+/// Null values and existing COM wrappers pass through unchanged.
+pub fn box_ireference(value: WinRTValue, value_type: TypeHandle) -> Result<WinRTValue> {
+    match value {
+        // Preserve null and legacy wrapper inputs; method invocation performs
+        // the final QueryInterface against the declared IReference<T>.
+        WinRTValue::Null | WinRTValue::Object(_) => return Ok(value),
+        _ => {}
+    }
+
+    if !value_matches_type(&value_type, &value) {
+        return Err(Error::InvalidType(value_type.kind(), value.get_type_kind()));
+    }
+
+    let table = value_type.table();
+    let generic = table.generic(IREFERENCE, 1);
+    let reference_type = table.parameterized(&generic, std::slice::from_ref(&value_type));
+    let iid = reference_type
+        .iid()
+        .ok_or_else(|| Error::TypeNotFound("Windows.Foundation.IReference<T>".into()))?;
+    Ok(WinRTValue::Object(DynamicReference::create(
+        value, value_type, iid,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use windows::Foundation::{IReference, Point, PropertyType};
+    use windows_core::HSTRING;
+
+    use super::*;
+    use crate::{MetadataTable, MethodSignature};
+
+    #[test]
+    fn boxes_primitive_and_string_values() {
+        let table = MetadataTable::new();
+
+        let value = box_ireference(WinRTValue::U32(17), table.u32_type()).unwrap();
+        let reference: IReference<u32> = value.as_object().unwrap().cast().unwrap();
+        assert_eq!(reference.Value().unwrap(), 17);
+
+        let value =
+            box_ireference(WinRTValue::HString(HSTRING::from("hello")), table.hstring()).unwrap();
+        let reference: IReference<HSTRING> = value.as_object().unwrap().cast().unwrap();
+        assert_eq!(reference.Value().unwrap(), "hello");
+    }
+
+    #[test]
+    fn boxes_enum_and_struct_values() {
+        let table = MetadataTable::new();
+        let enum_type = table.enum_type(
+            "Windows.Foundation.PropertyType",
+            vec![("UInt8".into(), PropertyType::UInt8.0)],
+        );
+        let value = box_ireference(
+            WinRTValue::Enum {
+                value: PropertyType::UInt8.0,
+                type_handle: enum_type.clone(),
+            },
+            enum_type,
+        )
+        .unwrap();
+        let reference: IReference<PropertyType> = value.as_object().unwrap().cast().unwrap();
+        assert_eq!(reference.Value().unwrap(), PropertyType::UInt8);
+
+        let struct_type = table.struct_type(
+            "Windows.Foundation.Point",
+            &[table.f32_type(), table.f32_type()],
+        );
+        let mut data = struct_type.default_value();
+        data.set_field(0, 1.5f32);
+        data.set_field(1, 2.5f32);
+        let value = box_ireference(WinRTValue::Struct(data), struct_type.clone()).unwrap();
+        let reference: IReference<Point> = value.as_object().unwrap().cast().unwrap();
+        assert_eq!(reference.Value().unwrap(), Point { X: 1.5, Y: 2.5 });
+    }
+
+    #[test]
+    fn copies_non_blittable_struct_values_for_the_caller() {
+        let table = MetadataTable::new();
+        let struct_type = table.struct_type("Test.StringStruct", &[table.hstring()]);
+        let mut data = struct_type.default_value();
+        let raw: *mut c_void = unsafe { std::mem::transmute(HSTRING::from("owned by caller")) };
+        unsafe {
+            (data.as_mut_ptr().add(struct_type.field_offset(0)) as *mut *mut c_void).write(raw);
+        }
+
+        let boxed = box_ireference(WinRTValue::Struct(data), struct_type.clone()).unwrap();
+        let generic = table.generic(IREFERENCE, 1);
+        let reference_type = table.parameterized(&generic, std::slice::from_ref(&struct_type));
+        let interface = table
+            .register_interface(
+                "IReference_StringStruct_Test",
+                reference_type.iid().unwrap(),
+            )
+            .add_method(
+                "get_Value",
+                MethodSignature::new(&table).add_out(struct_type.clone()),
+            );
+        let raw = boxed.as_object().unwrap().as_raw();
+        let result = interface.method(6).unwrap().invoke(raw, &[]).unwrap();
+        drop(boxed);
+
+        let result = result[0].as_struct().unwrap();
+        let raw: *mut c_void = result.get_field(0);
+        let value: &HSTRING = unsafe { &*(&raw as *const *mut c_void as *const HSTRING) };
+        assert_eq!(value, "owned by caller");
+    }
+
+    #[test]
+    fn preserves_null_and_existing_reference_values() {
+        let table = MetadataTable::new();
+        assert!(matches!(
+            box_ireference(WinRTValue::Null, table.u32_type()).unwrap(),
+            WinRTValue::Null
+        ));
+
+        let existing = windows::Foundation::PropertyValue::CreateUInt32(42)
+            .unwrap()
+            .cast::<IUnknown>()
+            .unwrap();
+        let boxed = box_ireference(WinRTValue::Object(existing), table.u32_type()).unwrap();
+        let reference: IReference<u32> = boxed.as_object().unwrap().cast().unwrap();
+        assert_eq!(reference.Value().unwrap(), 42);
+    }
+
+    #[test]
+    fn rejects_mismatched_value_types() {
+        let table = MetadataTable::new();
+        let error = box_ireference(WinRTValue::I32(1), table.u32_type()).unwrap_err();
+        assert!(matches!(
+            error,
+            Error::InvalidType(TypeKind::U32, TypeKind::I32)
+        ));
+    }
+}

--- a/tests/e2e_specs.json
+++ b/tests/e2e_specs.json
@@ -382,6 +382,27 @@
       ]
     },
     {
+      "id": "contact_date_nullable_values",
+      "namespace": "Windows.ApplicationModel.Contacts",
+      "class": "ContactDate",
+      "langs": ["py", "ts"],
+      "instantiate": { "kind": "activate" },
+      "checks": [
+        { "kind": "property_equals", "member": "day", "expected": null },
+        { "kind": "property_equals", "member": "month", "expected": null },
+        { "kind": "property_equals", "member": "year", "expected": null },
+        {
+          "kind": "ireference_roundtrip",
+          "member": "day",
+          "factory": "create_u_int32",
+          "reference_module": "i_reference_u_int32",
+          "reference_class": "IReference_UInt32",
+          "value": 17,
+          "compatibility_value": 23
+        }
+      ]
+    },
+    {
       "id": "vector_index_of_found",
       "namespace": "Windows.Globalization",
       "class": "Calendar",

--- a/tests/e2e_specs.schema.json
+++ b/tests/e2e_specs.schema.json
@@ -69,6 +69,7 @@
              "vector_view_access",
              "vector_index_of",
              "vector_get_many",
+             "ireference_roundtrip",
              "event_callback",
              "method_then_property_equals"
            ]
@@ -112,6 +113,11 @@
          "expected_index": { "type": "integer", "description": "Expected indexOf result (-1 if not found)" },
          "capacity": { "type": "integer", "description": "FillArray capacity used by vector_get_many" },
          "at_end": { "type": "boolean", "description": "Start vector_get_many at Size and expect no items" },
+         "factory": { "type": "string", "description": "PropertyValue factory used by ireference_roundtrip" },
+         "reference_module": { "type": "string", "description": "Generated IReference module used by ireference_roundtrip" },
+         "reference_class": { "type": "string", "description": "Generated IReference class used by ireference_roundtrip" },
+         "value": { "description": "Value used by ireference_roundtrip" },
+         "compatibility_value": { "description": "Value used to verify legacy wrapper compatibility" },
          "event_name": { "type": "string", "description": "Event name for event_callback (PascalCase, e.g. Closed)" },
          "trigger": { "type": "string", "description": "Method to call to trigger the event (snake_case)" },
          "property_path": {

--- a/tests/runners/py_runner.py
+++ b/tests/runners/py_runner.py
@@ -293,6 +293,42 @@ def run_check(check: dict, cls, obj, generated_dir: str, pkg_name: str) -> dict:
             else:
                 cr['pass'] = True
 
+        elif kind == 'ireference_roundtrip':
+            setattr(obj, member, check['value'])
+            actual = getattr(obj, member)
+            if actual != check['value']:
+                cr['error'] = (
+                    f'native IReference roundtrip returned {actual!r}, '
+                    f'expected {check["value"]!r}'
+                )
+                return cr
+
+            setattr(obj, member, None)
+            if getattr(obj, member) is not None:
+                cr['error'] = 'setting nullable value to None did not clear it'
+                return cr
+
+            property_value_mod = importlib.import_module(f"{pkg_name}.property_value")
+            property_value_cls = getattr(property_value_mod, 'PropertyValue')
+            factory = getattr(property_value_cls, check['factory'])
+            boxed = factory(check['compatibility_value'])
+
+            reference_mod = importlib.import_module(
+                f"{pkg_name}.{check['reference_module']}"
+            )
+            reference_cls = getattr(reference_mod, check['reference_class'])
+            reference = reference_cls.from_value(getattr(boxed, '_obj', boxed))
+
+            setattr(obj, member, reference)
+            actual = getattr(obj, member)
+            if actual != check['compatibility_value']:
+                cr['error'] = (
+                    f'wrapper IReference roundtrip returned {actual!r}, '
+                    f'expected {check["compatibility_value"]!r}'
+                )
+            else:
+                cr['pass'] = True
+
         elif kind == 'struct_roundtrip':
             struct_mod = importlib.import_module(f"{pkg_name}.{check['struct_module']}")
             struct_cls = getattr(struct_mod, check['struct_class'])

--- a/tests/runners/ts_runner.ts
+++ b/tests/runners/ts_runner.ts
@@ -304,6 +304,39 @@ async function runCheck(
       } else {
         cr.pass = true;
       }
+    } else if (kind === 'ireference_roundtrip') {
+      const value = (check as any).value;
+      obj[member] = value;
+      if (obj[member] !== value) {
+        cr.error = `native IReference roundtrip returned ${obj[member]}, expected ${value}`;
+        return cr;
+      }
+
+      obj[member] = null;
+      if (obj[member] !== null) {
+        cr.error = 'setting nullable value to null did not clear it';
+        return cr;
+      }
+
+      const propertyValueMod = await import(
+        `file://${path.resolve(generatedDir, 'PropertyValue.js').replace(/\\/g, '/')}`
+      );
+      const referenceModule = (check as any).reference_class;
+      const referenceMod = await import(
+        `file://${path.resolve(generatedDir, `${referenceModule}.js`).replace(/\\/g, '/')}`
+      );
+      const factory =
+        propertyValueMod.PropertyValue[
+          (check as any).factory.replace(/_([a-z])/g, (_: string, c: string) => c.toUpperCase())
+        ];
+      const boxed = factory((check as any).compatibility_value);
+      const referenceClass = referenceMod[(check as any).reference_class];
+      obj[member] = referenceClass.from(boxed);
+      if (obj[member] !== (check as any).compatibility_value) {
+        cr.error = `wrapper IReference roundtrip returned ${obj[member]}, expected ${(check as any).compatibility_value}`;
+      } else {
+        cr.pass = true;
+      }
     } else if (kind === 'struct_roundtrip') {
       const structClass = check.struct_class as string;
       const structModule = check.struct_module as string;

--- a/tests/typecheck/python_generated_api.py
+++ b/tests/typecheck/python_generated_api.py
@@ -11,6 +11,8 @@ from dynwinrt_py import (
     WinGUID,
 )
 from python_bindings.calendar import Calendar
+from python_bindings.contact_date import ContactDate
+from python_bindings.i_reference_u_int32 import IReference_UInt32
 from python_bindings.i_vector_view_string import IVectorView_String
 from python_bindings.i_www_form_url_decoder_entry import IWwwFormUrlDecoderEntry
 from python_bindings.uri import Uri
@@ -36,6 +38,18 @@ def check_uri() -> None:
     host: str = uri.host
     combined: Uri = uri.combine_uri("child")
     _: Tuple[str, Uri] = (host, combined)
+
+
+def check_nullable_value(
+    contact_date: ContactDate, legacy_day: IReference_UInt32
+) -> None:
+    day: int | None = contact_date.day
+    month: int | None = contact_date.month
+    year: int | None = contact_date.year
+    _: Tuple[int | None, int | None, int | None] = (day, month, year)
+    contact_date.day = 17
+    contact_date.day = None
+    contact_date.day = legacy_day
 
 
 def check_string_vector(calendar: Calendar) -> None:

--- a/tools/dynwinrt-codegen/src/codegen/common.rs
+++ b/tools/dynwinrt-codegen/src/codegen/common.rs
@@ -224,6 +224,46 @@ mod tests {
     }
 
     #[test]
+    fn wraps_javascript_ireference_inputs() {
+        let reference = |inner| TypeMeta::Parameterized {
+            namespace: "Windows.Foundation".into(),
+            name: "IReference".into(),
+            piid: "61c17706-2d65-11e0-9ae8-d48564015472".into(),
+            args: vec![inner],
+        };
+
+        assert!(
+            wrap_arg("value", &reference(TypeMeta::String))
+                .contains("boxReference(DynWinRtValue.hstring(value), DynWinRtType.hstring())")
+        );
+        assert!(
+            wrap_arg(
+                "value",
+                &reference(TypeMeta::Struct {
+                    namespace: "Windows.Foundation".into(),
+                    name: "Point".into(),
+                    fields: vec![],
+                })
+            )
+            .contains("_packPoint(value).toValue()")
+        );
+        assert!(
+            wrap_arg(
+                "value",
+                &reference(TypeMeta::Enum {
+                    namespace: "Test".into(),
+                    name: "Kind".into(),
+                    underlying: Box::new(TypeMeta::I32),
+                    members: vec![],
+                    doc: None,
+                    deprecated: None,
+                })
+            )
+            .contains("DynWinRtValue.enumValue(")
+        );
+    }
+
+    #[test]
     fn convert_return_basic() {
         let known = HashSet::new();
         let deferred = HashSet::new();
@@ -440,6 +480,46 @@ mod tests {
         assert_eq!(
             py_wrap_arg("f", &TypeMeta::F64),
             "DynWinRTValue.from_f64(f)"
+        );
+    }
+
+    #[test]
+    fn wraps_python_ireference_inputs() {
+        let reference = |inner| TypeMeta::Parameterized {
+            namespace: "Windows.Foundation".into(),
+            name: "IReference".into(),
+            piid: "61c17706-2d65-11e0-9ae8-d48564015472".into(),
+            args: vec![inner],
+        };
+
+        assert!(
+            py_wrap_arg("value", &reference(TypeMeta::String))
+                .contains("lambda value: DynWinRTValue.from_hstring(value)")
+        );
+        assert!(
+            py_wrap_arg(
+                "value",
+                &reference(TypeMeta::Struct {
+                    namespace: "Windows.Foundation".into(),
+                    name: "Point".into(),
+                    fields: vec![],
+                })
+            )
+            .contains("lambda value: _pack_point(value).to_value()")
+        );
+        assert!(
+            py_wrap_arg(
+                "value",
+                &reference(TypeMeta::Enum {
+                    namespace: "Test".into(),
+                    name: "Kind".into(),
+                    underlying: Box::new(TypeMeta::I32),
+                    members: vec![],
+                    doc: None,
+                    deprecated: None,
+                })
+            )
+            .contains("lambda value: DynWinRTValue.enum_value(")
         );
     }
 

--- a/tools/dynwinrt-codegen/src/codegen/javascript/ir.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/ir.rs
@@ -90,6 +90,7 @@ pub struct ProjectedConstructor {
 pub struct ProjectedProperty {
     pub name: String,
     pub ts_type: String,
+    pub setter_ts_type: Option<String>,
     pub readonly: bool,
     pub is_static: bool,
     pub doc: Option<DocInfo>,

--- a/tools/dynwinrt-codegen/src/codegen/javascript/method.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/method.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashSet;
 
+use crate::codegen::shared::imports::ireference_inner_type;
 use crate::types::TypeMeta;
 
 // ======================================================================
@@ -39,6 +40,17 @@ fn ts_param_type(typ: &TypeMeta) -> String {
 }
 
 pub(crate) fn ts_param_type_safe(typ: &TypeMeta, known: &HashSet<String>) -> String {
+    if let Some(inner) = ireference_inner_type(typ) {
+        let native = ts_return_type_safe(Some(inner), false, known);
+        let wrapper = match typ {
+            TypeMeta::Parameterized { name, args, .. } => {
+                crate::meta::make_parameterized_name(name, args)
+            }
+            _ => unreachable!(),
+        };
+        return format!("{} | null | {}", native, wrapper);
+    }
+
     match typ {
         TypeMeta::RuntimeClass { name, .. }
         | TypeMeta::Enum { name, .. }
@@ -116,6 +128,15 @@ pub(crate) fn ts_return_type_safe(
     is_async: bool,
     known: &HashSet<String>,
 ) -> String {
+    if let Some(inner) = typ.and_then(ireference_inner_type) {
+        let native = format!("{} | null", ts_return_type_safe(Some(inner), false, known));
+        return if is_async {
+            format!("Promise<{}>", native)
+        } else {
+            native
+        };
+    }
+
     match typ {
         Some(TypeMeta::RuntimeClass { name, .. })
         | Some(TypeMeta::Enum { name, .. })

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/methods.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/methods.rs
@@ -253,6 +253,7 @@ pub(super) fn project_static_method(
         return ProjectedMember::Property(ProjectedProperty {
             name: prop_name,
             ts_type: ts_return,
+            setter_ts_type: None,
             readonly: true,
             is_static: true,
             doc,
@@ -492,11 +493,17 @@ pub(super) fn project_instance_method(
         };
 
         // Check if there's a corresponding setter
-        let setter_line = find_setter_for_property(method, iface_var, obj_expr, iface_methods);
+        let setter =
+            find_setter_for_property(method, iface_var, obj_expr, iface_methods, known_types);
+        let (setter_line, setter_ts_type) = match setter {
+            Some((line, ts_type)) => (Some(line), ts_type),
+            None => (None, None),
+        };
 
         return Some(ProjectedMember::Property(ProjectedProperty {
             name: prop_name,
             ts_type: ts_return,
+            setter_ts_type,
             readonly: setter_line.is_none(),
             is_static: false,
             doc,
@@ -545,7 +552,8 @@ pub(super) fn project_instance_method(
 
         return Some(ProjectedMember::Property(ProjectedProperty {
             name: prop_name,
-            ts_type: param_type,
+            ts_type: param_type.clone(),
+            setter_ts_type: Some(param_type),
             readonly: false,
             is_static: false,
             doc,
@@ -840,7 +848,8 @@ fn find_setter_for_property(
     iface_var: &str,
     obj_expr: &str,
     iface_methods: Option<&[MethodMeta]>,
-) -> Option<String> {
+    known_types: &HashSet<String>,
+) -> Option<(String, Option<String>)> {
     let prop_suffix = getter.name.strip_prefix("get_")?;
     let setter_name = format!("put_{}", prop_suffix);
     let methods = iface_methods?;
@@ -848,13 +857,21 @@ fn find_setter_for_property(
         .iter()
         .find(|m| m.name == setter_name && m.is_property_setter)?;
     let setter_in_params = get_in_params(setter);
+    let setter_ts_type = setter_in_params.first().and_then(|param| {
+        ireference_inner_type(&param.typ)
+            .is_some()
+            .then(|| ts_param_type_safe(&param.typ, known_types))
+    });
     let arg = setter_in_params
         .first()
         .map(|p| wrap_arg("value", &p.typ))
         .unwrap_or_else(|| "value".to_string());
-    Some(format!(
-        "{}.method({}).invoke({}, [{}]);",
-        iface_var, setter.vtable_index, obj_expr, arg
+    Some((
+        format!(
+            "{}.method({}).invoke({}, [{}]);",
+            iface_var, setter.vtable_index, obj_expr, arg
+        ),
+        setter_ts_type,
     ))
 }
 

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
@@ -35,7 +35,7 @@ pub fn get_import_name() -> String {
 use crate::codegen::shared::imports::{
     NO_DEFERRED, collect_iface_type_imports, collect_type_imports,
     collect_used_generics_from_class, collect_used_generics_from_methods, fill_array_output_index,
-    fill_array_uses_retval_count, get_in_params, method_abi_output_count,
+    fill_array_uses_retval_count, get_in_params, ireference_inner_type, method_abi_output_count,
 };
 use crate::codegen::shared::structs::{
     collect_used_structs_from_class, collect_used_structs_from_iface,

--- a/tools/dynwinrt-codegen/src/codegen/javascript/render/declarations.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/render/declarations.rs
@@ -404,9 +404,10 @@ fn render_member_dts(out: &mut String, member: &ProjectedMember) {
                 ));
             }
             if prop.setter_line.is_some() {
+                let setter_type = prop.setter_ts_type.as_ref().unwrap_or(&prop.ts_type);
                 out.push_str(&format!(
                     "    {}set {}(value: {});\n",
-                    static_kw, prop.name, prop.ts_type
+                    static_kw, prop.name, setter_type
                 ));
             }
         }

--- a/tools/dynwinrt-codegen/src/codegen/javascript/signature.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/signature.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashSet;
 
+use crate::codegen::shared::imports::ireference_inner_type;
 use crate::meta::{InterfaceMeta, MethodMeta, ParamDirection};
 use crate::types::TypeMeta;
 
@@ -210,6 +211,15 @@ pub(crate) fn build_args_expr(in_params: &[&crate::meta::ParamMeta]) -> String {
 }
 
 pub(crate) fn wrap_arg(name: &str, typ: &TypeMeta) -> String {
+    if let Some(inner) = ireference_inner_type(typ) {
+        let value_type = ts_dynwinrt_type(inner);
+        let wrapped = wrap_reference_value("value", inner);
+        return format!(
+            "((value) => value == null ? DynWinRtValue.nullValue() : value instanceof DynWinRtValue ? value : value?._obj ?? DynWinRtValue.boxReference({}, {}))({})",
+            wrapped, value_type, name
+        );
+    }
+
     match typ {
         TypeMeta::String => format!("DynWinRtValue.hstring({})", name),
         TypeMeta::Bool => format!("DynWinRtValue.boolValue({})", name),
@@ -257,6 +267,7 @@ pub(crate) fn wrap_arg(name: &str, typ: &TypeMeta) -> String {
                     );
                 }
             }
+
             // For map-like collections, auto-wrap JS Map at runtime.
             // Same vtable-mismatch concern as vectors: createMap returns a
             // SingleThreadedMap whose identity vtable is IIterable
@@ -324,6 +335,36 @@ pub(crate) fn wrap_arg(name: &str, typ: &TypeMeta) -> String {
             format!("_pack{}({}).toValue()", struct_name, name)
         }
         _ => name.to_string(),
+    }
+}
+
+fn wrap_reference_value(name: &str, typ: &TypeMeta) -> String {
+    match typ {
+        TypeMeta::Bool => format!("DynWinRtValue.boolValue({})", name),
+        TypeMeta::I8 => format!("DynWinRtValue.i8Value({})", name),
+        TypeMeta::U8 => format!("DynWinRtValue.u8Value({})", name),
+        TypeMeta::I16 => format!("DynWinRtValue.i16({})", name),
+        TypeMeta::U16 | TypeMeta::Char16 => format!("DynWinRtValue.u16({})", name),
+        TypeMeta::I32 => format!("DynWinRtValue.i32({})", name),
+        TypeMeta::U32 => format!("DynWinRtValue.u32({})", name),
+        TypeMeta::I64 => format!("DynWinRtValue.i64({})", name),
+        TypeMeta::U64 => format!("DynWinRtValue.u64({})", name),
+        TypeMeta::F32 => format!("DynWinRtValue.f32({})", name),
+        TypeMeta::F64 => format!("DynWinRtValue.f64({})", name),
+        TypeMeta::String => format!("DynWinRtValue.hstring({})", name),
+        TypeMeta::Guid => format!("DynWinRtValue.guid(WinGuid.parse({}))", name),
+        TypeMeta::Enum { .. } => format!(
+            "DynWinRtValue.enumValue({}, {})",
+            ts_dynwinrt_type(typ),
+            name
+        ),
+        TypeMeta::Struct {
+            name: struct_name, ..
+        } if struct_name == "HResult" => format!("DynWinRtValue.i32({})", name),
+        TypeMeta::Struct {
+            name: struct_name, ..
+        } => format!("_pack{}({}).toValue()", struct_name, name),
+        _ => panic!("unsupported IReference inner type: {:?}", typ),
     }
 }
 
@@ -413,6 +454,13 @@ fn wrap_nullable_interface_return(expr: &str, wrapper: &str) -> String {
 
 fn unwrap_nullable_return(expr: &str) -> String {
     format!("((v) => v.isNull() ? null : v)({})", expr)
+}
+
+fn unwrap_nullable_reference_return(expr: &str, wrapper: &str) -> String {
+    format!(
+        "((v) => v.isNull() ? null : new {}(v).value)({})",
+        wrapper, expr
+    )
 }
 
 /// Convert an array return expression to the appropriate JS array type.
@@ -511,6 +559,13 @@ pub(crate) fn convert_return(
         Some(TypeMeta::F32 | TypeMeta::F64) => format!("{}.toF64()", expr),
         Some(TypeMeta::Bool) => format!("{}.toBool()", expr),
         Some(TypeMeta::Enum { .. }) => format!("{}.toNumber()", expr),
+        Some(typ @ TypeMeta::Parameterized { name, args, .. })
+            if ireference_inner_type(typ).is_some() =>
+        {
+            let concrete = crate::meta::make_parameterized_name(name, args);
+            let wrapper = resolve_type_name(&concrete, deferred);
+            unwrap_nullable_reference_return(expr, &wrapper)
+        }
         Some(TypeMeta::RuntimeClass { name, .. }) if known_types.contains(name) => {
             let r = resolve_type_name(name, deferred);
             wrap_nullable_class_return(expr, &r)

--- a/tools/dynwinrt-codegen/src/codegen/python/generator/class.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/generator/class.rs
@@ -22,6 +22,13 @@ pub fn generate_class(
     out.push_str(HEADER);
     out.push_str(FUTURE_ANNOTATIONS);
     out.push_str(IMPORT_LINE);
+    if has_ireference_input(
+        class
+            .all_interfaces()
+            .flat_map(|interface| interface.methods.iter()),
+    ) {
+        out.push_str(IREFERENCE_HELPER);
+    }
     out.push('\n');
     let mut type_checking_imports = Vec::new();
 

--- a/tools/dynwinrt-codegen/src/codegen/python/generator/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/generator/mod.rs
@@ -9,12 +9,12 @@ mod types;
 
 use std::collections::HashSet;
 
-use crate::meta::{ClassMeta, InterfaceMeta, ParamDirection};
+use crate::meta::{ClassMeta, InterfaceMeta, MethodMeta, ParamDirection};
 use crate::types::{TypeKind, TypeMeta};
 
 use crate::codegen::shared::imports::{
     collect_iface_type_imports, collect_type_imports, collect_used_generics_from_class,
-    collect_used_generics_from_methods,
+    collect_used_generics_from_methods, ireference_inner_type,
 };
 use crate::codegen::shared::structs::{
     collect_used_structs_from_class, collect_used_structs_from_iface,
@@ -64,6 +64,26 @@ def _dynwinrt_wait_action(value):
     value.wait()
     return None
 \n";
+
+const IREFERENCE_HELPER: &str = "\
+def _dynwinrt_box_reference(value, value_type, wrap):
+    raw = getattr(value, '_obj', value)
+    if isinstance(raw, DynWinRTValue):
+        return raw
+    if raw is None:
+        return DynWinRTValue.null_value()
+    return DynWinRTValue.box_reference(wrap(raw), value_type)
+
+
+";
+
+fn has_ireference_input<'a>(methods: impl IntoIterator<Item = &'a MethodMeta>) -> bool {
+    methods.into_iter().any(|method| {
+        method.params.iter().any(|param| {
+            param.direction == ParamDirection::In && ireference_inner_type(&param.typ).is_some()
+        })
+    })
+}
 
 pub use class::generate_class;
 pub use index::{append_to_index, generate_index};

--- a/tools/dynwinrt-codegen/src/codegen/python/generator/types.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/generator/types.rs
@@ -80,6 +80,9 @@ pub fn generate_interface(
     out.push_str(HEADER);
     out.push_str(FUTURE_ANNOTATIONS);
     out.push_str(IMPORT_LINE);
+    if has_ireference_input(iface.methods.iter()) {
+        out.push_str(IREFERENCE_HELPER);
+    }
     out.push('\n');
     let mut type_checking_imports = Vec::new();
 

--- a/tools/dynwinrt-codegen/src/codegen/python/signature.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/signature.rs
@@ -9,6 +9,7 @@ use crate::meta::{InterfaceMeta, MethodMeta, ParamDirection};
 use crate::types::TypeMeta;
 
 use super::naming::{to_snake_case, to_snake_case_filename};
+use crate::codegen::shared::imports::ireference_inner_type;
 
 pub(crate) fn py_runtime_symbol(type_name: &str, symbol_name: &str) -> String {
     format!(
@@ -192,6 +193,15 @@ pub(crate) fn py_build_method_sig(method: &MethodMeta) -> String {
 
 /// Wrap a Python variable name into a DynWinRTValue expression.
 pub(crate) fn py_wrap_arg(name: &str, typ: &TypeMeta) -> String {
+    if let Some(inner) = ireference_inner_type(typ) {
+        let value_type = py_dynwinrt_type(inner);
+        let wrapped = py_wrap_reference_value("value", inner);
+        return format!(
+            "_dynwinrt_box_reference({}, {}, lambda value: {})",
+            name, value_type, wrapped
+        );
+    }
+
     match typ {
         TypeMeta::String => format!("DynWinRTValue.from_hstring({})", name),
         TypeMeta::Bool => format!("DynWinRTValue.from_bool({})", name),
@@ -228,6 +238,38 @@ pub(crate) fn py_wrap_arg(name: &str, typ: &TypeMeta) -> String {
             format!("_pack_{}({}).to_value()", to_snake_case(struct_name), name)
         }
         _ => name.to_string(),
+    }
+}
+
+fn py_wrap_reference_value(name: &str, typ: &TypeMeta) -> String {
+    match typ {
+        TypeMeta::Bool => format!("DynWinRTValue.from_bool({})", name),
+        TypeMeta::I8 => format!("DynWinRTValue.from_i8({})", name),
+        TypeMeta::U8 => format!("DynWinRTValue.from_u8({})", name),
+        TypeMeta::I16 => format!("DynWinRTValue.from_i16({})", name),
+        TypeMeta::U16 | TypeMeta::Char16 => format!("DynWinRTValue.from_u16({})", name),
+        TypeMeta::I32 => format!("DynWinRTValue.from_i32({})", name),
+        TypeMeta::U32 => format!("DynWinRTValue.from_u32({})", name),
+        TypeMeta::I64 => format!("DynWinRTValue.from_i64({})", name),
+        TypeMeta::U64 => format!("DynWinRTValue.from_u64({})", name),
+        TypeMeta::F32 => format!("DynWinRTValue.from_f32({})", name),
+        TypeMeta::F64 => format!("DynWinRTValue.from_f64({})", name),
+        TypeMeta::String => format!("DynWinRTValue.from_hstring({})", name),
+        TypeMeta::Guid => format!("DynWinRTValue.from_guid(WinGUID.parse({}))", name),
+        TypeMeta::Enum { .. } => format!(
+            "DynWinRTValue.enum_value({}, {})",
+            py_dynwinrt_type(typ),
+            name
+        ),
+        TypeMeta::Struct {
+            name: struct_name, ..
+        } if struct_name == "HResult" => {
+            format!("DynWinRTValue.from_i32({})", name)
+        }
+        TypeMeta::Struct {
+            name: struct_name, ..
+        } => format!("_pack_{}({}).to_value()", to_snake_case(struct_name), name),
+        _ => panic!("unsupported IReference inner type: {:?}", typ),
     }
 }
 
@@ -279,6 +321,16 @@ pub(crate) fn py_convert_return(
             )
         }
         Some(TypeMeta::Enum { .. }) => format!("{}.to_number()", expr),
+        Some(typ @ TypeMeta::Parameterized { name, args, .. })
+            if ireference_inner_type(typ).is_some() =>
+        {
+            let concrete = crate::meta::make_parameterized_name(name, args);
+            let wrapper = py_runtime_symbol(&concrete, &concrete);
+            format!(
+                "(lambda value: None if value.is_null() else {}(value).value)({})",
+                wrapper, expr
+            )
+        }
         Some(TypeMeta::RuntimeClass { name, .. }) if known_types.contains(name) => {
             format!("{}({})", py_runtime_symbol(name, name), expr)
         }

--- a/tools/dynwinrt-codegen/src/codegen/python/type_helpers.rs
+++ b/tools/dynwinrt-codegen/src/codegen/python/type_helpers.rs
@@ -6,7 +6,9 @@
 use std::collections::HashSet;
 
 use crate::codegen::shared::docs::{DocText, find_param_doc};
-use crate::codegen::shared::imports::{fill_array_uses_retval_count, method_abi_output_count};
+use crate::codegen::shared::imports::{
+    fill_array_uses_retval_count, ireference_inner_type, method_abi_output_count,
+};
 use crate::meta::MethodMeta;
 use crate::types::TypeMeta;
 
@@ -46,6 +48,14 @@ pub(super) fn method_pydoc(method: &MethodMeta, in_params: &[&crate::meta::Param
 // Python type annotation helpers
 // ======================================================================
 
+fn py_optional_type(typ: String) -> String {
+    let unquoted = typ
+        .strip_prefix('\'')
+        .and_then(|value| value.strip_suffix('\''))
+        .unwrap_or(&typ);
+    format!("{} | None", unquoted)
+}
+
 fn py_param_type(typ: &TypeMeta) -> String {
     match typ {
         TypeMeta::Bool => "bool".to_string(),
@@ -75,6 +85,17 @@ fn py_param_type(typ: &TypeMeta) -> String {
 }
 
 pub(super) fn py_param_type_safe(typ: &TypeMeta, known: &HashSet<String>) -> String {
+    if let Some(inner) = ireference_inner_type(typ) {
+        let native = py_optional_type(py_return_type_safe(Some(inner), known));
+        let wrapper = match typ {
+            TypeMeta::Parameterized { name, args, .. } => {
+                crate::meta::make_parameterized_name(name, args)
+            }
+            _ => unreachable!(),
+        };
+        return format!("{} | {}", native, wrapper);
+    }
+
     match typ {
         TypeMeta::RuntimeClass { name, .. }
         | TypeMeta::Enum { name, .. }
@@ -88,6 +109,10 @@ pub(super) fn py_param_type_safe(typ: &TypeMeta, known: &HashSet<String>) -> Str
 }
 
 pub(super) fn py_return_type_safe(typ: Option<&TypeMeta>, known: &HashSet<String>) -> String {
+    if let Some(inner) = typ.and_then(ireference_inner_type) {
+        return py_optional_type(py_return_type_safe(Some(inner), known));
+    }
+
     match typ {
         Some(TypeMeta::RuntimeClass { name, .. })
         | Some(TypeMeta::Enum { name, .. })
@@ -370,5 +395,25 @@ mod tests {
             ),
             "handler: 'DynWinRTValue'"
         );
+    }
+
+    #[test]
+    fn ireference_returns_are_projected_as_optional_values() {
+        let reference = TypeMeta::Parameterized {
+            namespace: "Windows.Foundation".into(),
+            name: "IReference".into(),
+            piid: "61c17706-2d65-11e0-9ae8-d48564015472".into(),
+            args: vec![TypeMeta::U32],
+        };
+
+        assert_eq!(
+            py_return_type_safe(Some(&reference), &HashSet::new()),
+            "int | None"
+        );
+        assert_eq!(
+            py_param_type_safe(&reference, &HashSet::new()),
+            "int | None | IReference_UInt32"
+        );
+        assert_eq!(py_optional_type("'DayOfWeek'".into()), "DayOfWeek | None");
     }
 }

--- a/tools/dynwinrt-codegen/src/codegen/shared/imports.rs
+++ b/tools/dynwinrt-codegen/src/codegen/shared/imports.rs
@@ -17,6 +17,23 @@ pub(crate) static NO_DEFERRED: LazyLock<HashSet<String>> = LazyLock::new(HashSet
 // Generic collection helpers
 // ======================================================================
 
+pub(crate) fn ireference_inner_type(typ: &TypeMeta) -> Option<&TypeMeta> {
+    match typ {
+        TypeMeta::Parameterized {
+            namespace,
+            name,
+            args,
+            ..
+        } if namespace == "Windows.Foundation"
+            && name.split('`').next() == Some("IReference")
+            && args.len() == 1 =>
+        {
+            args.first()
+        }
+        _ => None,
+    }
+}
+
 /// Collect the set of known generic collection names used in method signatures.
 /// Returns e.g. ["IVectorView", "IMap"] for import generation.
 pub(crate) fn collect_used_generics_from_methods(methods: &[MethodMeta]) -> Vec<String> {

--- a/tools/dynwinrt-codegen/tests/nullable_return_test.rs
+++ b/tools/dynwinrt-codegen/tests/nullable_return_test.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-use dynwinrt_codegen::codegen::{project, render_dts, render_js};
+use dynwinrt_codegen::codegen::{project, python, python_stub, render_dts, render_js};
 use dynwinrt_codegen::meta;
 use dynwinrt_codegen::types::TypeMeta;
 
@@ -80,4 +80,101 @@ fn nullable_runtime_class_returns_are_guarded_without_type_changes() {
     assert!(dts.contains("static getDefault(): Accelerometer;"));
     assert!(dts.contains("Promise<Accelerometer>"));
     assert!(dts.contains("getCurrentReading(): AccelerometerReading;"));
+}
+
+#[test]
+fn ireference_values_are_projected_as_native_nullable_values() {
+    if !Path::new(WINDOWS_WINMD).exists() {
+        eprintln!("Skipping: Windows.winmd not found");
+        return;
+    }
+
+    let Some(contact_date) = meta::parse_class(
+        WINDOWS_WINMD,
+        "Windows.ApplicationModel.Contacts",
+        "ContactDate",
+    ) else {
+        panic!("ContactDate metadata not found");
+    };
+
+    let roots = vec![contact_date];
+    let deps = meta::resolve_dependencies(WINDOWS_WINMD, &roots, &[], &[]);
+    let mut classes = roots;
+    classes.extend(deps.classes);
+    let interfaces = deps.interfaces;
+
+    let mut known_types = HashSet::new();
+    for class in &classes {
+        known_types.insert(class.name.clone());
+    }
+    for interface in &interfaces {
+        known_types.insert(interface.name.clone());
+    }
+    for en in &deps.enums {
+        if let TypeMeta::Enum { name, .. } = en {
+            known_types.insert(name.clone());
+        }
+    }
+
+    let delegate_type_names: HashSet<String> = interfaces
+        .iter()
+        .filter(|interface| {
+            interface
+                .methods
+                .iter()
+                .any(|method| method.name == ".ctor")
+                && interface
+                    .methods
+                    .iter()
+                    .any(|method| method.name == "Invoke")
+        })
+        .map(|interface| interface.name.clone())
+        .collect();
+
+    let class = classes
+        .iter()
+        .find(|class| class.name == "ContactDate")
+        .expect("ContactDate class missing after dependency resolution");
+    let (delegate_sigs, delegate_sig_refs, delegate_param_wraps) =
+        project::build_delegate_signatures(&interfaces, &delegate_type_names, &known_types);
+    let projected = project::project_class(
+        class,
+        &known_types,
+        &delegate_type_names,
+        &HashSet::new(),
+        &delegate_sigs,
+        &delegate_sig_refs,
+        &delegate_param_wraps,
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+    let py = python::generate_class(class, &known_types, &delegate_type_names, &HashSet::new());
+    let pyi = python_stub::generate_class_stub(
+        class,
+        &known_types,
+        &delegate_type_names,
+        &HashSet::new(),
+    );
+
+    assert!(py.contains("def day(self) -> int | None:"));
+    assert!(py.contains(
+        "None if value.is_null() else _dynwinrt_symbol('i_reference_u_int32', 'IReference_UInt32')(value).value"
+    ));
+    assert!(py.contains("def day(self, value: int | None | IReference_UInt32):"));
+    assert!(py.contains(
+        "_dynwinrt_box_reference(value, DynWinRTType.u32_type(), lambda value: DynWinRTValue.from_u32(value))"
+    ));
+    assert!(pyi.contains("def day(self) -> int | None: ..."));
+    assert!(pyi.contains("def day(self, value: int | None | IReference_UInt32) -> None: ..."));
+    assert!(
+        js.contains("v.isNull() ? null")
+            && js.contains("IReference_UInt32")
+            && js.contains("(v).value"),
+        "JavaScript IReference getter must unbox nullable values:\n{js}"
+    );
+    assert!(
+        js.contains("DynWinRtValue.boxReference(DynWinRtValue.u32(value), DynWinRtType.u32())")
+    );
+    assert!(dts.contains("get day(): number | null;"));
+    assert!(dts.contains("set day(value: number | null | IReference_UInt32);"));
 }

--- a/tools/dynwinrt-codegen/tests/tsc_check_test.rs
+++ b/tools/dynwinrt-codegen/tests/tsc_check_test.rs
@@ -93,10 +93,32 @@ fn generated_dts_passes_tsc_no_emit() {
         .expect("spawn dynwinrt-codegen");
     assert!(status3.success(), "codegen failed (User): {:?}", status3);
 
+    let status4 = Command::new(exe)
+        .args([
+            "generate",
+            "--namespace",
+            "Windows.ApplicationModel.Contacts",
+            "--class-name",
+            "ContactDate",
+            "--lang",
+            "js",
+            "--output",
+        ])
+        .arg(&tmp)
+        .status()
+        .expect("spawn dynwinrt-codegen");
+    assert!(
+        status4.success(),
+        "codegen failed (ContactDate): {:?}",
+        status4
+    );
+
     fs::write(
         tmp.join("constructor-usage.ts"),
         r#"import { Uri } from "./Uri.js";
 import { User } from "./User.js";
+import { ContactDate } from "./ContactDate.js";
+import { IReference_UInt32 } from "./IReference_UInt32.js";
 
 new Uri("https://example.com");
 new Uri("https://example.com/base/", "child");
@@ -104,6 +126,15 @@ new Uri("https://example.com/base/", "child");
 new Uri();
 // @ts-expect-error User instances can only be returned by the system.
 new User();
+
+const contactDate = ContactDate.create();
+const day: number | null = contactDate.day;
+contactDate.day = 17;
+contactDate.day = null;
+declare const legacyDay: IReference_UInt32;
+contactDate.day = legacyDay;
+// @ts-expect-error Nullable UInt32 properties do not accept strings.
+contactDate.day = "17";
 "#,
     )
     .expect("write constructor usage");


### PR DESCRIPTION
### Summary

- Add shared core support for dynamically boxing  IReference<T> 
- Project JavaScript values as  T | null 
- Project Python values as  T | None 
- Accept native values and nulls directly in generated setters and methods
- Preserve legacy  IReference_*  wrapper inputs
- Support primitive, string, GUID, enum, and struct values with ABI-safe ownership

### Breaking change

Regenerated getters now return native values instead of  IReference_*  wrappers:

// Before
`const value = contact.day?.value;`

// After
`const value = contact.day;`

Existing wrapper inputs remain supported. Ordinary runtime-class/interface projections are unchanged.