### PR TITLE
Fix delegate wrapping for overloaded JavaScript methods

### DIFF
--- a/tools/dynwinrt-codegen/src/codegen/javascript/render/javascript/helpers.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/render/javascript/helpers.rs
@@ -122,6 +122,50 @@ pub(super) fn inject_unwrap(code: String) -> String {
     }
 }
 
+pub(super) fn emit_delegate_wraps(out: &mut String, method: &ProjectedMethod) {
+    for (param_name, delegate_name) in &method.delegate_wraps {
+        let needs_wrap = method
+            .params
+            .iter()
+            .find(|p| &p.name == param_name)
+            .and_then(|p| p.delegate_wrap.as_ref())
+            .map(|dw| {
+                dw.param_wraps
+                    .iter()
+                    .enumerate()
+                    .any(|(i, wrap)| *wrap != format!("__a{}__", i))
+            })
+            .unwrap_or(false);
+        if needs_wrap {
+            let wrap = method
+                .params
+                .iter()
+                .find(|p| &p.name == param_name)
+                .and_then(|p| p.delegate_wrap.as_ref())
+                .unwrap();
+            let arg_vars: Vec<String> = (0..wrap.param_wraps.len())
+                .map(|i| format!("__a{}__", i))
+                .collect();
+            out.push_str(&format!(
+                "        const _{}_wrapped = ({}) => {}({});\n",
+                param_name,
+                arg_vars.join(", "),
+                param_name,
+                wrap.param_wraps.join(", ")
+            ));
+            out.push_str(&format!(
+                "        const _{}_d = DynWinRtDelegate.create(IID_{}, {}_PARAM_TYPES, _{}_wrapped).toValue();\n",
+                param_name, delegate_name, delegate_name, param_name
+            ));
+        } else {
+            out.push_str(&format!(
+                "        const _{}_d = DynWinRtDelegate.create(IID_{}, {}_PARAM_TYPES, {}).toValue();\n",
+                param_name, delegate_name, delegate_name, param_name
+            ));
+        }
+    }
+}
+
 /// Generate a JS dispatcher for same-class overloads (from OverloadAttribute).
 /// Emits internal `_methodName__N` implementations and a public dispatcher.
 pub(super) fn render_same_class_overload_js(
@@ -152,6 +196,7 @@ pub(super) fn render_same_class_overload_js(
             "    {}{}{}({}) {{\n",
             static_kw, async_kw, internal_name, params_str
         ));
+        emit_delegate_wraps(out, method);
         match &method.async_kind {
             AsyncKind::None => {
                 if let Some(ref arr_expr) = method.array_return_expr {
@@ -341,46 +386,7 @@ pub(super) fn render_overload_dispatcher_js(
 
     // Fall through to original method body
     // Re-render the original method body inline (skip the signature, we already emitted it)
-    for (param_name, delegate_name) in &main_method.delegate_wraps {
-        let needs_wrap = main_method
-            .params
-            .iter()
-            .find(|p| &p.name == param_name)
-            .and_then(|p| p.delegate_wrap.as_ref())
-            .map(|dw| {
-                dw.param_wraps
-                    .iter()
-                    .enumerate()
-                    .any(|(i, w)| *w != format!("__a{}__", i))
-            })
-            .unwrap_or(false);
-        if needs_wrap {
-            let dw = main_method
-                .params
-                .iter()
-                .find(|p| &p.name == param_name)
-                .and_then(|p| p.delegate_wrap.as_ref())
-                .unwrap();
-            let arg_vars: Vec<String> = (0..dw.param_wraps.len())
-                .map(|i| format!("__a{}__", i))
-                .collect();
-            let args_str = arg_vars.join(", ");
-            let wraps_str = dw.param_wraps.join(", ");
-            out.push_str(&format!(
-                "        const _{}_wrapped = ({}) => {}({});\n",
-                param_name, args_str, param_name, wraps_str
-            ));
-            out.push_str(&format!(
-                "        const _{}_d = DynWinRtDelegate.create(IID_{}, {}_PARAM_TYPES, _{}_wrapped).toValue();\n",
-                param_name, delegate_name, delegate_name, param_name
-            ));
-        } else {
-            out.push_str(&format!(
-                "        const _{}_d = DynWinRtDelegate.create(IID_{}, {}_PARAM_TYPES, {}).toValue();\n",
-                param_name, delegate_name, delegate_name, param_name
-            ));
-        }
-    }
+    emit_delegate_wraps(out, main_method);
     match &main_method.async_kind {
         AsyncKind::None => {
             if let Some(ref arr_expr) = main_method.array_return_expr {

--- a/tools/dynwinrt-codegen/src/codegen/javascript/render/javascript/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/javascript/render/javascript/mod.rs
@@ -15,8 +15,8 @@ use crate::codegen::javascript::signature::ref_marker;
 
 use commonjs::convert_to_cjs_with_lazy;
 use helpers::{
-    emit_abortable_async_body, emit_with_progress_body, inject_unwrap, render_jsdoc,
-    render_overload_dispatcher_js, render_same_class_overload_js,
+    emit_abortable_async_body, emit_delegate_wraps, emit_with_progress_body, inject_unwrap,
+    render_jsdoc, render_overload_dispatcher_js, render_same_class_overload_js,
 };
 
 /// Render a projected file as CJS with lazy sibling requires.
@@ -410,48 +410,7 @@ fn render_member_js(out: &mut String, member: &ProjectedMember, _class_name: &st
                 static_kw, async_kw, method.name, params_str
             ));
 
-            // Wrap delegate params before invoke
-            for (param_name, delegate_name) in &method.delegate_wraps {
-                // Find param_wraps from the corresponding ProjectedParam
-                let needs_wrap = method
-                    .params
-                    .iter()
-                    .find(|p| &p.name == param_name)
-                    .and_then(|p| p.delegate_wrap.as_ref())
-                    .map(|dw| {
-                        dw.param_wraps
-                            .iter()
-                            .enumerate()
-                            .any(|(i, w)| *w != format!("__a{}__", i))
-                    })
-                    .unwrap_or(false);
-                if needs_wrap {
-                    let dw = method
-                        .params
-                        .iter()
-                        .find(|p| &p.name == param_name)
-                        .and_then(|p| p.delegate_wrap.as_ref())
-                        .unwrap();
-                    let arg_vars: Vec<String> = (0..dw.param_wraps.len())
-                        .map(|i| format!("__a{}__", i))
-                        .collect();
-                    let args_str = arg_vars.join(", ");
-                    let wraps_str = dw.param_wraps.join(", ");
-                    out.push_str(&format!(
-                        "        const _{}_wrapped = ({}) => {}({});\n",
-                        param_name, args_str, param_name, wraps_str
-                    ));
-                    out.push_str(&format!(
-                        "        const _{}_d = DynWinRtDelegate.create(IID_{}, {}_PARAM_TYPES, _{}_wrapped).toValue();\n",
-                        param_name, delegate_name, delegate_name, param_name
-                    ));
-                } else {
-                    out.push_str(&format!(
-                        "        const _{}_d = DynWinRtDelegate.create(IID_{}, {}_PARAM_TYPES, {}).toValue();\n",
-                        param_name, delegate_name, delegate_name, param_name
-                    ));
-                }
-            }
+            emit_delegate_wraps(out, method);
 
             match &method.async_kind {
                 AsyncKind::None => {

--- a/tools/dynwinrt-codegen/tests/delegate_overload_test.rs
+++ b/tools/dynwinrt-codegen/tests/delegate_overload_test.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use dynwinrt_codegen::codegen::{project, render_js};
+use dynwinrt_codegen::meta;
+use dynwinrt_codegen::types::TypeMeta;
+
+const WINDOWS_WINMD: &str =
+    r"C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.26100.0\Windows.winmd";
+
+#[test]
+fn delegate_overloads_emit_local_delegate_values() {
+    if !Path::new(WINDOWS_WINMD).exists() {
+        eprintln!("Skipping: Windows.winmd not found");
+        return;
+    }
+
+    let Some(dispatcher_queue) =
+        meta::parse_class(WINDOWS_WINMD, "Windows.System", "DispatcherQueue")
+    else {
+        panic!("DispatcherQueue metadata not found");
+    };
+
+    let roots = vec![dispatcher_queue];
+    let deps = meta::resolve_dependencies(WINDOWS_WINMD, &roots, &[], &[]);
+    let mut classes = roots;
+    classes.extend(deps.classes);
+    let interfaces = deps.interfaces;
+
+    let mut known_types = HashSet::new();
+    for class in &classes {
+        known_types.insert(class.name.clone());
+    }
+    for interface in &interfaces {
+        known_types.insert(interface.name.clone());
+    }
+    for en in &deps.enums {
+        if let TypeMeta::Enum { name, .. } = en {
+            known_types.insert(name.clone());
+        }
+    }
+
+    let delegate_type_names: HashSet<String> = interfaces
+        .iter()
+        .filter(|interface| {
+            interface
+                .methods
+                .iter()
+                .any(|method| method.name == ".ctor")
+                && interface
+                    .methods
+                    .iter()
+                    .any(|method| method.name == "Invoke")
+        })
+        .map(|interface| interface.name.clone())
+        .collect();
+    let (delegate_sigs, delegate_sig_refs, delegate_param_wraps) =
+        project::build_delegate_signatures(&interfaces, &delegate_type_names, &known_types);
+
+    let class = classes
+        .iter()
+        .find(|class| class.name == "DispatcherQueue")
+        .expect("DispatcherQueue missing after dependency resolution");
+    let projected = project::project_class(
+        class,
+        &known_types,
+        &delegate_type_names,
+        &HashSet::new(),
+        &delegate_sigs,
+        &delegate_sig_refs,
+        &delegate_param_wraps,
+    );
+    let js = render_js::render(&projected);
+
+    assert_eq!(
+        js.matches("const _callback_d = DynWinRtDelegate.create(")
+            .count(),
+        2,
+        "Each tryEnqueue overload must declare its callback delegate:\n{js}"
+    );
+    assert!(js.contains("_tryEnqueue_1(callback)"));
+    assert!(js.contains("_tryEnqueue_2(priority, callback)"));
+    assert!(js.contains("(callback == null ? DynWinRtValue.nullValue() : _callback_d)"));
+}


### PR DESCRIPTION

## Summary

- Emit delegate wrapper locals inside same-class overload implementations.
- Reuse the shared delegate-emission path for normal and overloaded methods.
- Add regression coverage using `Windows.System.DispatcherQueue`.