### PR TITLE
Add JavaScript-backed element factories and observable vectors

### DIFF
--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -55,6 +55,16 @@ the native window and XAML core are destroyed. Projects that never create a
 scope do not allocate WeakRefs or retain projected values. Direct runtime users
 can release an individual `DynWinRtValue` with `value.release()`.
 
+Generated WinUI `IElementFactory` bindings expose `IElementFactory.create()`.
+It creates a synchronous, UI-thread factory backed by JavaScript
+`getElement`/`recycleElement` callbacks. Call `releaseCallbacks()` on the
+returned factory after clearing its ItemsRepeater source so JavaScript item
+state can be released before the native repeater is destroyed.
+
+`DynWinRtValue.createVector()` objects implement `IObservableVector<T>` in
+addition to `IIterable<T>`, `IVector<T>`, and `IVectorView<T>`. Mutations emit
+the standard `VectorChanged` collection-change notifications.
+
 ## Platform support
 
 - **Windows 10 / 11** — x64 and arm64 native binaries shipped via `napi-rs` prebuilds

--- a/bindings/js/src/lib.rs
+++ b/bindings/js/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::all)]
 #![allow(clippy::missing_safety_doc)]
 
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 
 use dynwinrt;
 use napi::bindgen_prelude::BigInt;
@@ -1748,6 +1748,265 @@ impl DynWinRtDelegate {
   #[napi]
   pub fn to_value(&self) -> DynWinRTValue {
     DynWinRTValue(self.0.clone())
+  }
+}
+
+// ======================================================================
+// DynWinRtElementFactory — synchronous WinUI IElementFactory binding
+// ======================================================================
+
+type ElementFactoryGetFunction =
+  napi::bindgen_prelude::Function<'static, DynWinRTValue, DynWinRTValue>;
+type ElementFactoryRecycleFunction = napi::bindgen_prelude::Function<'static, DynWinRTValue, ()>;
+
+struct ElementFactoryCallbackRefs {
+  get_element: Option<Arc<napi::bindgen_prelude::FunctionRef<DynWinRTValue, DynWinRTValue>>>,
+  recycle_element: Option<Arc<napi::bindgen_prelude::FunctionRef<DynWinRTValue, ()>>>,
+}
+
+#[napi]
+pub struct DynWinRtElementFactory {
+  value: dynwinrt::WinRTValue,
+  callbacks: Arc<Mutex<ElementFactoryCallbackRefs>>,
+}
+
+unsafe fn take_pending_exception_message(env: napi::sys::napi_env) -> Option<String> {
+  let mut pending = false;
+  if napi::sys::napi_is_exception_pending(env, &mut pending) != napi::sys::Status::napi_ok
+    || !pending
+  {
+    return None;
+  }
+
+  let mut exception = std::ptr::null_mut();
+  if napi::sys::napi_get_and_clear_last_exception(env, &mut exception) != napi::sys::Status::napi_ok
+  {
+    return None;
+  }
+  let mut text = std::ptr::null_mut();
+  if napi::sys::napi_coerce_to_string(env, exception, &mut text) != napi::sys::Status::napi_ok {
+    return None;
+  }
+
+  let mut length = 0usize;
+  if napi::sys::napi_get_value_string_utf8(env, text, std::ptr::null_mut(), 0, &mut length)
+    != napi::sys::Status::napi_ok
+  {
+    return None;
+  }
+  let mut buffer = vec![0u8; length + 1];
+  let mut written = 0usize;
+  if napi::sys::napi_get_value_string_utf8(
+    env,
+    text,
+    buffer.as_mut_ptr().cast(),
+    buffer.len(),
+    &mut written,
+  ) != napi::sys::Status::napi_ok
+  {
+    return None;
+  }
+  Some(String::from_utf8_lossy(&buffer[..written]).into_owned())
+}
+
+#[napi]
+impl DynWinRtElementFactory {
+  #[napi(factory)]
+  pub fn create(
+    #[napi(ts_arg_type = "(args: DynWinRtValue) => DynWinRtValue")]
+    get_element: ElementFactoryGetFunction,
+    #[napi(ts_arg_type = "(args: DynWinRtValue) => void")]
+    recycle_element: ElementFactoryRecycleFunction,
+  ) -> napi::Result<DynWinRtElementFactory> {
+    use napi::bindgen_prelude::{FromNapiValue, ToNapiValue};
+    use napi::JsValue;
+    use windows::Win32::System::Threading::GetCurrentThreadId;
+
+    const E_FAIL: windows::core::HRESULT = windows::core::HRESULT(0x80004005u32 as i32);
+    const E_UNEXPECTED: windows::core::HRESULT = windows::core::HRESULT(0x8000FFFFu32 as i32);
+    const RPC_E_WRONG_THREAD: windows::core::HRESULT = windows::core::HRESULT(0x8001010Eu32 as i32);
+    const RO_E_CLOSED: windows::core::HRESULT = windows::core::HRESULT(0x80000013u32 as i32);
+
+    struct SendableEnv(napi::sys::napi_env);
+    unsafe impl Send for SendableEnv {}
+    unsafe impl Sync for SendableEnv {}
+
+    let register_tid = unsafe { GetCurrentThreadId() };
+    let raw_env = Arc::new(SendableEnv(get_element.value().env));
+    let callbacks = Arc::new(Mutex::new(ElementFactoryCallbackRefs {
+      get_element: Some(Arc::new(get_element.create_ref()?)),
+      recycle_element: Some(Arc::new(recycle_element.create_ref()?)),
+    }));
+
+    let get_env = raw_env.clone();
+    let get_callbacks = callbacks.clone();
+    let get_callback: dynwinrt::ElementFactoryGetCallback = Box::new(move |args| {
+      if unsafe { GetCurrentThreadId() } != register_tid {
+        return Err(RPC_E_WRONG_THREAD);
+      }
+
+      let get_ref = match get_callbacks.lock() {
+        Ok(callbacks) => {
+          let Some(callback) = callbacks.get_element.as_ref() else {
+            return Err(RO_E_CLOSED);
+          };
+          callback.clone()
+        }
+        Err(_) => return Err(E_FAIL),
+      };
+      let raw_env = get_env.0;
+      let js_arg = DynWinRTValue(args.clone());
+      let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(
+        || -> napi::Result<dynwinrt::WinRTValue> {
+          unsafe {
+            let mut scope = std::ptr::null_mut();
+            if napi::sys::napi_open_handle_scope(raw_env, &mut scope) != napi::sys::Status::napi_ok
+            {
+              return Err(napi::Error::from_reason("napi_open_handle_scope failed"));
+            }
+
+            let call_result = (|| -> napi::Result<dynwinrt::WinRTValue> {
+              let env = napi::Env::from_raw(raw_env);
+              let function = get_ref.borrow_back(&env)?;
+              let function_value = napi::JsValue::raw(&function);
+              let argument = DynWinRTValue::to_napi_value(raw_env, js_arg)?;
+              let mut undefined = std::ptr::null_mut();
+              napi::sys::napi_get_undefined(raw_env, &mut undefined);
+              let mut raw_result = std::ptr::null_mut();
+              let status = napi::sys::napi_call_function(
+                raw_env,
+                undefined,
+                function_value,
+                1,
+                &argument,
+                &mut raw_result,
+              );
+              if status != napi::sys::Status::napi_ok {
+                let detail = take_pending_exception_message(raw_env)
+                  .unwrap_or_else(|| "unknown JavaScript exception".into());
+                return Err(napi::Error::from_reason(format!(
+                  "IElementFactory getElement callback failed: {detail}"
+                )));
+              }
+              Ok(
+                <&DynWinRTValue>::from_napi_value(raw_env, raw_result)?
+                  .0
+                  .clone(),
+              )
+            })();
+            let call_result =
+              call_result.map_err(|error| match take_pending_exception_message(raw_env) {
+                Some(detail) => napi::Error::from_reason(format!("{error}: {detail}")),
+                None => error,
+              });
+            napi::sys::napi_close_handle_scope(raw_env, scope);
+            call_result
+          }
+        },
+      ));
+
+      match result {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => {
+          eprintln!("[dynwinrt] IElementFactory getElement dispatch error: {error}");
+          Err(E_FAIL)
+        }
+        Err(_) => Err(E_UNEXPECTED),
+      }
+    });
+
+    let recycle_env = raw_env.clone();
+    let recycle_callbacks = callbacks.clone();
+    let recycle_callback: dynwinrt::ElementFactoryRecycleCallback = Box::new(move |args| {
+      if unsafe { GetCurrentThreadId() } != register_tid {
+        return RPC_E_WRONG_THREAD;
+      }
+
+      let recycle_ref = match recycle_callbacks.lock() {
+        Ok(callbacks) => {
+          let Some(callback) = callbacks.recycle_element.as_ref() else {
+            return RO_E_CLOSED;
+          };
+          callback.clone()
+        }
+        Err(_) => return E_FAIL,
+      };
+      let raw_env = recycle_env.0;
+      let js_arg = DynWinRTValue(args.clone());
+      let result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| -> napi::Result<()> {
+          unsafe {
+            let mut scope = std::ptr::null_mut();
+            if napi::sys::napi_open_handle_scope(raw_env, &mut scope) != napi::sys::Status::napi_ok
+            {
+              return Err(napi::Error::from_reason("napi_open_handle_scope failed"));
+            }
+
+            let call_result = (|| -> napi::Result<()> {
+              let env = napi::Env::from_raw(raw_env);
+              let function = recycle_ref.borrow_back(&env)?;
+              let function_value = napi::JsValue::raw(&function);
+              let argument = DynWinRTValue::to_napi_value(raw_env, js_arg)?;
+              let mut undefined = std::ptr::null_mut();
+              napi::sys::napi_get_undefined(raw_env, &mut undefined);
+              let mut raw_result = std::ptr::null_mut();
+              let status = napi::sys::napi_call_function(
+                raw_env,
+                undefined,
+                function_value,
+                1,
+                &argument,
+                &mut raw_result,
+              );
+              if status != napi::sys::Status::napi_ok {
+                let detail = take_pending_exception_message(raw_env)
+                  .unwrap_or_else(|| "unknown JavaScript exception".into());
+                return Err(napi::Error::from_reason(format!(
+                  "IElementFactory recycleElement callback failed: {detail}"
+                )));
+              }
+              Ok(())
+            })();
+            let call_result =
+              call_result.map_err(|error| match take_pending_exception_message(raw_env) {
+                Some(detail) => napi::Error::from_reason(format!("{error}: {detail}")),
+                None => error,
+              });
+            napi::sys::napi_close_handle_scope(raw_env, scope);
+            call_result
+          }
+        }));
+
+      match result {
+        Ok(Ok(())) => windows::core::HRESULT(0),
+        Ok(Err(error)) => {
+          eprintln!("[dynwinrt] IElementFactory recycleElement dispatch error: {error}");
+          E_FAIL
+        }
+        Err(_) => E_UNEXPECTED,
+      }
+    });
+
+    Ok(DynWinRtElementFactory {
+      value: dynwinrt::create_element_factory_value(get_callback, recycle_callback),
+      callbacks,
+    })
+  }
+
+  #[napi]
+  pub fn to_value(&self) -> DynWinRTValue {
+    DynWinRTValue(self.value.clone())
+  }
+
+  #[napi]
+  pub fn release_callbacks(&self) -> napi::Result<()> {
+    let mut callbacks = self
+      .callbacks
+      .lock()
+      .map_err(|_| napi::Error::from_reason("IElementFactory callback state is poisoned"))?;
+    callbacks.get_element = None;
+    callbacks.recycle_element = None;
+    Ok(())
   }
 }
 

--- a/crates/dynwinrt/Cargo.toml
+++ b/crates/dynwinrt/Cargo.toml
@@ -22,6 +22,7 @@ version = ">=0.59, <=0.62"
 features = [
     "ApplicationModel",
     "Data_Xml_Dom",
+    "Foundation_Collections",
     "Devices_Geolocation",
     "Storage_Streams",
     "System_Threading",

--- a/crates/dynwinrt/src/com_helpers.rs
+++ b/crates/dynwinrt/src/com_helpers.rs
@@ -105,13 +105,12 @@ macro_rules! inspectable_stubs {
     };
 }
 
-/// Generate triple-vtable COM boilerplate for structs with three vtable pointers
-/// (first = iterable, second = vector, third = vector_view).
+/// Generate four-vtable COM boilerplate for collection structs.
 ///
-/// The struct layout must be: vtable_first, vtable_second, vtable_third, ...
-macro_rules! triple_vtable_com {
-    ($first_suffix:ident, $second_suffix:ident, $third_suffix:ident,
-     $second_iid_field:ident, $third_iid_field:ident) => {
+/// The struct layout must begin with the four vtable pointers in order.
+macro_rules! quad_vtable_com {
+    ($first_suffix:ident, $second_suffix:ident, $third_suffix:ident, $fourth_suffix:ident,
+     $second_iid_field:ident, $third_iid_field:ident, $fourth_iid_field:ident) => {
         paste::paste! {
             /// Recover &Self from the first (iterable) vtable pointer.
             unsafe fn [<from_ $first_suffix _ptr>](this: *mut ::core::ffi::c_void) -> &'static Self {
@@ -127,6 +126,11 @@ macro_rules! triple_vtable_com {
             /// Recover &Self from the third vtable pointer.
             unsafe fn [<from_ $third_suffix _ptr>](this: *mut ::core::ffi::c_void) -> &'static Self {
                 let base = (this as *const *const ::core::ffi::c_void).sub(2) as *const Self;
+                &*base
+            }
+
+            unsafe fn [<from_ $fourth_suffix _ptr>](this: *mut ::core::ffi::c_void) -> &'static Self {
+                let base = (this as *const *const ::core::ffi::c_void).sub(3) as *const Self;
                 &*base
             }
 
@@ -208,6 +212,31 @@ macro_rules! triple_vtable_com {
                 remaining
             }
 
+            // -- IUnknown for fourth interface --
+
+            unsafe extern "system" fn [<qi_ $fourth_suffix>](
+                this: *mut ::core::ffi::c_void,
+                iid: *const ::windows_core::GUID,
+                ppv: *mut *mut ::core::ffi::c_void,
+            ) -> ::windows_core::HRESULT {
+                let me = Self::[<from_ $fourth_suffix _ptr>](this);
+                Self::qi_impl(me, Self::[<as_ $first_suffix _ptr>](me as *const Self), iid, ppv)
+            }
+
+            unsafe extern "system" fn [<add_ref_ $fourth_suffix>](this: *mut ::core::ffi::c_void) -> u32 {
+                Self::[<from_ $fourth_suffix _ptr>](this).ref_count.add_ref()
+            }
+
+            unsafe extern "system" fn [<release_ $fourth_suffix>](this: *mut ::core::ffi::c_void) -> u32 {
+                let me = Self::[<from_ $fourth_suffix _ptr>](this);
+                let remaining = me.ref_count.release();
+                if remaining == 0 {
+                    let base = Self::[<as_ $first_suffix _ptr>](me as *const Self);
+                    drop(Box::from_raw(base as *mut Self));
+                }
+                remaining
+            }
+
             // -- Shared QI --
 
             unsafe fn qi_impl(
@@ -234,6 +263,10 @@ macro_rules! triple_vtable_com {
                     $crate::com_helpers::S_OK
                 } else if *iid == me.iids.$third_iid_field {
                     *ppv = (identity as *const *const ::core::ffi::c_void).add(2) as *mut ::core::ffi::c_void;
+                    me.ref_count.add_ref();
+                    $crate::com_helpers::S_OK
+                } else if *iid == me.iids.$fourth_iid_field {
+                    *ppv = (identity as *const *const ::core::ffi::c_void).add(3) as *mut ::core::ffi::c_void;
                     me.ref_count.add_ref();
                     $crate::com_helpers::S_OK
                 } else if *iid == ::windows_core::imp::IMarshal::IID {

--- a/crates/dynwinrt/src/element_factory.rs
+++ b/crates/dynwinrt/src/element_factory.rs
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use core::ffi::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use windows::Win32::System::Com::CoTaskMemAlloc;
+use windows_core::{GUID, HRESULT, IInspectable, IUnknown, Interface};
+
+use crate::com_helpers::{E_FAIL, E_NOINTERFACE, E_POINTER, IInspectableVtbl, S_OK};
+use crate::value::WinRTValue;
+
+pub const IID_IELEMENT_FACTORY: GUID = GUID::from_u128(0x75faba47_2cf2_54ae_91e6_0581556fddaa);
+const IID_IUIELEMENT: GUID = GUID::from_u128(0xc3c01020_320c_5cf6_9d24_d396bbfa4d8b);
+
+pub type ElementFactoryGetCallback =
+    Box<dyn Fn(&WinRTValue) -> std::result::Result<WinRTValue, HRESULT> + Send + Sync>;
+pub type ElementFactoryRecycleCallback = Box<dyn Fn(&WinRTValue) -> HRESULT + Send + Sync>;
+
+#[repr(C)]
+struct ElementFactoryVtbl {
+    base: IInspectableVtbl,
+    get_element: unsafe extern "system" fn(
+        this: *mut c_void,
+        args: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT,
+    recycle_element: unsafe extern "system" fn(this: *mut c_void, args: *mut c_void) -> HRESULT,
+}
+
+#[repr(C)]
+struct DynamicElementFactory {
+    vtable: *const ElementFactoryVtbl,
+    ref_count: windows_core::imp::RefCount,
+    get_element: ElementFactoryGetCallback,
+    recycle_element: ElementFactoryRecycleCallback,
+}
+
+unsafe impl Send for DynamicElementFactory {}
+unsafe impl Sync for DynamicElementFactory {}
+
+impl DynamicElementFactory {
+    const VTBL: ElementFactoryVtbl = ElementFactoryVtbl {
+        base: IInspectableVtbl {
+            base: windows_core::IUnknown_Vtbl {
+                QueryInterface: Self::query_interface,
+                AddRef: Self::add_ref,
+                Release: Self::release,
+            },
+            get_iids: Self::get_iids,
+            get_runtime_class_name: Self::get_runtime_class_name,
+            get_trust_level: Self::get_trust_level,
+        },
+        get_element: Self::get_element,
+        recycle_element: Self::recycle_element,
+    };
+
+    fn create(
+        get_element: ElementFactoryGetCallback,
+        recycle_element: ElementFactoryRecycleCallback,
+    ) -> IUnknown {
+        let factory = Box::new(Self {
+            vtable: &Self::VTBL,
+            ref_count: windows_core::imp::RefCount::new(1),
+            get_element,
+            recycle_element,
+        });
+        unsafe { IUnknown::from_raw(Box::into_raw(factory) as *mut c_void) }
+    }
+
+    unsafe fn from_ptr(this: *mut c_void) -> &'static Self {
+        &*(this as *const Self)
+    }
+
+    unsafe extern "system" fn query_interface(
+        this: *mut c_void,
+        iid: *const GUID,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        if iid.is_null() || result.is_null() {
+            return E_POINTER;
+        }
+
+        *result = std::ptr::null_mut();
+        let factory = Self::from_ptr(this);
+        let iid = &*iid;
+        if *iid == IUnknown::IID || *iid == IInspectable::IID || *iid == IID_IELEMENT_FACTORY {
+            *result = this;
+            factory.ref_count.add_ref();
+            S_OK
+        } else {
+            E_NOINTERFACE
+        }
+    }
+
+    unsafe extern "system" fn add_ref(this: *mut c_void) -> u32 {
+        Self::from_ptr(this).ref_count.add_ref()
+    }
+
+    unsafe extern "system" fn release(this: *mut c_void) -> u32 {
+        let factory = Self::from_ptr(this);
+        let remaining = factory.ref_count.release();
+        if remaining == 0 {
+            drop(Box::from_raw(this as *mut Self));
+        }
+        remaining
+    }
+
+    unsafe extern "system" fn get_iids(
+        _this: *mut c_void,
+        count: *mut u32,
+        result: *mut *mut GUID,
+    ) -> HRESULT {
+        if count.is_null() || result.is_null() {
+            return E_POINTER;
+        }
+
+        let allocated = CoTaskMemAlloc(std::mem::size_of::<GUID>()) as *mut GUID;
+        if allocated.is_null() {
+            return HRESULT(0x8007000Eu32 as i32);
+        }
+        allocated.write(IID_IELEMENT_FACTORY);
+        *count = 1;
+        *result = allocated;
+        S_OK
+    }
+
+    unsafe extern "system" fn get_runtime_class_name(
+        _this: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        if result.is_null() {
+            return E_POINTER;
+        }
+        *result = std::ptr::null_mut();
+        S_OK
+    }
+
+    unsafe extern "system" fn get_trust_level(_this: *mut c_void, result: *mut i32) -> HRESULT {
+        if result.is_null() {
+            return E_POINTER;
+        }
+        *result = 0;
+        S_OK
+    }
+
+    unsafe fn wrap_argument(args: *mut c_void) -> std::result::Result<WinRTValue, HRESULT> {
+        if args.is_null() {
+            return Err(E_POINTER);
+        }
+        let borrowed = IUnknown::from_raw_borrowed(&args).ok_or(E_POINTER)?;
+        Ok(WinRTValue::Object(borrowed.clone()))
+    }
+
+    unsafe extern "system" fn get_element(
+        this: *mut c_void,
+        args: *mut c_void,
+        result: *mut *mut c_void,
+    ) -> HRESULT {
+        if result.is_null() {
+            return E_POINTER;
+        }
+        *result = std::ptr::null_mut();
+
+        let factory = Self::from_ptr(this);
+        let argument = match Self::wrap_argument(args) {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let callback_result = catch_unwind(AssertUnwindSafe(|| (factory.get_element)(&argument)));
+        let value = match callback_result {
+            Ok(Ok(value)) => value,
+            Ok(Err(error)) => return error,
+            Err(_) => return E_FAIL,
+        };
+
+        let WinRTValue::Object(element) = value else {
+            return E_FAIL;
+        };
+        element.query(&IID_IUIELEMENT, result)
+    }
+
+    unsafe extern "system" fn recycle_element(this: *mut c_void, args: *mut c_void) -> HRESULT {
+        let factory = Self::from_ptr(this);
+        let argument = match Self::wrap_argument(args) {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        match catch_unwind(AssertUnwindSafe(|| (factory.recycle_element)(&argument))) {
+            Ok(result) => result,
+            Err(_) => E_FAIL,
+        }
+    }
+}
+
+pub fn create_element_factory(
+    get_element: ElementFactoryGetCallback,
+    recycle_element: ElementFactoryRecycleCallback,
+) -> IUnknown {
+    DynamicElementFactory::create(get_element, recycle_element)
+}
+
+pub fn create_element_factory_value(
+    get_element: ElementFactoryGetCallback,
+    recycle_element: ElementFactoryRecycleCallback,
+) -> WinRTValue {
+    WinRTValue::Object(create_element_factory(get_element, recycle_element))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use windows::Foundation::Uri;
+    use windows_core::{HSTRING, Interface};
+
+    use super::*;
+
+    #[test]
+    fn element_factory_rejects_non_ui_results_and_recycles() {
+        let returned = Uri::CreateUri(&HSTRING::from("https://example.com/returned"))
+            .unwrap()
+            .cast::<IUnknown>()
+            .unwrap();
+        let argument = Uri::CreateUri(&HSTRING::from("https://example.com/argument"))
+            .unwrap()
+            .cast::<IUnknown>()
+            .unwrap();
+        let recycle_count = Arc::new(AtomicUsize::new(0));
+        let recycle_count_callback = recycle_count.clone();
+        let returned_raw = returned.as_raw() as usize;
+        let factory = create_element_factory(
+            Box::new(move |value| {
+                assert!(matches!(value, WinRTValue::Object(_)));
+                let raw = returned_raw as *mut c_void;
+                let borrowed = unsafe { IUnknown::from_raw_borrowed(&raw) }.unwrap();
+                Ok(WinRTValue::Object(borrowed.clone()))
+            }),
+            Box::new(move |value| {
+                assert!(matches!(value, WinRTValue::Object(_)));
+                recycle_count_callback.fetch_add(1, Ordering::SeqCst);
+                S_OK
+            }),
+        );
+
+        let mut raw_factory = std::ptr::null_mut();
+        let hr = unsafe { factory.query(&IID_IELEMENT_FACTORY, &mut raw_factory) };
+        assert!(hr.is_ok());
+        let interface = unsafe { IUnknown::from_raw(raw_factory) };
+        let vtable = unsafe { *(interface.as_raw() as *const *const ElementFactoryVtbl) };
+
+        let mut raw_result = std::ptr::null_mut();
+        let hr = unsafe {
+            ((*vtable).get_element)(interface.as_raw(), argument.as_raw(), &mut raw_result)
+        };
+        assert_eq!(hr, E_NOINTERFACE);
+        assert!(raw_result.is_null());
+
+        let hr = unsafe { ((*vtable).recycle_element)(interface.as_raw(), argument.as_raw()) };
+        assert!(hr.is_ok());
+        assert_eq!(recycle_count.load(Ordering::SeqCst), 1);
+    }
+}

--- a/crates/dynwinrt/src/lib.rs
+++ b/crates/dynwinrt/src/lib.rs
@@ -18,6 +18,7 @@ mod array;
 mod com_helpers;
 mod dasync;
 pub mod delegate;
+pub mod element_factory;
 pub mod map;
 mod meta;
 pub mod metadata_table;
@@ -27,6 +28,10 @@ pub mod vector;
 pub use crate::array::ArrayData;
 pub use crate::dasync::{
     ProgressCallback, WinRTAsyncFuture, create_progress_handler, get_async_results,
+};
+pub use crate::element_factory::{
+    ElementFactoryGetCallback, ElementFactoryRecycleCallback, create_element_factory,
+    create_element_factory_value,
 };
 pub use crate::metadata_table::{MetadataTable, MethodHandle, TypeHandle, TypeKind, ValueTypeData};
 pub use crate::reference::box_ireference;

--- a/crates/dynwinrt/src/metadata_table/mod.rs
+++ b/crates/dynwinrt/src/metadata_table/mod.rs
@@ -318,6 +318,9 @@ impl MetadataTable {
             iterable: self.compute_parameterized_iid(&IITERABLE, &[elem]),
             vector: self.compute_parameterized_iid(&IVECTOR, &[elem]),
             vector_view: self.compute_parameterized_iid(&IVECTOR_VIEW, &[elem]),
+            observable_vector: self.compute_parameterized_iid(&IOBSERVABLE_VECTOR, &[elem]),
+            vector_changed_handler: self
+                .compute_parameterized_iid(&VECTOR_CHANGED_EVENT_HANDLER, &[elem]),
             iterator: self.compute_parameterized_iid(&IITERATOR, &[elem]),
         }
     }

--- a/crates/dynwinrt/src/metadata_table/type_kind.rs
+++ b/crates/dynwinrt/src/metadata_table/type_kind.rs
@@ -21,6 +21,10 @@ pub const IMAP: GUID = GUID::from_u128(0x3c2925fe_8519_45c1_aa79_197b6718c1c1);
 pub const IMAP_VIEW: GUID = GUID::from_u128(0xe9bdaaf0_cbf6_4c39_de49_316b34326a17);
 pub const IKEY_VALUE_PAIR: GUID = GUID::from_u128(0x02b51929_c1c4_4a7e_8940_0312b5c18500);
 pub const IOBSERVABLE_VECTOR: GUID = GUID::from_u128(0x5917eb53_50b4_4a0d_b309_65862b3f1dbc);
+pub const VECTOR_CHANGED_EVENT_HANDLER: GUID =
+    GUID::from_u128(0x0c051752_9fbf_4c70_aa0c_0e4c82d9a761);
+pub const IVECTOR_CHANGED_EVENT_ARGS: GUID =
+    GUID::from_u128(0x575933df_34fe_4480_af15_07691f3d5d9b);
 pub const IREFERENCE: GUID = GUID::from_u128(0x61c17706_2d65_11e0_9ae8_d48564015472);
 
 pub const ASYNC_ACTION_COMPLETED_HANDLER: GUID = windows_future::AsyncActionCompletedHandler::IID;

--- a/crates/dynwinrt/src/vector.rs
+++ b/crates/dynwinrt/src/vector.rs
@@ -8,7 +8,11 @@
 //! allowing JS callers to construct vectors and pass them to WinRT APIs.
 
 use core::ffi::c_void;
-use std::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::{
+    Mutex,
+    atomic::{AtomicI64, Ordering},
+};
 use windows_core::{GUID, HRESULT, IUnknown, Interface};
 
 use crate::com_helpers::{
@@ -29,6 +33,8 @@ pub struct VectorIids {
     pub iterable: GUID,
     pub vector: GUID,
     pub vector_view: GUID,
+    pub observable_vector: GUID,
+    pub vector_changed_handler: GUID,
     pub iterator: GUID,
 }
 
@@ -73,6 +79,14 @@ struct VectorViewVtbl {
         unsafe extern "system" fn(*mut c_void, u32, u32, *mut *mut c_void, *mut u32) -> HRESULT,
 }
 
+/// IObservableVector<T> vtable: IInspectable + VectorChanged add/remove.
+#[repr(C)]
+struct ObservableVectorVtbl {
+    base: IInspectableVtbl,
+    add_vector_changed: unsafe extern "system" fn(*mut c_void, *mut c_void, *mut i64) -> HRESULT,
+    remove_vector_changed: unsafe extern "system" fn(*mut c_void, i64) -> HRESULT,
+}
+
 /// IIterator<T> vtable: IInspectable + 4 methods
 #[repr(C)]
 struct IteratorVtbl {
@@ -81,6 +95,81 @@ struct IteratorVtbl {
     get_has_current: unsafe extern "system" fn(*mut c_void, *mut bool) -> HRESULT,
     move_next: unsafe extern "system" fn(*mut c_void, *mut bool) -> HRESULT,
     get_many: unsafe extern "system" fn(*mut c_void, u32, *mut *mut c_void, *mut u32) -> HRESULT,
+}
+
+const IID_IVECTOR_CHANGED_EVENT_ARGS: GUID =
+    GUID::from_u128(0x575933df_34fe_4480_af15_07691f3d5d9b);
+const COLLECTION_CHANGE_RESET: i32 = 0;
+const COLLECTION_CHANGE_ITEM_INSERTED: i32 = 1;
+const COLLECTION_CHANGE_ITEM_REMOVED: i32 = 2;
+const COLLECTION_CHANGE_ITEM_CHANGED: i32 = 3;
+
+#[repr(C)]
+struct VectorChangedEventArgsVtbl {
+    base: IInspectableVtbl,
+    get_collection_change: unsafe extern "system" fn(*mut c_void, *mut i32) -> HRESULT,
+    get_index: unsafe extern "system" fn(*mut c_void, *mut u32) -> HRESULT,
+}
+
+#[repr(C)]
+struct VectorChangedEventArgs {
+    vtable: *const VectorChangedEventArgsVtbl,
+    ref_count: windows_core::imp::RefCount,
+    collection_change: i32,
+    index: u32,
+}
+
+impl VectorChangedEventArgs {
+    const VTBL: VectorChangedEventArgsVtbl = VectorChangedEventArgsVtbl {
+        base: IInspectableVtbl {
+            base: windows_core::IUnknown_Vtbl {
+                QueryInterface: Self::qi,
+                AddRef: Self::add_ref,
+                Release: Self::release,
+            },
+            get_iids: Self::get_iids_stub,
+            get_runtime_class_name: Self::get_runtime_class_name_stub,
+            get_trust_level: Self::get_trust_level_stub,
+        },
+        get_collection_change: Self::get_collection_change,
+        get_index: Self::get_index,
+    };
+
+    fn create(collection_change: i32, index: u32) -> IUnknown {
+        let args = Box::new(Self {
+            vtable: &Self::VTBL,
+            ref_count: windows_core::imp::RefCount::new(1),
+            collection_change,
+            index,
+        });
+        unsafe { IUnknown::from_raw(Box::into_raw(args) as *mut c_void) }
+    }
+
+    single_vtable_com!(|_me: &Self| IID_IVECTOR_CHANGED_EVENT_ARGS);
+    inspectable_stubs!(stub);
+
+    unsafe extern "system" fn get_collection_change(
+        this: *mut c_void,
+        result: *mut i32,
+    ) -> HRESULT {
+        if result.is_null() {
+            return crate::com_helpers::E_POINTER;
+        }
+        *result = Self::from_ptr(this).collection_change;
+        S_OK
+    }
+
+    unsafe extern "system" fn get_index(this: *mut c_void, result: *mut u32) -> HRESULT {
+        if result.is_null() {
+            return crate::com_helpers::E_POINTER;
+        }
+        *result = Self::from_ptr(this).index;
+        S_OK
+    }
+
+    unsafe fn from_ptr(this: *mut c_void) -> &'static Self {
+        &*(this as *const Self)
+    }
 }
 
 /// Write a raw usize item to an output pointer, AddRef'ing if it's a COM reference type.
@@ -111,24 +200,28 @@ unsafe fn write_item_out(
 // SingleThreadedVector
 // ======================================================================
 
-/// A dynamically-constructed WinRT IVector<T> + IVectorView<T> + IIterable<T> COM object.
+/// A dynamically-constructed observable WinRT vector COM object.
 ///
 /// Stores items as raw `usize` values. For reference types (COM objects),
 /// each usize is a raw IUnknown pointer with manual AddRef/Release.
 /// For value types (structs ≤ pointer size), each usize holds the struct
 /// bytes directly — no refcounting needed.
 ///
-/// Implements three interfaces (like C++/WinRT's single_threaded_vector):
+/// Implements four interfaces:
 /// - IIterable<T>: First() for iteration
 /// - IVector<T>: mutable collection operations
 /// - IVectorView<T>: read-only live view over the same data
+/// - IObservableVector<T>: change notifications for native controls
 #[repr(C)]
 struct SingleThreadedVector {
     vtable_iterable: *const IterableVtbl,
     vtable_vector: *const VectorVtbl,
     vtable_view: *const VectorViewVtbl,
+    vtable_observable: *const ObservableVectorVtbl,
     ref_count: windows_core::imp::RefCount,
     items: Mutex<Vec<usize>>,
+    handlers: Mutex<HashMap<i64, IUnknown>>,
+    next_token: AtomicI64,
     is_value_type: bool,
     elem_size: usize,
     iids: VectorIids,
@@ -194,8 +287,31 @@ impl SingleThreadedVector {
         get_many: Self::view_get_many,
     };
 
-    triple_vtable_com!(iterable, vector, view, vector, vector_view);
-    inspectable_stubs!(iterable, vector, view);
+    const OBSERVABLE_VTBL: ObservableVectorVtbl = ObservableVectorVtbl {
+        base: IInspectableVtbl {
+            base: windows_core::IUnknown_Vtbl {
+                QueryInterface: Self::qi_observable,
+                AddRef: Self::add_ref_observable,
+                Release: Self::release_observable,
+            },
+            get_iids: Self::get_iids_observable,
+            get_runtime_class_name: Self::get_runtime_class_name_observable,
+            get_trust_level: Self::get_trust_level_observable,
+        },
+        add_vector_changed: Self::add_vector_changed,
+        remove_vector_changed: Self::remove_vector_changed,
+    };
+
+    quad_vtable_com!(
+        iterable,
+        vector,
+        view,
+        observable,
+        vector,
+        vector_view,
+        observable_vector
+    );
+    inspectable_stubs!(iterable, vector, view, observable);
 
     // ------------------------------------------------------------------
     // IIterable<T>
@@ -219,6 +335,69 @@ impl SingleThreadedVector {
             me.iids.iterator,
         );
         *result = iter.into_raw();
+        S_OK
+    }
+
+    // ------------------------------------------------------------------
+    // IObservableVector<T>
+    // ------------------------------------------------------------------
+
+    fn observable_ptr(&self) -> *mut c_void {
+        unsafe { (self as *const Self as *const *const c_void).add(3) as *mut c_void }
+    }
+
+    fn notify_changed(&self, collection_change: i32, index: u32) -> HRESULT {
+        let handlers: Vec<IUnknown> = match self.handlers.lock() {
+            Ok(handlers) => handlers.values().cloned().collect(),
+            Err(_) => return E_FAIL,
+        };
+        if handlers.is_empty() {
+            return S_OK;
+        }
+
+        let args = VectorChangedEventArgs::create(collection_change, index);
+        let sender = self.observable_ptr();
+        let mut first_error = S_OK;
+        for handler in handlers {
+            let function = unsafe {
+                let vtable = *(handler.as_raw() as *const *const *mut c_void);
+                *vtable.add(3)
+            };
+            let invoke: unsafe extern "system" fn(
+                *mut c_void,
+                *mut c_void,
+                *mut c_void,
+            ) -> HRESULT = unsafe { std::mem::transmute(function) };
+            let result = unsafe { invoke(handler.as_raw(), sender, args.as_raw()) };
+            if result.is_err() && first_error.is_ok() {
+                first_error = result;
+            }
+        }
+        first_error
+    }
+
+    unsafe extern "system" fn add_vector_changed(
+        this: *mut c_void,
+        handler: *mut c_void,
+        token: *mut i64,
+    ) -> HRESULT {
+        if handler.is_null() || token.is_null() {
+            return crate::com_helpers::E_POINTER;
+        }
+        let me = Self::from_observable_ptr(this);
+        let borrowed = match IUnknown::from_raw_borrowed(&handler) {
+            Some(handler) => handler,
+            None => return crate::com_helpers::E_POINTER,
+        };
+        let next = me.next_token.fetch_add(1, Ordering::Relaxed);
+        lock_or!(me.handlers, E_FAIL).insert(next, borrowed.clone());
+        *token = next;
+        S_OK
+    }
+
+    unsafe extern "system" fn remove_vector_changed(this: *mut c_void, token: i64) -> HRESULT {
+        let me = Self::from_observable_ptr(this);
+        lock_or!(me.handlers, E_FAIL).remove(&token);
         S_OK
     }
 
@@ -294,19 +473,21 @@ impl SingleThreadedVector {
 
     unsafe extern "system" fn set_at(this: *mut c_void, index: u32, value: *mut c_void) -> HRESULT {
         let me = Self::from_vector_ptr(this);
-        let mut items = lock_or!(me.items, E_FAIL);
-        if (index as usize) >= items.len() {
-            return E_BOUNDS;
+        {
+            let mut items = lock_or!(me.items, E_FAIL);
+            if (index as usize) >= items.len() {
+                return E_BOUNDS;
+            }
+            let old = items[index as usize];
+            items[index as usize] = if me.is_value_type {
+                value as usize
+            } else {
+                let new_val = com_to_usize(value);
+                com_usize_release(old);
+                new_val
+            };
         }
-        let old = items[index as usize];
-        items[index as usize] = if me.is_value_type {
-            value as usize
-        } else {
-            let new_val = com_to_usize(value);
-            com_usize_release(old);
-            new_val
-        };
-        S_OK
+        me.notify_changed(COLLECTION_CHANGE_ITEM_CHANGED, index)
     }
 
     unsafe extern "system" fn insert_at(
@@ -315,30 +496,34 @@ impl SingleThreadedVector {
         value: *mut c_void,
     ) -> HRESULT {
         let me = Self::from_vector_ptr(this);
-        let mut items = lock_or!(me.items, E_FAIL);
-        if (index as usize) > items.len() {
-            return E_BOUNDS;
+        {
+            let mut items = lock_or!(me.items, E_FAIL);
+            if (index as usize) > items.len() {
+                return E_BOUNDS;
+            }
+            let val = if me.is_value_type {
+                value as usize
+            } else {
+                com_to_usize(value)
+            };
+            items.insert(index as usize, val);
         }
-        let val = if me.is_value_type {
-            value as usize
-        } else {
-            com_to_usize(value)
-        };
-        items.insert(index as usize, val);
-        S_OK
+        me.notify_changed(COLLECTION_CHANGE_ITEM_INSERTED, index)
     }
 
     unsafe extern "system" fn remove_at(this: *mut c_void, index: u32) -> HRESULT {
         let me = Self::from_vector_ptr(this);
-        let mut items = lock_or!(me.items, E_FAIL);
-        if (index as usize) >= items.len() {
-            return E_BOUNDS;
-        }
-        let removed = items.remove(index as usize);
+        let removed = {
+            let mut items = lock_or!(me.items, E_FAIL);
+            if (index as usize) >= items.len() {
+                return E_BOUNDS;
+            }
+            items.remove(index as usize)
+        };
         if !me.is_value_type {
             com_usize_release(removed);
         }
-        S_OK
+        me.notify_changed(COLLECTION_CHANGE_ITEM_REMOVED, index)
     }
 
     unsafe extern "system" fn append(this: *mut c_void, value: *mut c_void) -> HRESULT {
@@ -348,24 +533,33 @@ impl SingleThreadedVector {
         } else {
             com_to_usize(value)
         };
-        lock_or!(me.items, E_FAIL).push(val);
-        S_OK
+        let index = {
+            let mut items = lock_or!(me.items, E_FAIL);
+            let index = items.len() as u32;
+            items.push(val);
+            index
+        };
+        me.notify_changed(COLLECTION_CHANGE_ITEM_INSERTED, index)
     }
 
     unsafe extern "system" fn remove_at_end(this: *mut c_void) -> HRESULT {
         let me = Self::from_vector_ptr(this);
-        let mut items = lock_or!(me.items, E_FAIL);
-        if items.is_empty() {
-            return E_BOUNDS;
-        }
-        let removed = match items.pop() {
-            Some(v) => v,
-            None => return E_BOUNDS,
+        let (removed, index) = {
+            let mut items = lock_or!(me.items, E_FAIL);
+            if items.is_empty() {
+                return E_BOUNDS;
+            }
+            let index = (items.len() - 1) as u32;
+            let removed = match items.pop() {
+                Some(v) => v,
+                None => return E_BOUNDS,
+            };
+            (removed, index)
         };
         if !me.is_value_type {
             com_usize_release(removed);
         }
-        S_OK
+        me.notify_changed(COLLECTION_CHANGE_ITEM_REMOVED, index)
     }
 
     unsafe extern "system" fn clear(this: *mut c_void) -> HRESULT {
@@ -376,7 +570,7 @@ impl SingleThreadedVector {
                 com_usize_release(raw);
             }
         }
-        S_OK
+        me.notify_changed(COLLECTION_CHANGE_RESET, 0)
     }
 
     unsafe extern "system" fn get_many(
@@ -424,7 +618,8 @@ impl SingleThreadedVector {
             };
             items.push(val);
         }
-        S_OK
+        drop(items);
+        me.notify_changed(COLLECTION_CHANGE_RESET, 0)
     }
 
     // ------------------------------------------------------------------
@@ -872,8 +1067,11 @@ fn new_vector(
         vtable_iterable: &SingleThreadedVector::ITERABLE_VTBL,
         vtable_vector: &SingleThreadedVector::VECTOR_VTBL,
         vtable_view: &SingleThreadedVector::VIEW_VTBL,
+        vtable_observable: &SingleThreadedVector::OBSERVABLE_VTBL,
         ref_count: windows_core::imp::RefCount::new(1),
         items: Mutex::new(items),
+        handlers: Mutex::new(HashMap::new()),
+        next_token: AtomicI64::new(1),
         is_value_type,
         elem_size,
         iids,
@@ -957,7 +1155,236 @@ mod tests {
     }
 
     #[test]
+    fn test_observable_vector_notifications() {
+        use std::sync::Arc;
+
+        use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize};
+
+        let _ = unsafe { RoInitialize(RO_INIT_MULTITHREADED) };
+        let table = MetadataTable::new();
+        let object_type = table.object();
+        let iids = table.vector_iids(&object_type);
+        let vector = create_vector(Vec::new(), iids.clone());
+        let changes = Arc::new(Mutex::new(Vec::<(i32, u32)>::new()));
+        let callback_changes = changes.clone();
+        let args_type = table.interface(IID_IVECTOR_CHANGED_EVENT_ARGS);
+        let handler = crate::delegate::create_delegate(
+            iids.vector_changed_handler,
+            vec![table.object(), args_type],
+            Box::new(move |args| {
+                let event_args = args[1].as_object().unwrap();
+                let mut raw_args = std::ptr::null_mut();
+                unsafe {
+                    event_args
+                        .query(&IID_IVECTOR_CHANGED_EVENT_ARGS, &mut raw_args)
+                        .ok()
+                        .unwrap();
+                }
+                let args_object = unsafe { IUnknown::from_raw(raw_args) };
+                let vtable =
+                    unsafe { *(args_object.as_raw() as *const *const VectorChangedEventArgsVtbl) };
+                let mut change = -1;
+                let mut index = u32::MAX;
+                assert_eq!(
+                    unsafe { ((*vtable).get_collection_change)(args_object.as_raw(), &mut change) },
+                    S_OK,
+                );
+                assert_eq!(
+                    unsafe { ((*vtable).get_index)(args_object.as_raw(), &mut index,) },
+                    S_OK,
+                );
+                callback_changes.lock().unwrap().push((change, index));
+                S_OK
+            }),
+        );
+
+        let mut observable_ptr = std::ptr::null_mut();
+        unsafe {
+            vector
+                .query(&iids.observable_vector, &mut observable_ptr)
+                .ok()
+                .unwrap();
+        }
+        let observable = unsafe { IUnknown::from_raw(observable_ptr) };
+        let observable_vtable =
+            unsafe { *(observable.as_raw() as *const *const ObservableVectorVtbl) };
+        let mut token = 0i64;
+        assert_eq!(
+            unsafe {
+                ((*observable_vtable).add_vector_changed)(
+                    observable.as_raw(),
+                    handler.as_raw(),
+                    &mut token,
+                )
+            },
+            S_OK,
+        );
+
+        let mut vector_ptr = std::ptr::null_mut();
+        unsafe {
+            vector.query(&iids.vector, &mut vector_ptr).ok().unwrap();
+        }
+        let mutable = unsafe { IUnknown::from_raw(vector_ptr) };
+        let vector_vtable = unsafe { *(mutable.as_raw() as *const *const VectorVtbl) };
+        let uri = |suffix: &str| {
+            windows::Foundation::Uri::CreateUri(&windows_core::HSTRING::from(format!(
+                "https://example.com/{suffix}",
+            )))
+            .unwrap()
+            .cast::<IUnknown>()
+            .unwrap()
+        };
+        let first = uri("first");
+        let second = uri("second");
+        let inserted = uri("inserted");
+
+        assert_eq!(
+            unsafe { ((*vector_vtable).append)(mutable.as_raw(), first.as_raw(),) },
+            S_OK,
+        );
+        assert_eq!(
+            unsafe { ((*vector_vtable).set_at)(mutable.as_raw(), 0, second.as_raw(),) },
+            S_OK,
+        );
+        assert_eq!(
+            unsafe { ((*vector_vtable).insert_at)(mutable.as_raw(), 0, inserted.as_raw(),) },
+            S_OK,
+        );
+        assert_eq!(
+            unsafe { ((*vector_vtable).remove_at)(mutable.as_raw(), 1,) },
+            S_OK,
+        );
+        assert_eq!(unsafe { ((*vector_vtable).clear)(mutable.as_raw()) }, S_OK,);
+
+        assert_eq!(
+            changes.lock().unwrap().as_slice(),
+            [
+                (COLLECTION_CHANGE_ITEM_INSERTED, 0),
+                (COLLECTION_CHANGE_ITEM_CHANGED, 0),
+                (COLLECTION_CHANGE_ITEM_INSERTED, 0),
+                (COLLECTION_CHANGE_ITEM_REMOVED, 1),
+                (COLLECTION_CHANGE_RESET, 0),
+            ],
+        );
+
+        assert_eq!(
+            unsafe { ((*observable_vtable).remove_vector_changed)(observable.as_raw(), token,) },
+            S_OK,
+        );
+        let after_remove = uri("after-remove");
+        assert_eq!(
+            unsafe { ((*vector_vtable).append)(mutable.as_raw(), after_remove.as_raw(),) },
+            S_OK,
+        );
+        assert_eq!(changes.lock().unwrap().len(), 5);
+    }
+
+    #[test]
+    fn test_observable_vector_allows_reentrant_unsubscribe_and_mutation() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicI64, AtomicUsize, Ordering},
+        };
+
+        use windows::Win32::System::WinRT::{RO_INIT_MULTITHREADED, RoInitialize};
+
+        let _ = unsafe { RoInitialize(RO_INIT_MULTITHREADED) };
+        let table = MetadataTable::new();
+        let iids = table.vector_iids(&table.object());
+        let vector = create_vector(Vec::new(), iids.clone());
+        let mut observable_ptr = std::ptr::null_mut();
+        let mut vector_ptr = std::ptr::null_mut();
+        unsafe {
+            vector
+                .query(&iids.observable_vector, &mut observable_ptr)
+                .ok()
+                .unwrap();
+            vector.query(&iids.vector, &mut vector_ptr).ok().unwrap();
+        }
+        let observable = unsafe { IUnknown::from_raw(observable_ptr) };
+        let mutable = unsafe { IUnknown::from_raw(vector_ptr) };
+        let observable_raw = observable.as_raw() as usize;
+        let vector_raw = mutable.as_raw() as usize;
+        let token = Arc::new(AtomicI64::new(0));
+        let callback_token = token.clone();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let callback_calls = calls.clone();
+        let reentrant_item =
+            windows::Foundation::Uri::CreateUri(windows_core::h!("https://example.com/reentrant"))
+                .unwrap()
+                .cast::<IUnknown>()
+                .unwrap();
+        let reentrant_raw = reentrant_item.as_raw() as usize;
+        let handler = crate::delegate::create_delegate(
+            iids.vector_changed_handler,
+            vec![
+                table.object(),
+                table.interface(IID_IVECTOR_CHANGED_EVENT_ARGS),
+            ],
+            Box::new(move |_args| {
+                callback_calls.fetch_add(1, Ordering::SeqCst);
+                let observable_ptr = observable_raw as *mut c_void;
+                let observable_vtable =
+                    unsafe { *(observable_ptr as *const *const ObservableVectorVtbl) };
+                assert_eq!(
+                    unsafe {
+                        ((*observable_vtable).remove_vector_changed)(
+                            observable_ptr,
+                            callback_token.load(Ordering::SeqCst),
+                        )
+                    },
+                    S_OK,
+                );
+
+                let vector_ptr = vector_raw as *mut c_void;
+                let vector_vtable = unsafe { *(vector_ptr as *const *const VectorVtbl) };
+                assert_eq!(
+                    unsafe { ((*vector_vtable).append)(vector_ptr, reentrant_raw as *mut c_void,) },
+                    S_OK,
+                );
+                S_OK
+            }),
+        );
+        let observable_vtable =
+            unsafe { *(observable.as_raw() as *const *const ObservableVectorVtbl) };
+        let mut raw_token = 0i64;
+        assert_eq!(
+            unsafe {
+                ((*observable_vtable).add_vector_changed)(
+                    observable.as_raw(),
+                    handler.as_raw(),
+                    &mut raw_token,
+                )
+            },
+            S_OK,
+        );
+        token.store(raw_token, Ordering::SeqCst);
+
+        let initial =
+            windows::Foundation::Uri::CreateUri(windows_core::h!("https://example.com/initial"))
+                .unwrap()
+                .cast::<IUnknown>()
+                .unwrap();
+        let vector_vtable = unsafe { *(mutable.as_raw() as *const *const VectorVtbl) };
+        assert_eq!(
+            unsafe { ((*vector_vtable).append)(mutable.as_raw(), initial.as_raw(),) },
+            S_OK,
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let mut size = 0u32;
+        assert_eq!(
+            unsafe { ((*vector_vtable).get_size)(mutable.as_raw(), &mut size,) },
+            S_OK,
+        );
+        assert_eq!(size, 2);
+    }
+
+    #[test]
     fn test_vector_iid_computation() {
+        use windows::Foundation::Collections::{IObservableVector, VectorChangedEventHandler};
+        use windows_core::HSTRING;
+
         let table = MetadataTable::new();
 
         // IVector<String> IID should match the known PIID computation
@@ -967,6 +1394,13 @@ mod tests {
         assert_ne!(iids.iterable, GUID::zeroed());
         assert_ne!(iids.vector, GUID::zeroed());
         assert_ne!(iids.vector_view, GUID::zeroed());
+        assert_ne!(iids.observable_vector, GUID::zeroed());
+        assert_ne!(iids.vector_changed_handler, GUID::zeroed());
+        assert_eq!(iids.observable_vector, IObservableVector::<HSTRING>::IID,);
+        assert_eq!(
+            iids.vector_changed_handler,
+            VectorChangedEventHandler::<HSTRING>::IID,
+        );
         assert_ne!(iids.iterator, GUID::zeroed());
 
         // All should be different from each other

--- a/tools/dynwinrt-codegen/npm/README.md
+++ b/tools/dynwinrt-codegen/npm/README.md
@@ -66,8 +66,12 @@ For each WinRT class, the codegen emits:
 - **JavaScript constructors** for unambiguous public default, factory, and composable activations
 - **The original factory methods** (`.create(...)`, `.createInstance(...)`) for compatibility
 - **An interface registration** (`DynWinRtType.registerInterface()`) wired to the COM vtable
+- **A JavaScript-backed `IElementFactory.create()` helper** for WinUI
+  ItemsRepeater realization and recycling
 - **`IAsyncOperation<T>` awaitables** with `.progress(cb)` for streaming results
 - **Generic collections** (`IVector<T>`, `IMap<K,V>`, `IIterable<T>`)
+- **Creatable observable vectors** that expose both `IObservableVector<T>`
+  events and `IVector<T>` mutation helpers
 - **Structs** with `pack`/`unpack` helpers
 - **Enums** (`Object.freeze`'d in JS, `enum` in `.d.ts`)
 - **Delegate types** (IID + parameter signatures) for event handlers

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/collections.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/collections.rs
@@ -510,6 +510,7 @@ pub(super) fn project_collection_create(
     iface: &InterfaceMeta,
     known_types: &HashSet<String>,
     members: &mut Vec<ProjectedMember>,
+    imports: &mut Vec<ProjectedImport>,
 ) {
     let Some(ref piid) = iface.generic_piid else {
         return;
@@ -538,6 +539,54 @@ pub(super) fn project_collection_create(
             sync_return_expr: Some(format!(
                 "new {}(DynWinRtValue.createVector(items.map(i => _unwrap(i)), {}))",
                 iface.name, elem_type
+            )),
+            async_convert_v: None,
+            is_void: false,
+            array_return_expr: None,
+            delegate_wraps: vec![],
+            progress_convert: None,
+            js_only: false,
+            overload_of: None,
+        }));
+    } else if piid == PIID_IOBSERVABLE_VECTOR && iface.generic_args.len() == 1 {
+        let elem_type = ts_dynwinrt_type(&iface.generic_args[0]);
+        let elem_ts = ts_param_type_safe(&iface.generic_args[0], known_types);
+        let vector_name = iface.name.replacen("IObservableVector", "IVector", 1);
+        imports.push(ProjectedImport {
+            symbols: vec![vector_name.clone()],
+            from: format!("./{}.js", vector_name),
+            runtime_only: false,
+            dts_only: false,
+            is_runtime_package: false,
+        });
+        members.push(ProjectedMember::Method(ProjectedMethod {
+            name: "create".into(),
+            doc: Some(DocInfo {
+                summary: Some(
+                    "Create an observable mutable vector from an array of items."
+                        .into(),
+                ),
+                deprecated: None,
+                returns: None,
+                params: vec![],
+            }),
+            params: vec![ProjectedParam {
+                name: "items".into(),
+                ts_type: format!("{}[]", elem_ts),
+                optional: false,
+                delegate_wrap: None,
+            }],
+            return_type: format!(
+                "{} & {}",
+                iface.name, vector_name,
+            ),
+            async_kind: AsyncKind::None,
+            is_static: true,
+            invoke_expr: String::new(),
+            sync_return_expr: Some(format!(
+                "(() => {{ const value = DynWinRtValue.createVector(items.map(i => _unwrap(i)), {elem_type}); const observable = new {observable}(value); const vector = new ((__load_{vector}()).{vector})(value); Object.defineProperties(vector, {{ onVectorChanged: {{ value: observable.onVectorChanged.bind(observable) }}, onceVectorChanged: {{ value: observable.onceVectorChanged.bind(observable) }}, offVectorChanged: {{ value: observable.offVectorChanged.bind(observable) }} }}); return vector; }})()",
+                observable = iface.name,
+                vector = vector_name,
             )),
             async_convert_v: None,
             is_void: false,

--- a/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/project/mod.rs
@@ -64,6 +64,7 @@ use structs::project_struct_helpers;
 // ======================================================================
 const PIID_IVECTOR: &str = "913337e9-11a1-4345-a3a2-4e7f956e222d";
 const PIID_IVECTOR_VIEW: &str = "bbe1fa4c-b0e3-4583-baef-1f1b2e483e56";
+const PIID_IOBSERVABLE_VECTOR: &str = "5917eb53-50b4-4a0d-b309-65862b3f1dbc";
 const PIID_IITERATOR: &str = "6a79e863-4300-459a-9966-cbb660963ee1";
 const PIID_IITERABLE: &str = "faa585ea-6214-4217-afda-7f46de5869b3";
 const PIID_IMAP: &str = "3c2925fe-8519-45c1-aa79-197b6718c1c1";
@@ -1064,7 +1065,58 @@ pub fn project_interface(
     project_collection_helpers(iface, known_types, &mut members, &mut imports, "this._obj");
 
     // Static create() for IVector / IMap
-    project_collection_create(iface, known_types, &mut members);
+    project_collection_create(iface, known_types, &mut members, &mut imports);
+
+    if iface.name == "IElementFactory" {
+        imports[0].symbols.push("DynWinRtElementFactory".into());
+        members.push(ProjectedMember::Method(ProjectedMethod {
+            name: "create".into(),
+            doc: Some(DocInfo {
+                summary: Some(
+                    "Create an IElementFactory backed by synchronous JavaScript callbacks.".into(),
+                ),
+                deprecated: None,
+                returns: None,
+                params: vec![],
+            }),
+            params: vec![
+                ProjectedParam {
+                    name: "getElement".into(),
+                    ts_type:
+                        "(args: ElementFactoryGetArgs) => UIElement"
+                            .into(),
+                    optional: false,
+                    delegate_wrap: None,
+                },
+                ProjectedParam {
+                    name: "recycleElement".into(),
+                    ts_type:
+                        "(args: ElementFactoryRecycleArgs) => void"
+                            .into(),
+                    optional: false,
+                    delegate_wrap: None,
+                },
+            ],
+            return_type: format!(
+                "{} & {{ releaseCallbacks(): void }}",
+                iface.name,
+            ),
+            async_kind: AsyncKind::None,
+            is_static: true,
+            invoke_expr: String::new(),
+            sync_return_expr: Some(format!(
+                "(() => {{ const elements = new Map(); const implementation = DynWinRtElementFactory.create((args) => {{ const element = getElement((__get_ElementFactoryGetArgs())._fromNative(args)); const nativeElement = _unwrap(element).cast((__load_UIElement()).IID_UIElement); elements.set(nativeElement.asRaw(), element); return nativeElement; }}, (args) => {{ const projectedArgs = (__get_ElementFactoryRecycleArgs())._fromNative(args); const projectedElement = projectedArgs.element; const identity = _unwrap(projectedElement).asRaw(); const element = elements.get(identity) ?? projectedElement; elements.delete(identity); const recycleArgs = Object.create(projectedArgs); Object.defineProperty(recycleArgs, 'element', {{ value: element }}); recycleElement(recycleArgs); }}); const factory = new {0}(implementation.toValue()); Object.defineProperty(factory, 'releaseCallbacks', {{ value: () => implementation.releaseCallbacks() }}); return factory; }})()",
+                iface.name,
+            )),
+            async_convert_v: None,
+            is_void: false,
+            array_return_expr: None,
+            delegate_wraps: vec![],
+            progress_convert: None,
+            js_only: false,
+            overload_of: None,
+        }));
+    }
 
     let has_parameterized_cast = iface.generic_piid.is_some();
     let needs_unwrap = check_needs_unwrap_simple(&members);
@@ -1153,6 +1205,11 @@ pub fn project_delegate(
                 .collect()
         })
         .unwrap_or_default();
+    let iid_arg_exprs: Vec<String> = if iface.generic_args.is_empty() {
+        param_exprs.clone()
+    } else {
+        iface.generic_args.iter().map(ts_dynwinrt_type).collect()
+    };
 
     let iid_rhs =
         if !iface.iid.is_empty() && iface.generic_args.is_empty() && iface.generic_piid.is_none() {
@@ -1161,7 +1218,7 @@ pub fn project_delegate(
             format!(
                 "DynWinRtType.parameterized(WinGuid.parse('{}'), [{}]).iid()",
                 iface.iid,
-                param_exprs.join(", ")
+                iid_arg_exprs.join(", ")
             )
         } else {
             "undefined".into()

--- a/tools/dynwinrt-codegen/tests/element_factory_test.rs
+++ b/tools/dynwinrt-codegen/tests/element_factory_test.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::{HashMap, HashSet};
+
+use dynwinrt_codegen::codegen::{project, render_dts, render_js};
+use dynwinrt_codegen::meta::{InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
+use dynwinrt_codegen::types::TypeMeta;
+
+#[test]
+fn element_factory_projects_js_callback_constructor() {
+    let get_args = TypeMeta::RuntimeClass {
+        namespace: "Microsoft.UI.Xaml".into(),
+        name: "ElementFactoryGetArgs".into(),
+        default_interface: None,
+    };
+    let recycle_args = TypeMeta::RuntimeClass {
+        namespace: "Microsoft.UI.Xaml".into(),
+        name: "ElementFactoryRecycleArgs".into(),
+        default_interface: None,
+    };
+    let ui_element = TypeMeta::RuntimeClass {
+        namespace: "Microsoft.UI.Xaml".into(),
+        name: "UIElement".into(),
+        default_interface: None,
+    };
+    let interface = InterfaceMeta {
+        name: "IElementFactory".into(),
+        namespace: "Microsoft.UI.Xaml".into(),
+        iid: "75faba47-2cf2-54ae-91e6-0581556fddaa".into(),
+        methods: vec![
+            MethodMeta {
+                name: "GetElement".into(),
+                raw_name: "GetElement".into(),
+                vtable_index: 6,
+                params: vec![ParamMeta {
+                    name: "args".into(),
+                    typ: get_args,
+                    direction: ParamDirection::In,
+                }],
+                return_type: Some(ui_element),
+                ..Default::default()
+            },
+            MethodMeta {
+                name: "RecycleElement".into(),
+                raw_name: "RecycleElement".into(),
+                vtable_index: 7,
+                params: vec![ParamMeta {
+                    name: "args".into(),
+                    typ: recycle_args,
+                    direction: ParamDirection::In,
+                }],
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let known_types = HashSet::from([
+        "IElementFactory".into(),
+        "ElementFactoryGetArgs".into(),
+        "ElementFactoryRecycleArgs".into(),
+        "UIElement".into(),
+    ]);
+    let projected = project::project_interface(
+        &interface,
+        &known_types,
+        &HashSet::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+
+    assert!(js.contains("DynWinRtElementFactory.create"));
+    assert!(js.contains("const elements = new Map()"));
+    assert!(js.contains("cast((__load_UIElement()).IID_UIElement)"));
+    assert!(js.contains("Object.defineProperty(recycleArgs, 'element'"));
+    assert!(js.contains("ElementFactoryGetArgs"));
+    assert!(js.contains("ElementFactoryRecycleArgs"));
+    assert!(dts.contains(
+        "static create(getElement: (args: ElementFactoryGetArgs) => UIElement, recycleElement: (args: ElementFactoryRecycleArgs) => void): IElementFactory & { releaseCallbacks(): void };",
+    ));
+}

--- a/tools/dynwinrt-codegen/tests/observable_vector_test.rs
+++ b/tools/dynwinrt-codegen/tests/observable_vector_test.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::{HashMap, HashSet};
+
+use dynwinrt_codegen::codegen::{project, render_dts, render_js};
+use dynwinrt_codegen::meta::{InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
+use dynwinrt_codegen::types::TypeMeta;
+
+#[test]
+fn observable_vector_projects_mutable_create_helper() {
+    let interface = InterfaceMeta {
+        name: "IObservableVector_Object".into(),
+        namespace: "Windows.Foundation.Collections".into(),
+        iid: String::new(),
+        generic_piid: Some("5917eb53-50b4-4a0d-b309-65862b3f1dbc".into()),
+        generic_args: vec![TypeMeta::Object],
+        ..Default::default()
+    };
+    let projected = project::project_interface(
+        &interface,
+        &HashSet::from(["IObservableVector_Object".into(), "IVector_Object".into()]),
+        &HashSet::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+
+    assert!(js.contains("DynWinRtValue.createVector"));
+    assert!(
+        js.contains("new ((__load_IVector_Object()).IVector_Object)(value)",),
+        "{js}",
+    );
+    assert!(js.contains("onVectorChanged"));
+    assert!(dts.contains(
+        "static create(items: unknown[]): IObservableVector_Object & IVector_Object;",
+    ));
+}
+
+#[test]
+fn generic_delegate_iid_uses_declared_type_arguments() {
+    let interface = InterfaceMeta {
+        name: "VectorChangedEventHandler_Object".into(),
+        namespace: "Windows.Foundation.Collections".into(),
+        iid: "0c051752-9fbf-4c70-aa0c-0e4c82d9a761".into(),
+        generic_args: vec![TypeMeta::Object],
+        methods: vec![MethodMeta {
+            name: "Invoke".into(),
+            raw_name: "Invoke".into(),
+            vtable_index: 3,
+            params: vec![
+                ParamMeta {
+                    name: "sender".into(),
+                    typ: TypeMeta::Object,
+                    direction: ParamDirection::In,
+                },
+                ParamMeta {
+                    name: "args".into(),
+                    typ: TypeMeta::Interface {
+                        namespace: "Windows.Foundation.Collections".into(),
+                        name: "IVectorChangedEventArgs".into(),
+                        iid: "575933df-34fe-4480-af15-07691f3d5d9b".into(),
+                    },
+                    direction: ParamDirection::In,
+                },
+            ],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let projected = project::project_delegate(&interface, &HashMap::new(), &HashMap::new());
+    let js = render_js::render(&projected);
+
+    assert!(js.contains(
+        "DynWinRtType.parameterized(WinGuid.parse('0c051752-9fbf-4c70-aa0c-0e4c82d9a761'), [DynWinRtType.object()]).iid()",
+    ));
+    assert!(js.contains(
+        "VectorChangedEventHandler_Object_PARAM_TYPES = [DynWinRtType.object(), DynWinRtType.interface(",
+    ));
+}


### PR DESCRIPTION
## Summary

- Add a native `IElementFactory` COM bridge backed by synchronous JavaScript `getElement` and `recycleElement` callbacks.
- Return the correct `IUIElement` interface and preserve projected wrapper identity across recycling.
- Add explicit `releaseCallbacks()` lifecycle management.
- Extend `createVector()` with `IObservableVector<T>` support.
- Emit standard `VectorChanged` notifications for insert, remove, replace, and reset operations.
- Support reentrant mutation and unsubscription during notifications.
- Generate `IElementFactory.create()` and mutable `IObservableVector<T>.create()` helpers.
- Fix generic delegate IID generation to use declared generic arguments.