### PR TITLE
 Prevent WinRT progress callbacks from keeping Node.js alive

### DIFF
--- a/bindings/js/__test__/index.spec.ts
+++ b/bindings/js/__test__/index.spec.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import test from 'ava'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 
 import {
   DynWinRtArray,
@@ -64,10 +66,7 @@ test('round-trip WinRT values', (t) => {
 
 test('box IReference values', (t) => {
   const valueType = DynWinRtType.u32()
-  const referenceType = DynWinRtType.parameterized(
-    WinGuid.parse('61c17706-2d65-11e0-9ae8-d48564015472'),
-    [valueType],
-  )
+  const referenceType = DynWinRtType.parameterized(WinGuid.parse('61c17706-2d65-11e0-9ae8-d48564015472'), [valueType])
   const reference = DynWinRtType.registerInterface('IReference_UInt32_Test', referenceType.iid()).addMethod(
     'get_Value',
     new DynWinRtMethodSig().addOut(valueType),
@@ -102,4 +101,44 @@ test('parse GUIDs', (t) => {
 
 test('report package identity state', (t) => {
   t.is(typeof hasPackageIdentity(), 'boolean')
+})
+
+test('progress callbacks do not keep Node alive after completion', async (t) => {
+  const child = spawn(process.execPath, [fileURLToPath(new URL('./progress-exit-child.mjs', import.meta.url))], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk
+  })
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk
+  })
+
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    child.kill()
+  }, 10_000)
+  t.teardown(() => {
+    clearTimeout(timeout)
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill()
+    }
+  })
+
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', resolve)
+  })
+  clearTimeout(timeout)
+
+  t.false(timedOut, 'child process remained alive after the progress operation completed')
+  t.is(code, 0, stderr)
+  t.regex(stdout, /progress-exit-ok/)
 })

--- a/bindings/js/__test__/progress-exit-child.mjs
+++ b/bindings/js/__test__/progress-exit-child.mjs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DynWinRtMethodSig, DynWinRtType, DynWinRtValue, WinGuid, roInitialize } from '../dist/index.js'
+
+roInitialize(1)
+
+const activationFactory = DynWinRtType.registerInterface(
+  'IActivationFactory',
+  WinGuid.parse('00000035-0000-0000-C000-000000000046'),
+).addMethod('ActivateInstance', new DynWinRtMethodSig().addOut(DynWinRtType.object()))
+
+const outputStream = DynWinRtType.registerInterface(
+  'IOutputStream',
+  WinGuid.parse('905A0FE6-BC53-11DF-8C49-001E4FC686DA'),
+).addMethod(
+  'WriteAsync',
+  new DynWinRtMethodSig()
+    .addIn(DynWinRtType.object())
+    .addOut(DynWinRtType.iAsyncOperationWithProgress(DynWinRtType.u32(), DynWinRtType.u32())),
+)
+
+const bufferFactory = DynWinRtType.registerInterface(
+  'IBufferFactory',
+  WinGuid.parse('71AF914D-C10F-484B-BC50-14BC623B3A27'),
+).addMethod('Create', new DynWinRtMethodSig().addIn(DynWinRtType.u32()).addOut(DynWinRtType.object()))
+
+const bufferType = DynWinRtType.registerInterface('IBuffer', WinGuid.parse('905A0FE0-BC53-11DF-8C49-001E4FC686DA'))
+  .addMethod('get_Capacity', new DynWinRtMethodSig().addOut(DynWinRtType.u32()))
+  .addMethod('get_Length', new DynWinRtMethodSig().addOut(DynWinRtType.u32()))
+  .addMethod('put_Length', new DynWinRtMethodSig().addIn(DynWinRtType.u32()))
+
+const stream = activationFactory
+  .method(6)
+  .invoke(
+    DynWinRtValue.activationFactory('Windows.Storage.Streams.InMemoryRandomAccessStream').cast(
+      WinGuid.parse('00000035-0000-0000-C000-000000000046'),
+    ),
+    [],
+  )
+const streamOutput = stream.cast(WinGuid.parse('905A0FE6-BC53-11DF-8C49-001E4FC686DA'))
+
+const buffer = bufferFactory
+  .method(6)
+  .invoke(
+    DynWinRtValue.activationFactory('Windows.Storage.Streams.Buffer').cast(
+      WinGuid.parse('71AF914D-C10F-484B-BC50-14BC623B3A27'),
+    ),
+    [DynWinRtValue.u32(1024)],
+  )
+bufferType
+  .method(8)
+  .invoke(buffer.cast(WinGuid.parse('905A0FE0-BC53-11DF-8C49-001E4FC686DA')), [DynWinRtValue.u32(1024)])
+
+const operation = outputStream.method(6).invoke(streamOutput, [buffer])
+operation.onProgress(() => {})
+
+const result = await operation.toPromise()
+if (result.toNumber() !== 1024) {
+  throw new Error(`Expected 1024 bytes written, got ${result.toNumber()}`)
+}
+
+console.log('progress-exit-ok')

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -758,7 +758,11 @@ impl DynWinRTValue {
       .progress_handler_iid()
       .ok_or_else(|| napi::Error::from_reason("onProgress: cannot compute progress handler IID"))?;
 
-    let tsfn = callback.build_threadsafe_function().build()?;
+    // Progress callbacks must not keep an otherwise idle Node process alive.
+    let tsfn = callback
+      .build_threadsafe_function()
+      .weak::<true>()
+      .build()?;
     let progress_cb: dynwinrt::ProgressCallback = Box::new(move |val: dynwinrt::WinRTValue| {
       tsfn.call(DynWinRTValue(val), ThreadsafeFunctionCallMode::NonBlocking);
     });


### PR DESCRIPTION
## Summary

- Create JavaScript progress `ThreadsafeFunction`s as weak references.
- Preserve progress delivery without keeping the Node.js event loop alive after completion.
- Add a child-process regression test using `IAsyncOperationWithProgress`.