### PR TITLE
Centralize WinUI bootstrap policy in a shared codegen extension

### DIFF
--- a/PYTHON_CHECKLIST.md
+++ b/PYTHON_CHECKLIST.md
@@ -173,4 +173,6 @@ of a dynamic projection.
 22. [x] Add typed event arguments while preserving token subscriptions and adding
         idempotent unsubscribe helpers.
 23. [x] Project public composable constructors and reject protected composition.
-24. [x] Add an experimental, typed WinUI `Application` bootstrap path.
+24. [x] Add an experimental, typed WinUI `Application` bootstrap path backed
+        by a shared `codegen/winrt/extensions/winui` spec consumed by both
+        JavaScript and Python projection.

--- a/tools/dynwinrt-codegen/src/codegen/winrt/extensions/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/extensions/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Optional framework-specific projections layered on the generic WinRT model.
+
+pub mod winui;

--- a/tools/dynwinrt-codegen/src/codegen/winrt/extensions/winui.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/extensions/winui.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Language-neutral policy for the optional WinUI `Application` bootstrap.
+//!
+//! This module describes which WinUI types and ABI facts are required. Language
+//! projectors remain responsible for rendering the helpers.
+
+use std::collections::HashSet;
+
+use crate::meta::ClassMeta;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WinUiClassRef {
+    pub namespace: &'static str,
+    pub name: &'static str,
+}
+
+impl WinUiClassRef {
+    pub const fn new(namespace: &'static str, name: &'static str) -> Self {
+        Self { namespace, name }
+    }
+
+    pub fn full_name(self) -> String {
+        format!("{}.{}", self.namespace, self.name)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WinUiAbiType {
+    Object,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WinUiBootstrapSpec {
+    pub application: WinUiClassRef,
+    pub metadata_provider: WinUiClassRef,
+    pub controls_resources: WinUiClassRef,
+    pub resource_manager: WinUiClassRef,
+    pub launched_callback_iid: &'static str,
+    pub launched_callback_params: &'static [WinUiAbiType],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedWinUiBootstrap {
+    pub spec: &'static WinUiBootstrapSpec,
+    pub supports_unpackaged_resources: bool,
+}
+
+const LAUNCHED_CALLBACK_PARAMS: &[WinUiAbiType] = &[WinUiAbiType::Object];
+
+pub const APPLICATION_BOOTSTRAP: WinUiBootstrapSpec = WinUiBootstrapSpec {
+    application: WinUiClassRef::new("Microsoft.UI.Xaml", "Application"),
+    metadata_provider: WinUiClassRef::new(
+        "Microsoft.UI.Xaml.XamlTypeInfo",
+        "XamlControlsXamlMetaDataProvider",
+    ),
+    controls_resources: WinUiClassRef::new("Microsoft.UI.Xaml.Controls", "XamlControlsResources"),
+    resource_manager: WinUiClassRef::new(
+        "Microsoft.Windows.ApplicationModel.Resources",
+        "ResourceManager",
+    ),
+    launched_callback_iid: "f81c4e72-7a18-4a30-9126-6f62b6bdac83",
+    launched_callback_params: LAUNCHED_CALLBACK_PARAMS,
+};
+
+pub fn is_application(class: &ClassMeta) -> bool {
+    class.full_name == APPLICATION_BOOTSTRAP.application.full_name()
+}
+
+pub fn resolve_application_bootstrap(
+    class: &ClassMeta,
+    known_types: &HashSet<String>,
+) -> Option<ResolvedWinUiBootstrap> {
+    let spec = &APPLICATION_BOOTSTRAP;
+    (is_application(class)
+        && known_types.contains(&spec.metadata_provider.full_name())
+        && known_types.contains(&spec.controls_resources.full_name()))
+    .then(|| ResolvedWinUiBootstrap {
+        spec,
+        supports_unpackaged_resources: known_types.contains(&spec.resource_manager.full_name()),
+    })
+}
+
+pub fn add_implicit_classes(winmd: &str, classes: &mut Vec<ClassMeta>) {
+    let spec = &APPLICATION_BOOTSTRAP;
+    if !classes.iter().any(is_application) {
+        return;
+    }
+
+    for reference in [
+        spec.metadata_provider,
+        spec.controls_resources,
+        spec.resource_manager,
+    ] {
+        let full_name = reference.full_name();
+        if classes.iter().any(|class| class.full_name == full_name) {
+            continue;
+        }
+        if let Some(class) = crate::meta::parse_class(winmd, reference.namespace, reference.name) {
+            classes.push(class);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_only_when_required_types_are_available() {
+        let application = ClassMeta {
+            full_name: APPLICATION_BOOTSTRAP.application.full_name(),
+            ..Default::default()
+        };
+        let required = HashSet::from([
+            APPLICATION_BOOTSTRAP.metadata_provider.full_name(),
+            APPLICATION_BOOTSTRAP.controls_resources.full_name(),
+        ]);
+
+        let resolved = resolve_application_bootstrap(&application, &required)
+            .expect("bootstrap should resolve");
+        assert!(!resolved.supports_unpackaged_resources);
+        assert_eq!(
+            resolved.spec.launched_callback_params,
+            &[WinUiAbiType::Object]
+        );
+
+        let mut unpackaged = required;
+        unpackaged.insert(APPLICATION_BOOTSTRAP.resource_manager.full_name());
+        assert!(
+            resolve_application_bootstrap(&application, &unpackaged)
+                .expect("bootstrap should resolve")
+                .supports_unpackaged_resources
+        );
+    }
+
+    #[test]
+    fn does_not_resolve_for_other_classes_or_missing_dependencies() {
+        let other = ClassMeta {
+            full_name: "Contoso.Application".into(),
+            ..Default::default()
+        };
+        assert!(resolve_application_bootstrap(&other, &HashSet::new()).is_none());
+
+        let application = ClassMeta {
+            full_name: APPLICATION_BOOTSTRAP.application.full_name(),
+            ..Default::default()
+        };
+        assert!(resolve_application_bootstrap(&application, &HashSet::new()).is_none());
+    }
+
+    #[test]
+    fn unrelated_short_resource_manager_name_does_not_enable_unpackaged_support() {
+        let application = ClassMeta {
+            full_name: APPLICATION_BOOTSTRAP.application.full_name(),
+            ..Default::default()
+        };
+        let known = HashSet::from([
+            APPLICATION_BOOTSTRAP.metadata_provider.full_name(),
+            APPLICATION_BOOTSTRAP.controls_resources.full_name(),
+            APPLICATION_BOOTSTRAP.resource_manager.name.to_string(),
+        ]);
+
+        assert!(
+            !resolve_application_bootstrap(&application, &known)
+                .expect("bootstrap should resolve")
+                .supports_unpackaged_resources
+        );
+    }
+}

--- a/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/constructors.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/constructors.rs
@@ -5,6 +5,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+use crate::codegen::winrt::extensions::winui;
 use crate::meta::{ConstructorKind, ConstructorMeta, InterfaceMeta, MethodMeta, ParamMeta};
 use crate::types::TypeMeta;
 
@@ -38,7 +39,7 @@ pub(super) fn project_constructor(
     delegate_sigs: &HashMap<String, String>,
     delegate_param_wraps: &HashMap<String, Vec<String>>,
 ) -> ProjectedConstructor {
-    if class.full_name == XAML_APPLICATION {
+    if winui::is_application(class) {
         return inaccessible_constructor(class);
     }
 

--- a/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/mod.rs
@@ -15,6 +15,7 @@ mod structs;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 
+use crate::codegen::winrt::extensions::winui::{self, WinUiAbiType};
 use crate::meta::{
     ClassMeta, InterfaceMeta, MethodMeta, PIID_IOBSERVABLE_VECTOR, PIID_IVECTOR, ParamDirection,
 };
@@ -71,11 +72,16 @@ const PIID_IMAP: &str = "3c2925fe-8519-45c1-aa79-197b6718c1c1";
 const PIID_IMAP_VIEW: &str = "e480ce40-a338-4ada-adcf-272272e48cb9";
 const ICLOSABLE_IID: &str = "30d5a829-7fa4-4026-83bb-d75bae4ea99e";
 const ISTRINGABLE_IID: &str = "96369f54-8eb6-48f0-abce-c1b211e627c3";
-const XAML_APPLICATION: &str = "Microsoft.UI.Xaml.Application";
-const XAML_METADATA_PROVIDER: &str = "XamlControlsXamlMetaDataProvider";
-const XAML_CONTROLS_RESOURCES: &str = "XamlControlsResources";
-const MRT_RESOURCE_MANAGER: &str = "ResourceManager";
-const XAML_LAUNCHED_CALLBACK_IID: &str = "f81c4e72-7a18-4a30-9126-6f62b6bdac83";
+
+fn project_winui_abi_types(types: &[WinUiAbiType]) -> String {
+    types
+        .iter()
+        .map(|typ| match typ {
+            WinUiAbiType::Object => "DynWinRtType.object()",
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 fn interface_iid_rhs(iface: &InterfaceMeta) -> Option<String> {
     if let Some(ref piid) = iface.generic_piid {
@@ -177,11 +183,9 @@ pub fn project_class(
     delegate_param_wraps: &HashMap<String, Vec<String>>,
 ) -> ProjectedFile {
     let used_structs = collect_used_structs_from_class(class);
-    let has_xaml_fluent_bootstrap = class.full_name == XAML_APPLICATION
-        && known_types.contains(XAML_METADATA_PROVIDER)
-        && known_types.contains(XAML_CONTROLS_RESOURCES);
+    let winui_bootstrap = winui::resolve_application_bootstrap(class, known_types);
     let supports_unpackaged_xaml =
-        has_xaml_fluent_bootstrap && known_types.contains(MRT_RESOURCE_MANAGER);
+        winui_bootstrap.is_some_and(|bootstrap| bootstrap.supports_unpackaged_resources);
 
     // Collect delegate names only from interfaces of THIS class (not the entire batch)
     // for delegate imports; but also include global delegate_type_names for type filtering
@@ -295,10 +299,11 @@ pub fn project_class(
         }
     }
 
-    if has_xaml_fluent_bootstrap {
-        let mut names = vec![XAML_METADATA_PROVIDER, XAML_CONTROLS_RESOURCES];
-        if supports_unpackaged_xaml {
-            names.push(MRT_RESOURCE_MANAGER);
+    if let Some(bootstrap) = winui_bootstrap {
+        let spec = bootstrap.spec;
+        let mut names = vec![spec.metadata_provider.name, spec.controls_resources.name];
+        if bootstrap.supports_unpackaged_resources {
+            names.push(spec.resource_manager.name);
         }
         for name in names {
             if imported_names.insert(name.into()) {
@@ -623,11 +628,13 @@ pub fn project_class(
         }
     }
 
-    if has_xaml_fluent_bootstrap {
-        let unpackaged_resource_setup = if supports_unpackaged_xaml {
+    if let Some(bootstrap) = winui_bootstrap {
+        let spec = bootstrap.spec;
+        let launched_callback_types = project_winui_abi_types(spec.launched_callback_params);
+        let unpackaged_resource_setup = if bootstrap.supports_unpackaged_resources {
             format!(
                 "if (!hasPackageIdentity()) {{ const _resourceManager = (__get_{resource_manager}()).createInstance(getWinappsdkResourcePriPath()); _app.onResourceManagerRequested((_sender, args) => {{ if (args === null) throw new Error('WinUI ResourceManagerRequested did not supply event arguments'); args.customResourceManager = _resourceManager; }}); }}",
-                resource_manager = MRT_RESOURCE_MANAGER,
+                resource_manager = spec.resource_manager.name,
             )
         } else {
             String::new()
@@ -650,7 +657,7 @@ pub fn project_class(
             params: vec![
                 ProjectedParam {
                     name: "metadataProvider".into(),
-                    ts_type: XAML_METADATA_PROVIDER.into(),
+                    ts_type: spec.metadata_provider.name.into(),
                     optional: false,
                     delegate_wrap: None,
                 },
@@ -667,8 +674,9 @@ pub fn project_class(
             is_static: true,
             invoke_expr: String::new(),
             sync_return_expr: Some(format!(
-                "(() => {{ const _launched = onLaunched == null ? null : DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], onLaunched).toValue(); return {class_name}._fromNative(DynWinRtValue.createXamlApplication(_unwrap(metadataProvider), _launched)); }})()",
-                callback_iid = XAML_LAUNCHED_CALLBACK_IID,
+                "(() => {{ const _launched = onLaunched == null ? null : DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [{callback_types}], onLaunched).toValue(); return {class_name}._fromNative(DynWinRtValue.createXamlApplication(_unwrap(metadataProvider), _launched)); }})()",
+                callback_iid = spec.launched_callback_iid,
+                callback_types = launched_callback_types,
                 class_name = class.name,
             )),
             async_convert_v: None,
@@ -706,10 +714,11 @@ pub fn project_class(
             is_static: true,
             invoke_expr: String::new(),
             sync_return_expr: Some(format!(
-                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [DynWinRtType.object()], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); const _app = {class_name}._fromNative(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); {unpackaged_resource_setup} return _app; }})()",
-                callback_iid = XAML_LAUNCHED_CALLBACK_IID,
-                provider = XAML_METADATA_PROVIDER,
-                resources = XAML_CONTROLS_RESOURCES,
+                "(() => {{ const _provider = (__get_{provider}()).create(); let _resourcesInitialized = false; const _launched = DynWinRtDelegate.create(WinGuid.parse('{callback_iid}'), [{callback_types}], () => {{ const _app = {class_name}.current; if (_app === null) throw new Error('WinUI Application.Current is unavailable during OnLaunched'); if (!_resourcesInitialized) {{ _app.resources.mergedDictionaries.append((__get_{resources}()).create()); _resourcesInitialized = true; }} onLaunched?.(); }}); const _app = {class_name}._fromNative(DynWinRtValue.createXamlApplication(_unwrap(_provider), _launched.toValue())); {unpackaged_resource_setup} return _app; }})()",
+                callback_iid = spec.launched_callback_iid,
+                callback_types = launched_callback_types,
+                provider = spec.metadata_provider.name,
+                resources = spec.controls_resources.name,
                 class_name = class.name,
             )),
             async_convert_v: None,
@@ -734,7 +743,7 @@ pub fn project_class(
                 delegate_sigs,
                 delegate_param_wraps,
             );
-            if class.full_name == XAML_APPLICATION && method.name == "Start" {
+            if winui::is_application(class) && method.name == "Start" {
                 if let ProjectedMember::Method(projected_method) = &projected {
                     let mut scheduled = projected_method.clone();
                     scheduled.name = "startScheduled".into();

--- a/tools/dynwinrt-codegen/src/codegen/winrt/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/mod.rs
@@ -3,6 +3,7 @@
 
 //! Windows Runtime code generation.
 
+pub mod extensions;
 pub mod javascript;
 pub mod python;
 pub(crate) mod shared;

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/class.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/class.rs
@@ -6,10 +6,21 @@
 use super::imports::{emit_type_checking_imports, format_py_type_import};
 use super::structs::generate_struct_helpers;
 use super::*;
+use crate::codegen::winrt::extensions::winui::{self, WinUiAbiType};
 use crate::codegen::winrt::python::collections::{
     CollectionKind, class_interface, interface_kind, map_iterable_name, runtime_mixin,
 };
 use crate::meta::{ConstructorKind, ParamMeta};
+
+fn project_winui_abi_types(types: &[WinUiAbiType]) -> String {
+    types
+        .iter()
+        .map(|typ| match typ {
+            WinUiAbiType::Object => "DynWinRTType.object()",
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
 
 /// Generate a Python file for a single RuntimeClass.
 pub fn generate_class(
@@ -21,6 +32,7 @@ pub fn generate_class(
     let used_structs = collect_used_structs_from_class(class);
     let collection_iface = class_interface(class);
     let collection_kind = collection_iface.and_then(interface_kind);
+    let winui_bootstrap = winui::resolve_application_bootstrap(class, known_types);
     let collection_uses_default = collection_iface.is_some_and(|collection_iface| {
         class
             .default_interface
@@ -382,30 +394,21 @@ pub fn generate_class(
         }
     }
 
-    // WinUI XAML Application fluent bootstrap. When we're generating
-    // Microsoft.UI.Xaml.Application and the sibling XAML types are also in
-    // scope, expose `create_with_metadata_provider(...)` and `create(...)`
-    // helpers that mirror the JS side.
-    const XAML_APPLICATION: &str = "Microsoft.UI.Xaml.Application";
-    const XAML_METADATA_PROVIDER: &str = "XamlControlsXamlMetaDataProvider";
-    const XAML_CONTROLS_RESOURCES: &str = "XamlControlsResources";
-    const MRT_RESOURCE_MANAGER: &str = "ResourceManager";
-    const XAML_LAUNCHED_CALLBACK_IID: &str = "f81c4e72-7a18-4a30-9126-6f62b6bdac83";
-    let has_xaml_fluent_bootstrap = class.full_name == XAML_APPLICATION
-        && known_types.contains(XAML_METADATA_PROVIDER)
-        && known_types.contains(XAML_CONTROLS_RESOURCES);
-    let supports_unpackaged_xaml =
-        has_xaml_fluent_bootstrap && known_types.contains(MRT_RESOURCE_MANAGER);
-    if has_xaml_fluent_bootstrap {
-        let metadata_module = to_snake_case_filename(XAML_METADATA_PROVIDER);
-        let resources_module = to_snake_case_filename(XAML_CONTROLS_RESOURCES);
-        let resource_manager_module = to_snake_case_filename(MRT_RESOURCE_MANAGER);
+    if let Some(bootstrap) = winui_bootstrap {
+        let spec = bootstrap.spec;
+        let metadata_provider = spec.metadata_provider.name;
+        let controls_resources = spec.controls_resources.name;
+        let resource_manager = spec.resource_manager.name;
+        let callback_types = project_winui_abi_types(spec.launched_callback_params);
+        let metadata_module = to_snake_case_filename(metadata_provider);
+        let resources_module = to_snake_case_filename(controls_resources);
+        let resource_manager_module = to_snake_case_filename(resource_manager);
 
         out.push('\n');
         out.push_str("    @staticmethod\n");
         out.push_str(&format!(
-            "    def create_with_metadata_provider(metadata_provider: '{XAML_METADATA_PROVIDER}', on_launched: Callable[[], object] | None = None) -> '{}':\n",
-            class.name
+            "    def create_with_metadata_provider(metadata_provider: '{metadata_provider}', on_launched: Callable[[], object] | None = None) -> '{}':\n",
+            class.name,
         ));
         out.push_str(
             "        \"\"\"Compose a WinUI `Application` that exposes the supplied XAML metadata provider.\n\
@@ -416,7 +419,8 @@ pub fn generate_class(
         out.push_str("        _launched = None\n");
         out.push_str("        if on_launched is not None:\n");
         out.push_str(&format!(
-            "            _launched = DynWinRtDelegate.create(WinGUID.parse('{XAML_LAUNCHED_CALLBACK_IID}'), [DynWinRTType.object()], lambda _args: on_launched()).to_value()\n",
+            "            _launched = DynWinRtDelegate.create(WinGUID.parse('{callback_iid}'), [{callback_types}], lambda _args: on_launched()).to_value()\n",
+            callback_iid = spec.launched_callback_iid,
         ));
         out.push_str(&format!(
             "        return {}._from_native(DynWinRTValue.create_xaml_application(getattr(metadata_provider, '_obj', metadata_provider), _launched))\n",
@@ -434,7 +438,7 @@ pub fn generate_class(
              and optionally configure unpackaged resource resolution before running `on_launched`.\"\"\"\n",
         );
         out.push_str(&format!(
-            "        _provider = _dynwinrt_symbol('{metadata_module}', '{XAML_METADATA_PROVIDER}').create()\n",
+            "        _provider = _dynwinrt_symbol('{metadata_module}', '{metadata_provider}').create()\n",
         ));
         out.push_str("        _resources_initialized = [False]\n");
         out.push_str("        def _on_launched_wrapped(_args):\n");
@@ -448,25 +452,26 @@ pub fn generate_class(
         );
         out.push_str("            if not _resources_initialized[0]:\n");
         out.push_str(&format!(
-            "                _app.resources.merged_dictionaries.append(_dynwinrt_symbol('{resources_module}', '{XAML_CONTROLS_RESOURCES}').create())\n",
+            "                _app.resources.merged_dictionaries.append(_dynwinrt_symbol('{resources_module}', '{controls_resources}').create())\n",
         ));
         out.push_str("                _resources_initialized[0] = True\n");
         out.push_str("            if on_launched is not None:\n");
         out.push_str("                on_launched()\n");
         out.push_str(&format!(
-            "        _launched = DynWinRtDelegate.create(WinGUID.parse('{XAML_LAUNCHED_CALLBACK_IID}'), [DynWinRTType.object()], _on_launched_wrapped).to_value()\n",
+            "        _launched = DynWinRtDelegate.create(WinGUID.parse('{callback_iid}'), [{callback_types}], _on_launched_wrapped).to_value()\n",
+            callback_iid = spec.launched_callback_iid,
         ));
         out.push_str(&format!(
             "        _app = {}._from_native(DynWinRTValue.create_xaml_application(getattr(_provider, '_obj', _provider), _launched))\n",
             class.name
         ));
-        if supports_unpackaged_xaml {
+        if bootstrap.supports_unpackaged_resources {
             out.push_str(
                 "        from dynwinrt_py import has_package_identity, get_winappsdk_resource_pri_path\n",
             );
             out.push_str("        if not has_package_identity():\n");
             out.push_str(&format!(
-                "            _resource_manager = _dynwinrt_symbol('{resource_manager_module}', '{MRT_RESOURCE_MANAGER}').create_instance(get_winappsdk_resource_pri_path())\n",
+                "            _resource_manager = _dynwinrt_symbol('{resource_manager_module}', '{resource_manager}').create_instance(get_winappsdk_resource_pri_path())\n",
             ));
             out.push_str("            def _on_resource_manager_requested(_sender, args):\n");
             out.push_str("                if args is None:\n");

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/stubs.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/stubs.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use crate::meta::{ClassMeta, InterfaceMeta, MethodMeta};
 use crate::types::{TypeKind, TypeMeta};
 
+use crate::codegen::winrt::extensions::winui;
 use crate::codegen::winrt::shared::imports::{
     collect_iface_type_imports, collect_type_imports, collect_used_generics_from_class,
     collect_used_generics_from_methods,
@@ -254,16 +255,10 @@ pub fn generate_class_stub(
     delegate_type_names: &HashSet<String>,
     shared_iids: &HashSet<String>,
 ) -> String {
-    const XAML_APPLICATION: &str = "Microsoft.UI.Xaml.Application";
-    const XAML_METADATA_PROVIDER: &str = "XamlControlsXamlMetaDataProvider";
-    const XAML_CONTROLS_RESOURCES: &str = "XamlControlsResources";
-
     let used_structs = collect_used_structs_from_class(class);
     let collection_iface = class_interface(class);
     let collection_kind = collection_iface.and_then(interface_kind);
-    let has_xaml_fluent_bootstrap = class.full_name == XAML_APPLICATION
-        && known_types.contains(XAML_METADATA_PROVIDER)
-        && known_types.contains(XAML_CONTROLS_RESOURCES);
+    let winui_bootstrap = winui::resolve_application_bootstrap(class, known_types);
     let has_events = class.all_interfaces().any(|iface| {
         iface
             .methods
@@ -282,7 +277,7 @@ pub fn generate_class_stub(
     ) {
         out.push_str(ASYNC_IMPORT_LINE);
     }
-    if has_events || has_xaml_fluent_bootstrap {
+    if has_events || winui_bootstrap.is_some() {
         out.push_str("from typing import Callable\n");
     }
     if !class.required_interfaces.is_empty() {
@@ -351,11 +346,12 @@ pub fn generate_class_stub(
             imported_names.insert(format!("IID_{}", req_iface.name));
         }
     }
-    if has_xaml_fluent_bootstrap {
+    if let Some(bootstrap) = winui_bootstrap {
+        let metadata_provider = bootstrap.spec.metadata_provider;
         out.push_str(&format!(
             "from .{} import {}  # noqa: F401\n",
-            to_snake_case_filename(XAML_METADATA_PROVIDER),
-            XAML_METADATA_PROVIDER
+            to_snake_case_filename(metadata_provider.name),
+            metadata_provider.name,
         ));
     }
     out.push('\n');
@@ -465,12 +461,13 @@ pub fn generate_class_stub(
         out.push_str(&format!("    def create() -> '{}': ...\n", class.name));
     }
 
-    if has_xaml_fluent_bootstrap {
+    if let Some(bootstrap) = winui_bootstrap {
+        let metadata_provider = bootstrap.spec.metadata_provider.name;
         out.push('\n');
         out.push_str("    @staticmethod\n");
         out.push_str(&format!(
-            "    def create_with_metadata_provider(metadata_provider: '{}', on_launched: Callable[[], object] | None = ...) -> '{}': ...\n",
-            XAML_METADATA_PROVIDER, class.name
+            "    def create_with_metadata_provider(metadata_provider: '{metadata_provider}', on_launched: Callable[[], object] | None = ...) -> '{}': ...\n",
+            class.name,
         ));
         out.push_str("    @staticmethod\n");
         out.push_str(&format!(

--- a/tools/dynwinrt-codegen/src/main.rs
+++ b/tools/dynwinrt-codegen/src/main.rs
@@ -11,6 +11,7 @@ use dynwinrt_codegen::codegen::com;
 use dynwinrt_codegen::codegen::package;
 use dynwinrt_codegen::codegen::python;
 use dynwinrt_codegen::codegen::typescript;
+use dynwinrt_codegen::codegen::winrt::extensions::winui;
 use dynwinrt_codegen::codegen::{project, render_dts, render_js};
 use dynwinrt_codegen::com_metadata;
 use dynwinrt_codegen::meta;
@@ -417,7 +418,7 @@ fn run() -> Result<(), String> {
                     }
                 }
 
-                add_implicit_js_types(&winmd, &lang, &mut classes);
+                winui::add_implicit_classes(&winmd, &mut classes);
                 generate_for_types(
                     &winmd,
                     output_dir,
@@ -569,7 +570,7 @@ fn run() -> Result<(), String> {
                     let mut classes = meta::parse_namespace(&winmd, ns);
                     let mut interfaces = meta::parse_interfaces(&winmd, ns);
                     let mut enums = meta::parse_enums(&winmd, ns);
-                    add_implicit_js_types(&winmd, &lang, &mut classes);
+                    winui::add_implicit_classes(&winmd, &mut classes);
                     for c in classes.iter_mut() {
                         doc_table.apply_to_class(c);
                     }
@@ -680,32 +681,6 @@ fn run() -> Result<(), String> {
     Ok(())
 }
 
-fn add_implicit_js_types(winmd: &str, lang: &str, classes: &mut Vec<meta::ClassMeta>) {
-    if !matches!(lang, "js" | "py")
-        || !classes
-            .iter()
-            .any(|class| class.full_name == "Microsoft.UI.Xaml.Application")
-    {
-        return;
-    }
-
-    for (namespace, name) in [
-        (
-            "Microsoft.UI.Xaml.XamlTypeInfo",
-            "XamlControlsXamlMetaDataProvider",
-        ),
-        ("Microsoft.UI.Xaml.Controls", "XamlControlsResources"),
-    ] {
-        let full_name = format!("{}.{}", namespace, name);
-        if classes.iter().any(|class| class.full_name == full_name) {
-            continue;
-        }
-        if let Some(class) = meta::parse_class(winmd, namespace, name) {
-            classes.push(class);
-        }
-    }
-}
-
 /// Generate files for a set of types plus their transitive dependencies.
 /// When `dry_run` is true, all parsing/resolution runs but no files are written.
 fn generate_for_types(
@@ -757,14 +732,20 @@ fn generate_for_types(
     let mut known_types: HashSet<String> = HashSet::new();
     for c in &all_classes {
         known_types.insert(c.name.clone());
+        known_types.insert(c.full_name.clone());
     }
     for i in &emittable_interfaces {
         known_types.insert(i.name.clone());
+        known_types.insert(format!("{}.{}", i.namespace, i.name));
     }
     for e in &all_enums {
-        if let TypeMeta::Enum { name, .. } = e {
+        if let TypeMeta::Enum {
+            namespace, name, ..
+        } = e
+        {
             if !class_names_all.contains(name) {
                 known_types.insert(name.clone());
+                known_types.insert(format!("{namespace}.{name}"));
             }
         }
     }

--- a/tools/dynwinrt-codegen/src/main.rs
+++ b/tools/dynwinrt-codegen/src/main.rs
@@ -701,6 +701,7 @@ fn generate_for_types(
     all_classes.extend(deps.classes);
     all_interfaces.extend(deps.interfaces);
     all_enums.extend(deps.enums);
+    validate_unique_class_output_names(&all_classes)?;
 
     // Newly-merged dependency types haven't been doc-annotated yet. Apply doc table
     // uniformly so dependency classes/interfaces/enums carry the same XML docs as
@@ -820,6 +821,26 @@ fn generate_for_types(
     }
 
     Ok((all_classes.len(), all_interfaces.len(), all_enums.len()))
+}
+
+fn validate_unique_class_output_names(classes: &[meta::ClassMeta]) -> Result<(), String> {
+    let mut full_name_by_short_name: HashMap<&str, &str> = HashMap::new();
+    for class in classes {
+        match full_name_by_short_name.get(class.name.as_str()) {
+            Some(existing) if *existing != class.full_name => {
+                return Err(format!(
+                    "Cannot generate `{}` and `{}` in one output directory because both use \
+                     the short class name `{}`. Generate them separately or select only one type.",
+                    existing, class.full_name, class.name
+                ));
+            }
+            Some(_) => {}
+            None => {
+                full_name_by_short_name.insert(&class.name, &class.full_name);
+            }
+        }
+    }
+    Ok(())
 }
 
 fn generate_js_files(
@@ -1839,4 +1860,46 @@ fn find_windows_sdk_winmd() -> Option<String> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinct_classes_with_the_same_short_name_are_rejected() {
+        let classes = vec![
+            meta::ClassMeta {
+                name: "ResourceManager".into(),
+                namespace: "Contoso".into(),
+                full_name: "Contoso.ResourceManager".into(),
+                ..Default::default()
+            },
+            meta::ClassMeta {
+                name: "ResourceManager".into(),
+                namespace: "Microsoft.Windows.ApplicationModel.Resources".into(),
+                full_name: "Microsoft.Windows.ApplicationModel.Resources.ResourceManager".into(),
+                ..Default::default()
+            },
+        ];
+
+        let error = validate_unique_class_output_names(&classes)
+            .expect_err("same-name classes must not overwrite each other");
+        assert!(error.contains("Contoso.ResourceManager"));
+        assert!(error.contains("Microsoft.Windows.ApplicationModel.Resources.ResourceManager"));
+        assert!(error.contains("short class name `ResourceManager`"));
+    }
+
+    #[test]
+    fn duplicate_metadata_for_the_same_class_is_allowed() {
+        let class = meta::ClassMeta {
+            name: "Application".into(),
+            namespace: "Microsoft.UI.Xaml".into(),
+            full_name: "Microsoft.UI.Xaml.Application".into(),
+            ..Default::default()
+        };
+
+        validate_unique_class_output_names(&[class.clone(), class])
+            .expect("identical metadata does not create an ambiguous output");
+    }
 }

--- a/tools/dynwinrt-codegen/tests/composable_factory_test.rs
+++ b/tools/dynwinrt-codegen/tests/composable_factory_test.rs
@@ -421,8 +421,11 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
         "Application".into(),
         "ApplicationInitializationCallback".into(),
         "XamlControlsXamlMetaDataProvider".into(),
+        "Microsoft.UI.Xaml.XamlTypeInfo.XamlControlsXamlMetaDataProvider".into(),
         "XamlControlsResources".into(),
+        "Microsoft.UI.Xaml.Controls.XamlControlsResources".into(),
         "ResourceManager".into(),
+        "Microsoft.Windows.ApplicationModel.Resources.ResourceManager".into(),
     ]);
     let delegate_names = HashSet::from(["ApplicationInitializationCallback".into()]);
     let delegate_sigs = HashMap::from([(
@@ -492,4 +495,38 @@ fn winui_application_projects_fluent_bootstrap_helpers() {
     assert!(pyi.contains(
         "def create(on_launched: Callable[[], object] | None = ...) -> 'Application': ..."
     ));
+}
+
+#[test]
+fn winui_application_without_extension_dependencies_has_no_bootstrap_helpers() {
+    let application = ClassMeta {
+        name: "Application".into(),
+        namespace: "Microsoft.UI.Xaml".into(),
+        full_name: "Microsoft.UI.Xaml.Application".into(),
+        ..Default::default()
+    };
+    let known_types = HashSet::from(["Application".into()]);
+    let projected = project::project_class(
+        &application,
+        &known_types,
+        &HashSet::new(),
+        &HashSet::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+    let py = python::generate_class(&application, &known_types, &HashSet::new(), &HashSet::new());
+    let pyi = python_stub::generate_class_stub(
+        &application,
+        &known_types,
+        &HashSet::new(),
+        &HashSet::new(),
+    );
+
+    assert!(!js.contains("createWithMetadataProvider"));
+    assert!(!dts.contains("createWithMetadataProvider"));
+    assert!(!py.contains("create_with_metadata_provider"));
+    assert!(!pyi.contains("create_with_metadata_provider"));
 }


### PR DESCRIPTION
## Summary

Moves WinUI `Application` bootstrap policy out of the JavaScript and Python generators into a shared, language-neutral codegen extension.

## Changes

- Add `codegen/winrt/extensions/winui.rs`.
- Centralize WinUI type identities, callback IID/ABI, implicit dependencies, and unpackaged resource detection.
- Update JavaScript and Python generators/stubs to consume the shared spec.
- Replace `add_implicit_js_types()` with language-neutral WinUI dependency injection.
- Use fully qualified type identities to avoid short-name collisions.
- Preserve existing generated JavaScript and Python APIs and behavior.
- Add positive, negative, and same-name collision regression tests.