### PR TITLE
Fix delegate dependency closure in WinRT code generation

### DIFF
--- a/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/methods.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/methods.rs
@@ -25,10 +25,80 @@ fn projected_method_outputs(method: &MethodMeta) -> Vec<(usize, &TypeMeta)> {
     outputs
 }
 
-fn output_ts_type(typ: &TypeMeta, known_types: &HashSet<String>) -> String {
+fn is_projected_delegate_type(typ: Option<&TypeMeta>, delegate_names: &HashSet<String>) -> bool {
     match typ {
+        Some(TypeMeta::Delegate { .. }) => true,
+        Some(TypeMeta::Interface { name, .. }) => delegate_names.contains(name),
+        Some(TypeMeta::Parameterized { name, args, .. }) => {
+            delegate_names.contains(&crate::meta::make_parameterized_name(name, args))
+        }
+        _ => false,
+    }
+}
+
+fn projected_ts_return_type(
+    typ: Option<&TypeMeta>,
+    is_async: bool,
+    known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
+) -> String {
+    match typ {
+        Some(TypeMeta::AsyncOperation(inner)) => format!(
+            "Promise<{}>",
+            projected_ts_return_type(Some(inner), false, known_types, delegate_names)
+        ),
+        Some(TypeMeta::AsyncOperationWithProgress(result, _)) => {
+            let inner = projected_ts_return_type(Some(result), false, known_types, delegate_names);
+            format!(
+                "Promise<{i}> & {{ progress(cb: (value: unknown) => void): Promise<{i}> & {{ progress: any; toPromise(): Promise<{i}>; cancel(): void; }}; toPromise(): Promise<{i}>; cancel(): void; }}",
+                i = inner
+            )
+        }
+        Some(TypeMeta::Array(inner)) if is_projected_delegate_type(Some(inner), delegate_names) => {
+            "Array<DynWinRtValue | null>".into()
+        }
+        _ if is_projected_delegate_type(typ, delegate_names) => {
+            if is_async {
+                "Promise<DynWinRtValue | null>".into()
+            } else {
+                "DynWinRtValue | null".into()
+            }
+        }
+        _ => ts_return_type_safe(typ, is_async, known_types),
+    }
+}
+
+fn convert_projected_return(
+    expr: &str,
+    typ: Option<&TypeMeta>,
+    known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
+) -> String {
+    match typ {
+        Some(TypeMeta::Array(inner)) if is_projected_delegate_type(Some(inner), delegate_names) => {
+            format!(
+                "{}.asArray().toValues().map(v => v.isNull() ? null : v)",
+                expr
+            )
+        }
+        _ if is_projected_delegate_type(typ, delegate_names) => {
+            format!("((v) => v.isNull() ? null : v)({})", expr)
+        }
+        _ => convert_return(expr, typ, false, known_types, &NO_DEFERRED),
+    }
+}
+
+fn output_ts_type(
+    typ: &TypeMeta,
+    known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
+) -> String {
+    match typ {
+        TypeMeta::Array(inner) if is_projected_delegate_type(Some(inner), delegate_names) => {
+            "Array<DynWinRtValue | null>".into()
+        }
         TypeMeta::Array(inner) => ts_array_element_type(inner, known_types),
-        _ => ts_return_type_safe(Some(typ), false, known_types),
+        _ => projected_ts_return_type(Some(typ), false, known_types, delegate_names),
     }
 }
 
@@ -36,11 +106,21 @@ fn convert_output(
     expr: &str,
     typ: &TypeMeta,
     known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
     deferred: &HashSet<String>,
 ) -> String {
     match typ {
+        TypeMeta::Array(inner) if is_projected_delegate_type(Some(inner), delegate_names) => {
+            format!(
+                "{}.asArray().toValues().map(v => v.isNull() ? null : v)",
+                expr
+            )
+        }
         TypeMeta::Array(inner) => {
             convert_array_return(&format!("{}.asArray()", expr), inner, known_types, deferred)
+        }
+        _ if is_projected_delegate_type(Some(typ), delegate_names) => {
+            format!("((v) => v.isNull() ? null : v)({})", expr)
         }
         _ => convert_return(expr, Some(typ), false, known_types, deferred),
     }
@@ -50,15 +130,16 @@ fn project_multi_output(
     method: &MethodMeta,
     invoke_expr: &str,
     known_types: &HashSet<String>,
+    delegate_names: &HashSet<String>,
 ) -> (String, String) {
     let outputs = projected_method_outputs(method);
     let return_type = match outputs.as_slice() {
-        [(_, typ)] => output_ts_type(typ, known_types),
+        [(_, typ)] => output_ts_type(typ, known_types, delegate_names),
         _ => format!(
             "[{}]",
             outputs
                 .iter()
-                .map(|(_, typ)| output_ts_type(typ, known_types))
+                .map(|(_, typ)| output_ts_type(typ, known_types, delegate_names))
                 .collect::<Vec<_>>()
                 .join(", ")
         ),
@@ -67,8 +148,13 @@ fn project_multi_output(
     let converted = outputs
         .iter()
         .map(|(index, typ)| {
-            let converted =
-                convert_output(&format!("_r[{}]", index), typ, known_types, &NO_DEFERRED);
+            let converted = convert_output(
+                &format!("_r[{}]", index),
+                typ,
+                known_types,
+                delegate_names,
+                &NO_DEFERRED,
+            );
             if fill_array_uses_retval_count(method)
                 && fill_array_output_index(method) == Some(*index)
             {
@@ -237,24 +323,49 @@ pub(super) fn project_static_method(
     });
     let is_async = return_type_meta.is_some_and(|rt| rt.is_async()) && !is_with_progress;
     let is_multi_output = method_abi_output_count(method) > 1;
+    let has_array_out = method.params.iter().any(|p| {
+        (p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill)
+            && matches!(p.typ, TypeMeta::Array(_))
+    });
+    let has_return = method_abi_output_count(method) > 0;
+    let array_out_elem =
+        if has_array_out && (return_type_meta.is_none() || fill_array_uses_retval_count(method)) {
+            method.params.iter().find_map(|p| {
+                if p.direction == ParamDirection::Out || p.direction == ParamDirection::OutFill {
+                    if let TypeMeta::Array(inner) = &p.typ {
+                        Some(inner.as_ref())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        };
+    let single_out = if has_return && return_type_meta.is_none() && array_out_elem.is_none() {
+        projected_method_outputs(method)
+            .into_iter()
+            .next()
+            .map(|(_, typ)| typ)
+    } else {
+        None
+    };
 
     let statics_call = format!("{cls}.s_{iface}()", cls = class.name, iface = iface.name);
 
     // Static property getter
     if method.is_property_getter && in_params.is_empty() {
         let prop_name = to_camel_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
-        let ts_return = ts_return_type_safe(return_type_meta, false, known_types);
+        let ts_return =
+            projected_ts_return_type(return_type_meta, false, known_types, delegate_names);
         let invoke_expr = format!(
             "_{}.method({}).invoke({}, [])",
             iface.name, method.vtable_index, statics_call
         );
-        let converted = convert_return(
-            &invoke_expr,
-            return_type_meta,
-            false,
-            known_types,
-            &NO_DEFERRED,
-        );
+        let converted =
+            convert_projected_return(&invoke_expr, return_type_meta, known_types, delegate_names);
         let doc = build_method_doc(method, &in_params);
         return ProjectedMember::Property(ProjectedProperty {
             name: prop_name,
@@ -268,7 +379,17 @@ pub(super) fn project_static_method(
         });
     }
 
-    let mut ts_return = ts_return_type_safe(return_type_meta, is_async, known_types);
+    let mut ts_return = if let Some(elem) = array_out_elem {
+        if is_projected_delegate_type(Some(elem), delegate_names) {
+            "Array<DynWinRtValue | null>".into()
+        } else {
+            ts_array_element_type(elem, known_types)
+        }
+    } else if let Some(output) = single_out {
+        output_ts_type(output, known_types, delegate_names)
+    } else {
+        projected_ts_return_type(return_type_meta, is_async, known_types, delegate_names)
+    };
     let params = project_params(
         &in_params,
         known_types,
@@ -295,6 +416,7 @@ pub(super) fn project_static_method(
     let async_kind;
     let sync_return_expr;
     let async_convert_v;
+    let array_return_expr;
     let mut progress_convert = None;
 
     if is_with_progress {
@@ -308,23 +430,24 @@ pub(super) fn project_static_method(
             _ => None,
         };
         let progress_ts = progress_type
-            .map(|p| ts_return_type_safe(Some(p), false, known_types))
+            .map(|p| projected_ts_return_type(Some(p), false, known_types, delegate_names))
             .unwrap_or_else(|| "unknown".to_string());
         // Build conversion expression for progress value
-        let p_convert = convert_return("_p", progress_type, false, known_types, &NO_DEFERRED);
+        let p_convert = convert_projected_return("_p", progress_type, known_types, delegate_names);
         if p_convert != "_p" {
             progress_convert = Some(p_convert);
         }
         let is_action = matches!(return_type_meta, Some(TypeMeta::AsyncActionWithProgress(_)));
-        let inner_convert = convert_return("_v", inner_type, false, known_types, &NO_DEFERRED);
+        let inner_convert = convert_projected_return("_v", inner_type, known_types, delegate_names);
         if is_action {
             async_kind = AsyncKind::ActionWithProgress(progress_ts);
         } else {
-            let inner_ts = ts_return_type_safe(inner_type, false, known_types);
+            let inner_ts = projected_ts_return_type(inner_type, false, known_types, delegate_names);
             async_kind = AsyncKind::OperationWithProgress(inner_ts, progress_ts);
         }
         sync_return_expr = None;
         async_convert_v = Some(inner_convert);
+        array_return_expr = None;
     } else if is_async {
         let inner_type = async_inner_type(return_type_meta);
         let is_action = matches!(return_type_meta, Some(TypeMeta::AsyncAction));
@@ -332,33 +455,70 @@ pub(super) fn project_static_method(
             async_kind = AsyncKind::Action;
             async_convert_v = None;
         } else {
-            let convert_v = convert_return("_v", inner_type, false, known_types, &NO_DEFERRED);
-            let inner_ts = ts_return_type_safe(inner_type, false, known_types);
+            let convert_v = convert_projected_return("_v", inner_type, known_types, delegate_names);
+            let inner_ts = projected_ts_return_type(inner_type, false, known_types, delegate_names);
             async_kind = AsyncKind::Operation(inner_ts);
             async_convert_v = Some(convert_v);
         }
         sync_return_expr = None;
+        array_return_expr = None;
     } else if is_multi_output {
         async_kind = AsyncKind::None;
-        let (multi_return, multi_expr) = project_multi_output(method, &invoke_expr, known_types);
+        let (multi_return, multi_expr) =
+            project_multi_output(method, &invoke_expr, known_types, delegate_names);
         ts_return = multi_return;
         sync_return_expr = Some(multi_expr);
         async_convert_v = None;
+        array_return_expr = None;
+    } else if let Some(elem) = array_out_elem {
+        async_kind = AsyncKind::None;
+        let arr_expr = if fill_array_uses_retval_count(method) {
+            format!(
+                "_r[{}].asArray()",
+                fill_array_output_index(method).expect("FillArray output index")
+            )
+        } else {
+            format!("{}.asArray()", invoke_expr)
+        };
+        let converted = if is_projected_delegate_type(Some(elem), delegate_names) {
+            format!("{}.toValues().map(v => v.isNull() ? null : v)", arr_expr)
+        } else {
+            convert_array_return(&arr_expr, elem, known_types, &NO_DEFERRED)
+        };
+        sync_return_expr = None;
+        async_convert_v = None;
+        array_return_expr = if fill_array_uses_retval_count(method) {
+            Some(format!(
+                "(() => {{ const _r = {}; return {}.slice(0, _r[{}].toNumber()); }})()",
+                invoke_expr,
+                converted,
+                method_abi_output_count(method) - 1
+            ))
+        } else {
+            Some(converted)
+        };
+    } else if let Some(output) = single_out {
+        async_kind = AsyncKind::None;
+        sync_return_expr = Some(convert_output(
+            &invoke_expr,
+            output,
+            known_types,
+            delegate_names,
+            &NO_DEFERRED,
+        ));
+        async_convert_v = None;
+        array_return_expr = None;
     } else {
         async_kind = AsyncKind::None;
-        let converted = convert_return(
-            &invoke_expr,
-            return_type_meta,
-            false,
-            known_types,
-            &NO_DEFERRED,
-        );
+        let converted =
+            convert_projected_return(&invoke_expr, return_type_meta, known_types, delegate_names);
         sync_return_expr = if return_type_meta.is_some() {
             Some(converted)
         } else {
             None
         };
         async_convert_v = None;
+        array_return_expr = None;
     }
 
     let mut ts_params = params;
@@ -403,8 +563,8 @@ pub(super) fn project_static_method(
         sync_return_expr,
         async_convert_v,
         progress_convert,
-        is_void: return_type_meta.is_none() && !is_async,
-        array_return_expr: None,
+        is_void: !has_return && !is_async,
+        array_return_expr,
         delegate_wraps,
         js_only: false,
         overload_of,
@@ -437,13 +597,8 @@ pub(super) fn project_instance_method(
     });
     let has_return = method_abi_output_count(method) > 0;
 
-    let is_delegate_type = |typ: Option<&TypeMeta>| -> bool {
-        match typ {
-            Some(TypeMeta::Delegate { .. }) => true,
-            Some(TypeMeta::Interface { name, .. }) => delegate_type_names.contains(name),
-            _ => false,
-        }
-    };
+    let is_delegate_type =
+        |typ: Option<&TypeMeta>| is_projected_delegate_type(typ, delegate_type_names);
 
     let mut doc = build_method_doc(method, &in_params);
 
@@ -483,26 +638,18 @@ pub(super) fn project_instance_method(
     // Property getter
     if method.is_property_getter && in_params.is_empty() {
         let prop_name = to_camel_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
-        let ts_return = if is_delegate_type(return_type_meta) {
-            "DynWinRtValue".to_string()
-        } else {
-            ts_return_type_safe(return_type_meta, false, known_types)
-        };
+        let ts_return =
+            projected_ts_return_type(return_type_meta, false, known_types, delegate_type_names);
         let invoke_expr = format!(
             "{}.method({}).invoke({}, [])",
             iface_var, method.vtable_index, obj_expr
         );
-        let converted = if is_delegate_type(return_type_meta) {
-            invoke_expr.clone()
-        } else {
-            convert_return(
-                &invoke_expr,
-                return_type_meta,
-                false,
-                known_types,
-                &NO_DEFERRED,
-            )
-        };
+        let converted = convert_projected_return(
+            &invoke_expr,
+            return_type_meta,
+            known_types,
+            delegate_type_names,
+        );
 
         // Check if there's a corresponding setter
         let setter =
@@ -602,11 +749,25 @@ pub(super) fn project_instance_method(
         } else {
             None
         };
+    let single_out = if has_return && return_type_meta.is_none() && array_out_elem.is_none() {
+        projected_method_outputs(method)
+            .into_iter()
+            .next()
+            .map(|(_, typ)| typ)
+    } else {
+        None
+    };
 
     let mut ts_return = if let Some(elem) = array_out_elem {
-        ts_array_element_type(elem, known_types)
+        if is_projected_delegate_type(Some(elem), delegate_type_names) {
+            "Array<DynWinRtValue | null>".into()
+        } else {
+            ts_array_element_type(elem, known_types)
+        }
+    } else if let Some(output) = single_out {
+        output_ts_type(output, known_types, delegate_type_names)
     } else {
-        ts_return_type_safe(return_type_meta, is_async, known_types)
+        projected_ts_return_type(return_type_meta, is_async, known_types, delegate_type_names)
     };
 
     let args_expr = build_args_expr(&in_params);
@@ -638,18 +799,21 @@ pub(super) fn project_instance_method(
             _ => None,
         };
         let progress_ts = progress_type
-            .map(|p| ts_return_type_safe(Some(p), false, known_types))
+            .map(|p| projected_ts_return_type(Some(p), false, known_types, delegate_type_names))
             .unwrap_or_else(|| "unknown".to_string());
-        let p_convert = convert_return("_p", progress_type, false, known_types, &NO_DEFERRED);
+        let p_convert =
+            convert_projected_return("_p", progress_type, known_types, delegate_type_names);
         if p_convert != "_p" {
             progress_convert = Some(p_convert);
         }
         let is_action = matches!(return_type_meta, Some(TypeMeta::AsyncActionWithProgress(_)));
-        let inner_convert = convert_return("_v", inner_type, false, known_types, &NO_DEFERRED);
+        let inner_convert =
+            convert_projected_return("_v", inner_type, known_types, delegate_type_names);
         if is_action {
             async_kind = AsyncKind::ActionWithProgress(progress_ts);
         } else {
-            let inner_ts = ts_return_type_safe(inner_type, false, known_types);
+            let inner_ts =
+                projected_ts_return_type(inner_type, false, known_types, delegate_type_names);
             async_kind = AsyncKind::OperationWithProgress(inner_ts, progress_ts);
         }
         sync_return_expr = None;
@@ -662,8 +826,10 @@ pub(super) fn project_instance_method(
             async_kind = AsyncKind::Action;
             async_convert_v = None;
         } else {
-            let convert_v = convert_return("_v", inner_type, false, known_types, &NO_DEFERRED);
-            let inner_ts = ts_return_type_safe(inner_type, false, known_types);
+            let convert_v =
+                convert_projected_return("_v", inner_type, known_types, delegate_type_names);
+            let inner_ts =
+                projected_ts_return_type(inner_type, false, known_types, delegate_type_names);
             async_kind = AsyncKind::Operation(inner_ts);
             async_convert_v = Some(convert_v);
         }
@@ -671,7 +837,8 @@ pub(super) fn project_instance_method(
         array_return_expr = None;
     } else if is_multi_output && !fill_array_uses_retval_count(method) {
         async_kind = AsyncKind::None;
-        let (multi_return, multi_expr) = project_multi_output(method, &invoke_expr, known_types);
+        let (multi_return, multi_expr) =
+            project_multi_output(method, &invoke_expr, known_types, delegate_type_names);
         ts_return = multi_return;
         sync_return_expr = Some(multi_expr);
         async_convert_v = None;
@@ -686,7 +853,11 @@ pub(super) fn project_instance_method(
         } else {
             format!("{}.asArray()", invoke_expr)
         };
-        let converted = convert_array_return(&arr_expr, elem, known_types, &NO_DEFERRED);
+        let converted = if is_projected_delegate_type(Some(elem), delegate_type_names) {
+            format!("{}.toValues().map(v => v.isNull() ? null : v)", arr_expr)
+        } else {
+            convert_array_return(&arr_expr, elem, known_types, &NO_DEFERRED)
+        };
         sync_return_expr = None;
         async_convert_v = None;
         array_return_expr = if fill_array_uses_retval_count(method) {
@@ -699,15 +870,25 @@ pub(super) fn project_instance_method(
         } else {
             Some(converted)
         };
+    } else if let Some(output) = single_out {
+        async_kind = AsyncKind::None;
+        sync_return_expr = Some(convert_output(
+            &invoke_expr,
+            output,
+            known_types,
+            delegate_type_names,
+            &NO_DEFERRED,
+        ));
+        async_convert_v = None;
+        array_return_expr = None;
     } else {
         async_kind = AsyncKind::None;
         if has_return {
-            let converted = convert_return(
+            let converted = convert_projected_return(
                 &invoke_expr,
                 return_type_meta,
-                false,
                 known_types,
-                &NO_DEFERRED,
+                delegate_type_names,
             );
             sync_return_expr = Some(converted);
         } else {

--- a/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/mod.rs
@@ -193,18 +193,11 @@ pub fn project_class(
     let all_ifaces: Vec<&InterfaceMeta> = class.all_interfaces().collect();
     for iface in &all_ifaces {
         collect_delegate_names_from_methods(&iface.methods, &mut delegate_names);
-        for method in &iface.methods {
-            for param in method
-                .params
-                .iter()
-                .filter(|param| param.direction == ParamDirection::In)
-            {
-                let type_name = ts_param_type_dts(&param.typ, known_types);
-                if delegate_type_names.contains(&type_name) {
-                    delegate_names.insert(type_name);
-                }
-            }
-        }
+        collect_known_delegate_names_from_methods(
+            &iface.methods,
+            delegate_type_names,
+            &mut delegate_names,
+        );
     }
     // All known delegate type names (used to filter type imports — delegates typed as Interface
     // in parameter metadata must not be imported as regular type imports)
@@ -1053,8 +1046,13 @@ pub fn project_interface(
     let used_structs = collect_used_structs_from_iface(iface);
     let has_structs = !used_structs.is_empty();
 
-    let mut delegate_names: HashSet<String> = delegate_type_names.clone();
+    let mut delegate_names: HashSet<String> = HashSet::new();
     collect_delegate_names_from_methods(&iface.methods, &mut delegate_names);
+    collect_known_delegate_names_from_methods(
+        &iface.methods,
+        delegate_type_names,
+        &mut delegate_names,
+    );
 
     // Build imports
     let mut imports = Vec::new();
@@ -1474,6 +1472,107 @@ fn collect_delegate_names_from_methods(
                 }
             }
         }
+    }
+}
+
+fn collect_known_delegate_names_from_methods(
+    methods: &[MethodMeta],
+    known_delegate_names: &HashSet<String>,
+    delegate_names: &mut HashSet<String>,
+) {
+    for method in methods {
+        for parameter in &method.params {
+            collect_known_delegate_names_from_type(
+                &parameter.typ,
+                known_delegate_names,
+                delegate_names,
+            );
+        }
+        if let Some(return_type) = &method.return_type {
+            collect_known_delegate_names_from_type(
+                return_type,
+                known_delegate_names,
+                delegate_names,
+            );
+        }
+    }
+}
+
+fn collect_known_delegate_names_from_type(
+    typ: &TypeMeta,
+    known_delegate_names: &HashSet<String>,
+    delegate_names: &mut HashSet<String>,
+) {
+    match typ {
+        TypeMeta::Delegate { name, .. } => {
+            delegate_names.insert(name.clone());
+        }
+        TypeMeta::Interface { name, .. } => {
+            if known_delegate_names.contains(name) {
+                delegate_names.insert(name.clone());
+            }
+        }
+        TypeMeta::AsyncActionWithProgress(inner)
+        | TypeMeta::AsyncOperation(inner)
+        | TypeMeta::Array(inner) => {
+            collect_known_delegate_names_from_type(
+                inner,
+                known_delegate_names,
+                delegate_names,
+            );
+        }
+        TypeMeta::AsyncOperationWithProgress(
+            result,
+            progress,
+        ) => {
+            collect_known_delegate_names_from_type(
+                result,
+                known_delegate_names,
+                delegate_names,
+            );
+            collect_known_delegate_names_from_type(
+                progress,
+                known_delegate_names,
+                delegate_names,
+            );
+        }
+        TypeMeta::Parameterized { name, args, .. } => {
+            let concrete =
+                crate::meta::make_parameterized_name(
+                    name,
+                    args,
+                );
+            if known_delegate_names.contains(&concrete) {
+                delegate_names.insert(concrete);
+            }
+            for argument in args {
+                collect_known_delegate_names_from_type(
+                    argument,
+                    known_delegate_names,
+                    delegate_names,
+                );
+            }
+        }
+        TypeMeta::RuntimeClass {
+            default_interface: Some(interface),
+            ..
+        } => {
+            collect_known_delegate_names_from_type(
+                interface,
+                known_delegate_names,
+                delegate_names,
+            );
+        }
+        TypeMeta::Struct { fields, .. } => {
+            for field in fields {
+                collect_known_delegate_names_from_type(
+                    &field.typ,
+                    known_delegate_names,
+                    delegate_names,
+                );
+            }
+        }
+        _ => {}
     }
 }
 

--- a/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/javascript/project/mod.rs
@@ -190,13 +190,18 @@ pub fn project_class(
     // Collect delegate names only from interfaces of THIS class (not the entire batch)
     // for delegate imports; but also include global delegate_type_names for type filtering
     let mut delegate_names: HashSet<String> = HashSet::new();
+    let mut runtime_delegate_names: HashSet<String> = HashSet::new();
     let all_ifaces: Vec<&InterfaceMeta> = class.all_interfaces().collect();
     for iface in &all_ifaces {
-        collect_delegate_names_from_methods(&iface.methods, &mut delegate_names);
         collect_known_delegate_names_from_methods(
             &iface.methods,
             delegate_type_names,
             &mut delegate_names,
+        );
+        collect_runtime_delegate_names_from_methods(
+            &iface.methods,
+            delegate_type_names,
+            &mut runtime_delegate_names,
         );
     }
     // All known delegate type names (used to filter type imports — delegates typed as Interface
@@ -233,7 +238,7 @@ pub fn project_class(
     }
 
     // Delegate imports (runtime only — IID + PARAM_TYPES)
-    let mut sorted_delegates: Vec<_> = delegate_names.iter().collect();
+    let mut sorted_delegates: Vec<_> = runtime_delegate_names.iter().collect();
     sorted_delegates.sort();
     for dname in &sorted_delegates {
         imports.push(ProjectedImport {
@@ -1047,11 +1052,16 @@ pub fn project_interface(
     let has_structs = !used_structs.is_empty();
 
     let mut delegate_names: HashSet<String> = HashSet::new();
-    collect_delegate_names_from_methods(&iface.methods, &mut delegate_names);
+    let mut runtime_delegate_names: HashSet<String> = HashSet::new();
     collect_known_delegate_names_from_methods(
         &iface.methods,
         delegate_type_names,
         &mut delegate_names,
+    );
+    collect_runtime_delegate_names_from_methods(
+        &iface.methods,
+        delegate_type_names,
+        &mut runtime_delegate_names,
     );
 
     // Build imports
@@ -1071,7 +1081,7 @@ pub fn project_interface(
         }
     }
 
-    let mut sorted_delegates: Vec<_> = delegate_names.iter().collect();
+    let mut sorted_delegates: Vec<_> = runtime_delegate_names.iter().collect();
     sorted_delegates.sort();
     for dname in &sorted_delegates {
         imports.push(ProjectedImport {
@@ -1449,27 +1459,30 @@ fn format_type_import_projected(name: &str, kind: TypeKind) -> ProjectedImport {
     }
 }
 
-fn collect_delegate_names_from_methods(
+fn collect_runtime_delegate_names_from_methods(
     methods: &[MethodMeta],
+    known_delegate_names: &HashSet<String>,
     delegate_names: &mut HashSet<String>,
 ) {
     for method in methods {
-        for p in &method.params {
-            match &p.typ {
+        for parameter in &method.params {
+            if parameter.direction != ParamDirection::In {
+                continue;
+            }
+            match &parameter.typ {
                 TypeMeta::Delegate { name, .. } => {
                     delegate_names.insert(name.clone());
                 }
-                TypeMeta::Interface { name, .. }
-                    if method.is_event_add || method.is_event_remove =>
-                {
+                TypeMeta::Interface { name, .. } if known_delegate_names.contains(name) => {
                     delegate_names.insert(name.clone());
                 }
-                _ => {}
-            }
-            if method.is_event_add || method.is_event_remove {
-                if let TypeMeta::Parameterized { name, args, .. } = &p.typ {
-                    delegate_names.insert(crate::meta::make_parameterized_name(name, args));
+                TypeMeta::Parameterized { name, args, .. } => {
+                    let concrete = crate::meta::make_parameterized_name(name, args);
+                    if known_delegate_names.contains(&concrete) {
+                        delegate_names.insert(concrete);
+                    }
                 }
+                _ => {}
             }
         }
     }
@@ -1515,33 +1528,14 @@ fn collect_known_delegate_names_from_type(
         TypeMeta::AsyncActionWithProgress(inner)
         | TypeMeta::AsyncOperation(inner)
         | TypeMeta::Array(inner) => {
-            collect_known_delegate_names_from_type(
-                inner,
-                known_delegate_names,
-                delegate_names,
-            );
+            collect_known_delegate_names_from_type(inner, known_delegate_names, delegate_names);
         }
-        TypeMeta::AsyncOperationWithProgress(
-            result,
-            progress,
-        ) => {
-            collect_known_delegate_names_from_type(
-                result,
-                known_delegate_names,
-                delegate_names,
-            );
-            collect_known_delegate_names_from_type(
-                progress,
-                known_delegate_names,
-                delegate_names,
-            );
+        TypeMeta::AsyncOperationWithProgress(result, progress) => {
+            collect_known_delegate_names_from_type(result, known_delegate_names, delegate_names);
+            collect_known_delegate_names_from_type(progress, known_delegate_names, delegate_names);
         }
         TypeMeta::Parameterized { name, args, .. } => {
-            let concrete =
-                crate::meta::make_parameterized_name(
-                    name,
-                    args,
-                );
+            let concrete = crate::meta::make_parameterized_name(name, args);
             if known_delegate_names.contains(&concrete) {
                 delegate_names.insert(concrete);
             }
@@ -1557,11 +1551,7 @@ fn collect_known_delegate_names_from_type(
             default_interface: Some(interface),
             ..
         } => {
-            collect_known_delegate_names_from_type(
-                interface,
-                known_delegate_names,
-                delegate_names,
-            );
+            collect_known_delegate_names_from_type(interface, known_delegate_names, delegate_names);
         }
         TypeMeta::Struct { fields, .. } => {
             for field in fields {

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/class.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/class.rs
@@ -98,14 +98,17 @@ pub fn generate_class(
 
     // Collect delegate names from all interfaces of this class
     let mut delegate_names = HashSet::new();
+    let mut runtime_delegate_names = HashSet::new();
     let all_ifaces: Vec<&InterfaceMeta> = class.all_interfaces().collect();
     for iface in &all_ifaces {
-        delegate_names.extend(
-            super::super::collect_referenced_delegate_names(
-                &iface.methods,
-                delegate_type_names,
-            ),
-        );
+        delegate_names.extend(super::super::collect_referenced_delegate_names(
+            &iface.methods,
+            delegate_type_names,
+        ));
+        runtime_delegate_names.extend(super::super::collect_runtime_delegate_names(
+            &iface.methods,
+            delegate_type_names,
+        ));
     }
 
     // Collection generics import (skip delegates)
@@ -119,7 +122,7 @@ pub fn generate_class(
     }
 
     // Import delegate IID + PARAM_TYPES
-    let mut sorted_delegates: Vec<_> = delegate_names.iter().collect();
+    let mut sorted_delegates: Vec<_> = runtime_delegate_names.iter().collect();
     sorted_delegates.sort();
     for dname in &sorted_delegates {
         let module = to_snake_case_filename(dname);

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/class.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/class.rs
@@ -97,21 +97,15 @@ pub fn generate_class(
     let mut type_checking_imports = Vec::new();
 
     // Collect delegate names from all interfaces of this class
-    let mut delegate_names: HashSet<String> = delegate_type_names.clone();
+    let mut delegate_names = HashSet::new();
     let all_ifaces: Vec<&InterfaceMeta> = class.all_interfaces().collect();
     for iface in &all_ifaces {
-        for method in &iface.methods {
-            for p in &method.params {
-                if let TypeMeta::Delegate { name, .. } = &p.typ {
-                    delegate_names.insert(name.clone());
-                }
-                if method.is_event_add || method.is_event_remove {
-                    if let TypeMeta::Parameterized { name, args, .. } = &p.typ {
-                        delegate_names.insert(crate::meta::make_parameterized_name(name, args));
-                    }
-                }
-            }
-        }
+        delegate_names.extend(
+            super::super::collect_referenced_delegate_names(
+                &iface.methods,
+                delegate_type_names,
+            ),
+        );
     }
 
     // Collection generics import (skip delegates)

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/types.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/types.rs
@@ -114,10 +114,9 @@ pub fn generate_interface(
 
     // Collect delegate names
     let delegate_names =
-        super::super::collect_referenced_delegate_names(
-            &iface.methods,
-            delegate_type_names,
-        );
+        super::super::collect_referenced_delegate_names(&iface.methods, delegate_type_names);
+    let runtime_delegate_names =
+        super::super::collect_runtime_delegate_names(&iface.methods, delegate_type_names);
 
     // Import parameterized collection types (skip delegates)
     let collection_names = collect_used_generics_from_methods(&iface.methods);
@@ -145,7 +144,7 @@ pub fn generate_interface(
     }
 
     // Import delegate IID + PARAM_TYPES
-    let mut sorted_delegates: Vec<_> = delegate_names.iter().collect();
+    let mut sorted_delegates: Vec<_> = runtime_delegate_names.iter().collect();
     sorted_delegates.sort();
     for dname in &sorted_delegates {
         let module = to_snake_case_filename(dname);

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/types.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/generator/types.rs
@@ -113,19 +113,11 @@ pub fn generate_interface(
     let mut type_checking_imports = Vec::new();
 
     // Collect delegate names
-    let mut delegate_names: HashSet<String> = delegate_type_names.clone();
-    for method in &iface.methods {
-        for p in &method.params {
-            if let TypeMeta::Delegate { name, .. } = &p.typ {
-                delegate_names.insert(name.clone());
-            }
-            if method.is_event_add || method.is_event_remove {
-                if let TypeMeta::Parameterized { name, args, .. } = &p.typ {
-                    delegate_names.insert(crate::meta::make_parameterized_name(name, args));
-                }
-            }
-        }
-    }
+    let delegate_names =
+        super::super::collect_referenced_delegate_names(
+            &iface.methods,
+            delegate_type_names,
+        );
 
     // Import parameterized collection types (skip delegates)
     let collection_names = collect_used_generics_from_methods(&iface.methods);

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/method.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/method.rs
@@ -14,14 +14,33 @@ use crate::codegen::winrt::shared::imports::{
 use super::naming::to_snake_case;
 use super::signature::{
     py_convert_return, py_runtime_symbol, py_type_guard, py_wrap_arg, py_wrap_async,
+    py_wrap_async_with_converters,
 };
 use super::type_helpers::{
     method_pydoc, py_delegate_callable_type, py_factory_return_type, py_method_abi_output_count,
-    py_method_outputs, py_method_return_type, py_param_list, py_return_type_safe,
+    py_method_outputs, py_method_return_type, py_output_type, py_param_list,
 };
 
 fn is_delegate_type(typ: &TypeMeta, delegate_type_names: &HashSet<String>) -> bool {
     delegate_name(typ, delegate_type_names).is_some()
+}
+
+fn delegate_value_converter(
+    typ: &TypeMeta,
+    delegate_type_names: &HashSet<String>,
+) -> Option<String> {
+    if is_delegate_type(typ, delegate_type_names) {
+        return Some("lambda value: None if value.is_null() else value".into());
+    }
+    if let TypeMeta::Array(inner) = typ
+        && is_delegate_type(inner, delegate_type_names)
+    {
+        return Some(
+            "lambda value: [None if item.is_null() else item for item in value.as_array().to_values()]"
+                .into(),
+        );
+    }
+    None
 }
 
 /// Build a Python callback signature + wrapper expression for an event delegate.
@@ -143,8 +162,38 @@ fn convert_method_output(
     known_types: &HashSet<String>,
     delegate_type_names: &HashSet<String>,
 ) -> String {
-    if is_delegate_type(typ, delegate_type_names) {
-        return format!("(lambda value: None if value.is_null() else value)({expr})");
+    if let Some(converter) = delegate_value_converter(typ, delegate_type_names) {
+        return format!("({converter})({expr})");
+    }
+    match typ {
+        TypeMeta::AsyncOperation(result) => {
+            return py_wrap_async_with_converters(
+                expr,
+                typ,
+                delegate_value_converter(result, delegate_type_names),
+                None,
+                known_types,
+            );
+        }
+        TypeMeta::AsyncActionWithProgress(progress) => {
+            return py_wrap_async_with_converters(
+                expr,
+                typ,
+                None,
+                delegate_value_converter(progress, delegate_type_names),
+                known_types,
+            );
+        }
+        TypeMeta::AsyncOperationWithProgress(result, progress) => {
+            return py_wrap_async_with_converters(
+                expr,
+                typ,
+                delegate_value_converter(result, delegate_type_names),
+                delegate_value_converter(progress, delegate_type_names),
+                known_types,
+            );
+        }
+        _ => {}
     }
     py_convert_return(expr, Some(typ), typ.is_async(), known_types)
 }
@@ -751,12 +800,9 @@ pub(crate) fn generate_method_body(
 
     if method.is_property_getter && in_params.is_empty() {
         let prop_name = to_snake_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
-        let py_return = if return_type.is_some_and(|typ| is_delegate_type(typ, delegate_type_names))
-        {
-            "DynWinRTValue | None".to_string()
-        } else {
-            py_return_type_safe(return_type, known_types)
-        };
+        let py_return = return_type
+            .map(|typ| py_output_type(typ, known_types, delegate_type_names))
+            .unwrap_or_else(|| "None".to_string());
         out.push_str("    @_property\n");
         out.push_str(&format!("    def {}(self) -> {}:\n", prop_name, py_return));
         out.push_str(&method_pydoc(method, &in_params));

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/mod.rs
@@ -45,19 +45,12 @@ pub(crate) fn collect_referenced_delegate_names(
             | TypeMeta::Array(inner) => {
                 collect(inner, known, result);
             }
-            TypeMeta::AsyncOperationWithProgress(
-                result_type,
-                progress,
-            ) => {
+            TypeMeta::AsyncOperationWithProgress(result_type, progress) => {
                 collect(result_type, known, result);
                 collect(progress, known, result);
             }
             TypeMeta::Parameterized { name, args, .. } => {
-                let concrete =
-                    crate::meta::make_parameterized_name(
-                        name,
-                        args,
-                    );
+                let concrete = crate::meta::make_parameterized_name(name, args);
                 if known.contains(&concrete) {
                     result.insert(concrete);
                 }
@@ -83,18 +76,43 @@ pub(crate) fn collect_referenced_delegate_names(
     let mut result = std::collections::HashSet::new();
     for method in methods {
         for parameter in &method.params {
-            collect(
-                &parameter.typ,
-                known_delegate_names,
-                &mut result,
-            );
+            collect(&parameter.typ, known_delegate_names, &mut result);
         }
         if let Some(return_type) = &method.return_type {
-            collect(
-                return_type,
-                known_delegate_names,
-                &mut result,
-            );
+            collect(return_type, known_delegate_names, &mut result);
+        }
+    }
+    result
+}
+
+pub(crate) fn collect_runtime_delegate_names(
+    methods: &[crate::meta::MethodMeta],
+    known_delegate_names: &std::collections::HashSet<String>,
+) -> std::collections::HashSet<String> {
+    use crate::meta::ParamDirection;
+    use crate::types::TypeMeta;
+
+    let mut result = std::collections::HashSet::new();
+    for method in methods {
+        for parameter in &method.params {
+            if parameter.direction != ParamDirection::In {
+                continue;
+            }
+            match &parameter.typ {
+                TypeMeta::Delegate { name, .. } => {
+                    result.insert(name.clone());
+                }
+                TypeMeta::Interface { name, .. } if known_delegate_names.contains(name) => {
+                    result.insert(name.clone());
+                }
+                TypeMeta::Parameterized { name, args, .. } => {
+                    let concrete = crate::meta::make_parameterized_name(name, args);
+                    if known_delegate_names.contains(&concrete) {
+                        result.insert(concrete);
+                    }
+                }
+                _ => {}
+            }
         }
     }
     result

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/mod.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/mod.rs
@@ -21,6 +21,85 @@ pub use naming::{
     python_namespace_segments, python_public_module_name, to_snake_case_filename,
 };
 
+pub(crate) fn collect_referenced_delegate_names(
+    methods: &[crate::meta::MethodMeta],
+    known_delegate_names: &std::collections::HashSet<String>,
+) -> std::collections::HashSet<String> {
+    fn collect(
+        typ: &crate::types::TypeMeta,
+        known: &std::collections::HashSet<String>,
+        result: &mut std::collections::HashSet<String>,
+    ) {
+        use crate::types::TypeMeta;
+        match typ {
+            TypeMeta::Delegate { name, .. } => {
+                result.insert(name.clone());
+            }
+            TypeMeta::Interface { name, .. } => {
+                if known.contains(name) {
+                    result.insert(name.clone());
+                }
+            }
+            TypeMeta::AsyncActionWithProgress(inner)
+            | TypeMeta::AsyncOperation(inner)
+            | TypeMeta::Array(inner) => {
+                collect(inner, known, result);
+            }
+            TypeMeta::AsyncOperationWithProgress(
+                result_type,
+                progress,
+            ) => {
+                collect(result_type, known, result);
+                collect(progress, known, result);
+            }
+            TypeMeta::Parameterized { name, args, .. } => {
+                let concrete =
+                    crate::meta::make_parameterized_name(
+                        name,
+                        args,
+                    );
+                if known.contains(&concrete) {
+                    result.insert(concrete);
+                }
+                for argument in args {
+                    collect(argument, known, result);
+                }
+            }
+            TypeMeta::RuntimeClass {
+                default_interface: Some(interface),
+                ..
+            } => {
+                collect(interface, known, result);
+            }
+            TypeMeta::Struct { fields, .. } => {
+                for field in fields {
+                    collect(&field.typ, known, result);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut result = std::collections::HashSet::new();
+    for method in methods {
+        for parameter in &method.params {
+            collect(
+                &parameter.typ,
+                known_delegate_names,
+                &mut result,
+            );
+        }
+        if let Some(return_type) = &method.return_type {
+            collect(
+                return_type,
+                known_delegate_names,
+                &mut result,
+            );
+        }
+    }
+    result
+}
+
 pub fn package_struct_identities(
     classes: &[crate::meta::ClassMeta],
     interfaces: &[crate::meta::InterfaceMeta],

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/signature.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/signature.rs
@@ -621,6 +621,16 @@ pub(crate) fn py_wrap_async(
     result_converter: Option<String>,
     known_types: &HashSet<String>,
 ) -> String {
+    py_wrap_async_with_converters(expr, async_type, result_converter, None, known_types)
+}
+
+pub(crate) fn py_wrap_async_with_converters(
+    expr: &str,
+    async_type: &TypeMeta,
+    result_converter: Option<String>,
+    progress_converter: Option<String>,
+    known_types: &HashSet<String>,
+) -> String {
     match async_type {
         TypeMeta::AsyncAction => format!(
             "_dynwinrt_track_projected(_DynWinRTAsync({}, {}), 'WinRTAsync')",
@@ -636,13 +646,13 @@ pub(crate) fn py_wrap_async(
             "_dynwinrt_track_projected(_DynWinRTAsyncWithProgress({}, {}, {}), 'WinRTAsyncWithProgress')",
             expr,
             result_converter.unwrap_or_else(|| "lambda _value: None".to_string()),
-            py_value_converter(progress, known_types)
+            progress_converter.unwrap_or_else(|| py_value_converter(progress, known_types))
         ),
         TypeMeta::AsyncOperationWithProgress(result, progress) => format!(
             "_dynwinrt_track_projected(_DynWinRTAsyncWithProgress({}, {}, {}), 'WinRTAsyncWithProgress')",
             expr,
             result_converter.unwrap_or_else(|| py_value_converter(result, known_types)),
-            py_value_converter(progress, known_types)
+            progress_converter.unwrap_or_else(|| py_value_converter(progress, known_types))
         ),
         _ => panic!("py_wrap_async requires an async type: {:?}", async_type),
     }

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/stub_helpers.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/stub_helpers.rs
@@ -13,8 +13,8 @@ use super::naming::{python_module_name, to_snake_case};
 use super::native_types::{FoundationType, foundation_type};
 use super::structs::{py_struct_field_read_type, py_struct_field_type};
 use super::type_helpers::{
-    py_delegate_callable_type, py_factory_return_type, py_method_return_type, py_param_list,
-    py_param_type_safe, py_return_type_safe,
+    py_delegate_callable_type, py_factory_return_type, py_method_return_type, py_output_type,
+    py_param_list, py_param_type_safe,
 };
 use crate::codegen::winrt::shared::imports::ireference_inner_type;
 
@@ -236,11 +236,9 @@ pub(super) fn emit_method_stub_named(
 
     if method.is_property_getter && in_params.is_empty() {
         let prop_name = to_snake_case(method.name.strip_prefix("get_").unwrap_or(&method.name));
-        let py_return = if is_delegate_type(return_type) {
-            "DynWinRTValue | None".to_string()
-        } else {
-            py_return_type_safe(return_type, known_types)
-        };
+        let py_return = return_type
+            .map(|typ| py_output_type(typ, known_types, delegate_type_names))
+            .unwrap_or_else(|| "None".to_string());
         out.push_str(&format!("{indent}@builtins.property\n"));
         out.push_str(&format!(
             "{indent}def {}(self) -> {}: ...\n",

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/stubs.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/stubs.rs
@@ -115,10 +115,9 @@ pub fn generate_interface_stub(
     out.push('\n');
 
     let delegate_names =
-        super::collect_referenced_delegate_names(
-            &iface.methods,
-            delegate_type_names,
-        );
+        super::collect_referenced_delegate_names(&iface.methods, delegate_type_names);
+    let runtime_delegate_names =
+        super::collect_runtime_delegate_names(&iface.methods, delegate_type_names);
 
     let collection_names = collect_used_generics_from_methods(&iface.methods);
     let observable_vector = observable_vector_name(iface);
@@ -147,7 +146,7 @@ pub fn generate_interface_stub(
         ));
     }
 
-    let mut sorted_delegates: Vec<_> = delegate_names.iter().collect();
+    let mut sorted_delegates: Vec<_> = runtime_delegate_names.iter().collect();
     sorted_delegates.sort();
     for dname in &sorted_delegates {
         let module = to_snake_case_filename(dname);
@@ -347,13 +346,16 @@ pub fn generate_class_stub(
     }
 
     let mut delegate_names = HashSet::new();
+    let mut runtime_delegate_names = HashSet::new();
     for iface in class.all_interfaces() {
-        delegate_names.extend(
-            super::collect_referenced_delegate_names(
-                &iface.methods,
-                delegate_type_names,
-            ),
-        );
+        delegate_names.extend(super::collect_referenced_delegate_names(
+            &iface.methods,
+            delegate_type_names,
+        ));
+        runtime_delegate_names.extend(super::collect_runtime_delegate_names(
+            &iface.methods,
+            delegate_type_names,
+        ));
     }
 
     let collection_names = collect_used_generics_from_class(class);
@@ -367,7 +369,7 @@ pub fn generate_class_stub(
         }
     }
 
-    let mut sorted_delegates: Vec<_> = delegate_names.iter().collect();
+    let mut sorted_delegates: Vec<_> = runtime_delegate_names.iter().collect();
     sorted_delegates.sort();
     for dname in &sorted_delegates {
         let module = to_snake_case_filename(dname);

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/stubs.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/stubs.rs
@@ -114,19 +114,11 @@ pub fn generate_interface_stub(
     }
     out.push('\n');
 
-    let mut delegate_names: HashSet<String> = delegate_type_names.clone();
-    for method in &iface.methods {
-        for p in &method.params {
-            if let TypeMeta::Delegate { name, .. } = &p.typ {
-                delegate_names.insert(name.clone());
-            }
-            if method.is_event_add || method.is_event_remove {
-                if let TypeMeta::Parameterized { name, args, .. } = &p.typ {
-                    delegate_names.insert(crate::meta::make_parameterized_name(name, args));
-                }
-            }
-        }
-    }
+    let delegate_names =
+        super::collect_referenced_delegate_names(
+            &iface.methods,
+            delegate_type_names,
+        );
 
     let collection_names = collect_used_generics_from_methods(&iface.methods);
     let observable_vector = observable_vector_name(iface);
@@ -354,20 +346,14 @@ pub fn generate_class_stub(
         out.push_str("_DispatchResultT = TypeVar('_DispatchResultT')\n\n");
     }
 
-    let mut delegate_names: HashSet<String> = delegate_type_names.clone();
+    let mut delegate_names = HashSet::new();
     for iface in class.all_interfaces() {
-        for method in &iface.methods {
-            for p in &method.params {
-                if let TypeMeta::Delegate { name, .. } = &p.typ {
-                    delegate_names.insert(name.clone());
-                }
-                if method.is_event_add || method.is_event_remove {
-                    if let TypeMeta::Parameterized { name, args, .. } = &p.typ {
-                        delegate_names.insert(crate::meta::make_parameterized_name(name, args));
-                    }
-                }
-            }
-        }
+        delegate_names.extend(
+            super::collect_referenced_delegate_names(
+                &iface.methods,
+                delegate_type_names,
+            ),
+        );
     }
 
     let collection_names = collect_used_generics_from_class(class);

--- a/tools/dynwinrt-codegen/src/codegen/winrt/python/type_helpers.rs
+++ b/tools/dynwinrt-codegen/src/codegen/winrt/python/type_helpers.rs
@@ -246,16 +246,40 @@ pub(super) fn py_method_outputs(method: &MethodMeta) -> Vec<(usize, &TypeMeta)> 
     outputs
 }
 
-fn py_output_type(
+fn is_delegate_output(typ: &TypeMeta, delegate_type_names: &HashSet<String>) -> bool {
+    match typ {
+        TypeMeta::Delegate { .. } => true,
+        TypeMeta::Interface { name, .. } => delegate_type_names.contains(name),
+        TypeMeta::Parameterized { name, args, .. } => {
+            delegate_type_names.contains(&crate::meta::make_parameterized_name(name, args))
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn py_output_type(
     typ: &TypeMeta,
     known_types: &HashSet<String>,
     delegate_type_names: &HashSet<String>,
 ) -> String {
     match typ {
-        TypeMeta::Delegate { .. } => "DynWinRTValue | None".to_string(),
-        TypeMeta::Interface { name, .. } if delegate_type_names.contains(name) => {
-            "DynWinRTValue | None".to_string()
+        _ if is_delegate_output(typ, delegate_type_names) => "DynWinRTValue | None".to_string(),
+        TypeMeta::Array(inner) if is_delegate_output(inner, delegate_type_names) => {
+            "list[DynWinRTValue | None]".to_string()
         }
+        TypeMeta::AsyncOperation(inner) => format!(
+            "WinRTAsync[{}]",
+            py_output_type(inner, known_types, delegate_type_names)
+        ),
+        TypeMeta::AsyncOperationWithProgress(result, progress) => format!(
+            "WinRTAsyncWithProgress[{}, {}]",
+            py_output_type(result, known_types, delegate_type_names),
+            py_output_type(progress, known_types, delegate_type_names)
+        ),
+        TypeMeta::AsyncActionWithProgress(progress) => format!(
+            "WinRTAsyncWithProgress[None, {}]",
+            py_output_type(progress, known_types, delegate_type_names)
+        ),
         _ => py_return_type_safe(Some(typ), known_types),
     }
 }

--- a/tools/dynwinrt-codegen/tests/delegate_dependency_closure_test.rs
+++ b/tools/dynwinrt-codegen/tests/delegate_dependency_closure_test.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::{HashMap, HashSet};
+
+use dynwinrt_codegen::codegen::{
+    project, python, python_stub, render_js,
+};
+use dynwinrt_codegen::meta::{
+    InterfaceMeta, MethodMeta, ParamDirection, ParamMeta,
+};
+use dynwinrt_codegen::types::TypeMeta;
+
+fn delegate_interface(name: &str) -> TypeMeta {
+    TypeMeta::Interface {
+        namespace: "Contoso".into(),
+        name: name.into(),
+        iid: String::new(),
+    }
+}
+
+#[test]
+fn generated_interfaces_import_only_referenced_delegates() {
+    let interface = InterfaceMeta {
+        name: "IDataSource".into(),
+        namespace: "Contoso".into(),
+        iid: "11111111-1111-1111-1111-111111111111".into(),
+        methods: vec![
+            MethodMeta {
+                name: "SetDataProvider".into(),
+                raw_name: "SetDataProvider".into(),
+                vtable_index: 6,
+                params: vec![ParamMeta {
+                    name: "callback".into(),
+                    typ: delegate_interface("DataProviderHandler"),
+                    direction: ParamDirection::In,
+                }],
+                ..Default::default()
+            },
+            MethodMeta {
+                name: "GetCallbacksAsync".into(),
+                raw_name: "GetCallbacksAsync".into(),
+                vtable_index: 7,
+                return_type: Some(TypeMeta::AsyncOperation(
+                    Box::new(TypeMeta::Array(Box::new(
+                        delegate_interface("AsyncHandler"),
+                    ))),
+                )),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let known_types = HashSet::from([
+        "IDataSource".into(),
+        "DataProviderHandler".into(),
+        "AsyncHandler".into(),
+        "UnrelatedHandler".into(),
+    ]);
+    let delegates = HashSet::from([
+        "DataProviderHandler".into(),
+        "AsyncHandler".into(),
+        "UnrelatedHandler".into(),
+    ]);
+    let signatures = HashMap::from([
+        (
+            "DataProviderHandler".into(),
+            "(value: unknown) => void".into(),
+        ),
+        (
+            "AsyncHandler".into(),
+            "() => void".into(),
+        ),
+        (
+            "UnrelatedHandler".into(),
+            "() => void".into(),
+        ),
+    ]);
+    let projected = project::project_interface(
+        &interface,
+        &known_types,
+        &delegates,
+        &signatures,
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let js = render_js::render(&projected);
+    let py = python::generate_interface(
+        &interface,
+        &known_types,
+        &delegates,
+    );
+    let pyi = python_stub::generate_interface_stub(
+        &interface,
+        &known_types,
+        &delegates,
+    );
+
+    for generated in [&js, &py, &pyi] {
+        assert!(
+            generated.contains("DataProviderHandler")
+                || generated.contains("data_provider_handler"),
+            "{generated}",
+        );
+        assert!(
+            generated.contains("AsyncHandler")
+                || generated.contains("async_handler"),
+            "{generated}",
+        );
+        assert!(
+            !generated.contains("UnrelatedHandler")
+                && !generated.contains("unrelated_handler"),
+            "{generated}",
+        );
+    }
+}
+
+#[test]
+fn delegate_free_interfaces_do_not_import_global_delegates() {
+    let interface = InterfaceMeta {
+        name: "IValue".into(),
+        namespace: "Contoso".into(),
+        iid: "22222222-2222-2222-2222-222222222222".into(),
+        ..Default::default()
+    };
+    let known_types = HashSet::from([
+        "IValue".into(),
+        "UnrelatedHandler".into(),
+    ]);
+    let delegates =
+        HashSet::from(["UnrelatedHandler".into()]);
+    let projected = project::project_interface(
+        &interface,
+        &known_types,
+        &delegates,
+        &HashMap::new(),
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+
+    assert!(
+        !render_js::render(&projected)
+            .contains("UnrelatedHandler"),
+    );
+    assert!(
+        !python::generate_interface(
+            &interface,
+            &known_types,
+            &delegates,
+        )
+        .contains("unrelated_handler"),
+    );
+    assert!(
+        !python_stub::generate_interface_stub(
+            &interface,
+            &known_types,
+            &delegates,
+        )
+        .contains("unrelated_handler"),
+    );
+}

--- a/tools/dynwinrt-codegen/tests/delegate_dependency_closure_test.rs
+++ b/tools/dynwinrt-codegen/tests/delegate_dependency_closure_test.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 
 use dynwinrt_codegen::codegen::{project, python, python_stub, render_dts, render_js};
-use dynwinrt_codegen::meta::{InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
+use dynwinrt_codegen::meta::{ClassMeta, InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
 use dynwinrt_codegen::types::TypeMeta;
 
 fn delegate_interface(name: &str) -> TypeMeta {
@@ -16,7 +16,7 @@ fn delegate_interface(name: &str) -> TypeMeta {
 }
 
 #[test]
-fn generated_interfaces_import_only_referenced_delegates() {
+fn generated_interfaces_import_only_runtime_delegates() {
     let interface = InterfaceMeta {
         name: "IDataSource".into(),
         namespace: "Contoso".into(),
@@ -70,6 +70,13 @@ fn generated_interfaces_import_only_referenced_delegates() {
                 is_property_getter: true,
                 ..Default::default()
             },
+            MethodMeta {
+                name: "GetDataProvider".into(),
+                raw_name: "GetDataProvider".into(),
+                vtable_index: 11,
+                return_type: Some(delegate_interface("DataProviderHandler")),
+                ..Default::default()
+            },
         ],
         ..Default::default()
     };
@@ -105,14 +112,24 @@ fn generated_interfaces_import_only_referenced_delegates() {
     let py = python::generate_interface(&interface, &known_types, &delegates);
     let pyi = python_stub::generate_interface_stub(&interface, &known_types, &delegates);
 
+    assert_eq!(
+        js.matches("require('./DataProviderHandler.js')").count(),
+        1,
+        "{js}",
+    );
+    assert_eq!(
+        py.matches("from .data_provider_handler import").count(),
+        1,
+        "{py}",
+    );
+    assert_eq!(
+        pyi.matches("from .data_provider_handler import").count(),
+        1,
+        "{pyi}",
+    );
     for generated in [&js, &py, &pyi] {
         assert!(
-            generated.contains("DataProviderHandler")
-                || generated.contains("data_provider_handler"),
-            "{generated}",
-        );
-        assert!(
-            generated.contains("AsyncHandler") || generated.contains("async_handler"),
+            !generated.contains("AsyncHandler") && !generated.contains("async_handler"),
             "{generated}",
         );
         assert!(
@@ -138,6 +155,7 @@ fn generated_interfaces_import_only_referenced_delegates() {
             && dts.contains("getCallback(): DynWinRtValue | null",)
             && dts.contains("getCallbackOut(): DynWinRtValue | null",)
             && dts.contains("get callbacks(): Array<DynWinRtValue | null>",)
+            && dts.contains("getDataProvider(): DynWinRtValue | null",)
             && !dts.contains("Promise<AsyncHandler[]>"),
         "{dts}",
     );
@@ -154,6 +172,85 @@ fn generated_interfaces_import_only_referenced_delegates() {
             && !pyi.contains("WinRTAsync[list[AsyncHandler | None]]",),
         "{pyi}",
     );
+}
+
+#[test]
+fn generated_classes_do_not_import_output_only_delegates() {
+    let class = ClassMeta {
+        name: "CallbackSource".into(),
+        namespace: "Contoso".into(),
+        full_name: "Contoso.CallbackSource".into(),
+        default_interface: Some(InterfaceMeta {
+            name: "ICallbackSource".into(),
+            namespace: "Contoso".into(),
+            iid: "33333333-3333-3333-3333-333333333333".into(),
+            methods: vec![
+                MethodMeta {
+                    name: "SetHandler".into(),
+                    raw_name: "SetHandler".into(),
+                    vtable_index: 6,
+                    params: vec![ParamMeta {
+                        name: "callback".into(),
+                        typ: delegate_interface("InputHandler"),
+                        direction: ParamDirection::In,
+                    }],
+                    ..Default::default()
+                },
+                MethodMeta {
+                    name: "GetHandlerAsync".into(),
+                    raw_name: "GetHandlerAsync".into(),
+                    vtable_index: 7,
+                    return_type: Some(TypeMeta::AsyncOperation(Box::new(delegate_interface(
+                        "OutputHandler",
+                    )))),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let known_types = HashSet::from([
+        "CallbackSource".into(),
+        "ICallbackSource".into(),
+        "InputHandler".into(),
+        "OutputHandler".into(),
+    ]);
+    let delegates = HashSet::from(["InputHandler".into(), "OutputHandler".into()]);
+    let signatures = HashMap::from([
+        ("InputHandler".into(), "() => void".into()),
+        ("OutputHandler".into(), "() => void".into()),
+    ]);
+    let projected = project::project_class(
+        &class,
+        &known_types,
+        &delegates,
+        &HashSet::new(),
+        &signatures,
+        &HashMap::new(),
+        &HashMap::new(),
+    );
+    let js = render_js::render(&projected);
+    let dts = render_dts::render(&projected);
+    let py = python::generate_class(&class, &known_types, &delegates, &HashSet::new());
+    let pyi = python_stub::generate_class_stub(&class, &known_types, &delegates, &HashSet::new());
+
+    assert!(
+        js.contains("require('./InputHandler.js')")
+            && !js.contains("require('./OutputHandler.js')"),
+        "{js}",
+    );
+    assert!(
+        dts.contains("getHandlerAsync(signal?: AbortSignal): Promise<DynWinRtValue | null>",),
+        "{dts}",
+    );
+    for generated in [&py, &pyi] {
+        assert!(
+            generated.contains("from .input_handler import",)
+                && !generated.contains("from .output_handler import",),
+            "{generated}",
+        );
+    }
 }
 
 #[test]

--- a/tools/dynwinrt-codegen/tests/delegate_dependency_closure_test.rs
+++ b/tools/dynwinrt-codegen/tests/delegate_dependency_closure_test.rs
@@ -3,12 +3,8 @@
 
 use std::collections::{HashMap, HashSet};
 
-use dynwinrt_codegen::codegen::{
-    project, python, python_stub, render_js,
-};
-use dynwinrt_codegen::meta::{
-    InterfaceMeta, MethodMeta, ParamDirection, ParamMeta,
-};
+use dynwinrt_codegen::codegen::{project, python, python_stub, render_dts, render_js};
+use dynwinrt_codegen::meta::{InterfaceMeta, MethodMeta, ParamDirection, ParamMeta};
 use dynwinrt_codegen::types::TypeMeta;
 
 fn delegate_interface(name: &str) -> TypeMeta {
@@ -41,11 +37,37 @@ fn generated_interfaces_import_only_referenced_delegates() {
                 name: "GetCallbacksAsync".into(),
                 raw_name: "GetCallbacksAsync".into(),
                 vtable_index: 7,
-                return_type: Some(TypeMeta::AsyncOperation(
-                    Box::new(TypeMeta::Array(Box::new(
-                        delegate_interface("AsyncHandler"),
-                    ))),
-                )),
+                return_type: Some(TypeMeta::AsyncOperation(Box::new(TypeMeta::Array(
+                    Box::new(delegate_interface("AsyncHandler")),
+                )))),
+                ..Default::default()
+            },
+            MethodMeta {
+                name: "GetCallback".into(),
+                raw_name: "GetCallback".into(),
+                vtable_index: 8,
+                return_type: Some(delegate_interface("AsyncHandler")),
+                ..Default::default()
+            },
+            MethodMeta {
+                name: "GetCallbackOut".into(),
+                raw_name: "GetCallbackOut".into(),
+                vtable_index: 9,
+                params: vec![ParamMeta {
+                    name: "callback".into(),
+                    typ: delegate_interface("AsyncHandler"),
+                    direction: ParamDirection::Out,
+                }],
+                ..Default::default()
+            },
+            MethodMeta {
+                name: "get_Callbacks".into(),
+                raw_name: "get_Callbacks".into(),
+                vtable_index: 10,
+                return_type: Some(TypeMeta::Array(Box::new(delegate_interface(
+                    "AsyncHandler",
+                )))),
+                is_property_getter: true,
                 ..Default::default()
             },
         ],
@@ -67,14 +89,8 @@ fn generated_interfaces_import_only_referenced_delegates() {
             "DataProviderHandler".into(),
             "(value: unknown) => void".into(),
         ),
-        (
-            "AsyncHandler".into(),
-            "() => void".into(),
-        ),
-        (
-            "UnrelatedHandler".into(),
-            "() => void".into(),
-        ),
+        ("AsyncHandler".into(), "() => void".into()),
+        ("UnrelatedHandler".into(), "() => void".into()),
     ]);
     let projected = project::project_interface(
         &interface,
@@ -85,16 +101,9 @@ fn generated_interfaces_import_only_referenced_delegates() {
         &HashMap::new(),
     );
     let js = render_js::render(&projected);
-    let py = python::generate_interface(
-        &interface,
-        &known_types,
-        &delegates,
-    );
-    let pyi = python_stub::generate_interface_stub(
-        &interface,
-        &known_types,
-        &delegates,
-    );
+    let dts = render_dts::render(&projected);
+    let py = python::generate_interface(&interface, &known_types, &delegates);
+    let pyi = python_stub::generate_interface_stub(&interface, &known_types, &delegates);
 
     for generated in [&js, &py, &pyi] {
         assert!(
@@ -103,16 +112,48 @@ fn generated_interfaces_import_only_referenced_delegates() {
             "{generated}",
         );
         assert!(
-            generated.contains("AsyncHandler")
-                || generated.contains("async_handler"),
+            generated.contains("AsyncHandler") || generated.contains("async_handler"),
             "{generated}",
         );
         assert!(
-            !generated.contains("UnrelatedHandler")
-                && !generated.contains("unrelated_handler"),
+            !generated.contains("UnrelatedHandler") && !generated.contains("unrelated_handler"),
             "{generated}",
         );
     }
+
+    assert!(
+        js.contains(".asArray().toValues().map(v => v.isNull() ? null : v)",)
+            && !js.contains("new AsyncHandler")
+            && !js.contains("__get_AsyncHandler"),
+        "{js}",
+    );
+    assert!(
+        js.contains("getCallback()")
+            && js.contains("((v) => v.isNull() ? null : v)",)
+            && js.contains("getCallbackOut()"),
+        "{js}",
+    );
+    assert!(
+        dts.contains("Promise<Array<DynWinRtValue | null>>",)
+            && dts.contains("getCallback(): DynWinRtValue | null",)
+            && dts.contains("getCallbackOut(): DynWinRtValue | null",)
+            && dts.contains("get callbacks(): Array<DynWinRtValue | null>",)
+            && !dts.contains("Promise<AsyncHandler[]>"),
+        "{dts}",
+    );
+    assert!(
+        py.contains("WinRTAsync[list[DynWinRTValue | None]]",)
+            && py.contains("value.as_array().to_values()",)
+            && py.contains("def callbacks(self) -> list[DynWinRTValue | None]:",)
+            && !py.contains("WinRTAsync[list[AsyncHandler | None]]",),
+        "{py}",
+    );
+    assert!(
+        pyi.contains("WinRTAsync[list[DynWinRTValue | None]]",)
+            && pyi.contains("def callbacks(self) -> list[DynWinRTValue | None]:",)
+            && !pyi.contains("WinRTAsync[list[AsyncHandler | None]]",),
+        "{pyi}",
+    );
 }
 
 #[test]
@@ -123,12 +164,8 @@ fn delegate_free_interfaces_do_not_import_global_delegates() {
         iid: "22222222-2222-2222-2222-222222222222".into(),
         ..Default::default()
     };
-    let known_types = HashSet::from([
-        "IValue".into(),
-        "UnrelatedHandler".into(),
-    ]);
-    let delegates =
-        HashSet::from(["UnrelatedHandler".into()]);
+    let known_types = HashSet::from(["IValue".into(), "UnrelatedHandler".into()]);
+    let delegates = HashSet::from(["UnrelatedHandler".into()]);
     let projected = project::project_interface(
         &interface,
         &known_types,
@@ -138,24 +175,13 @@ fn delegate_free_interfaces_do_not_import_global_delegates() {
         &HashMap::new(),
     );
 
+    assert!(!render_js::render(&projected).contains("UnrelatedHandler"),);
     assert!(
-        !render_js::render(&projected)
-            .contains("UnrelatedHandler"),
+        !python::generate_interface(&interface, &known_types, &delegates,)
+            .contains("unrelated_handler"),
     );
     assert!(
-        !python::generate_interface(
-            &interface,
-            &known_types,
-            &delegates,
-        )
-        .contains("unrelated_handler"),
-    );
-    assert!(
-        !python_stub::generate_interface_stub(
-            &interface,
-            &known_types,
-            &delegates,
-        )
-        .contains("unrelated_handler"),
+        !python_stub::generate_interface_stub(&interface, &known_types, &delegates,)
+            .contains("unrelated_handler"),
     );
 }


### PR DESCRIPTION
## Summary

- Collect delegate dependencies from the signatures actually referenced by each generated type instead of including every known delegate.
- Recursively resolve delegates used by parameters, return values, arrays, parameterized types, async/progress operations, runtime-class default interfaces, and struct fields.
- Apply the same dependency-closure logic to JavaScript generation, Python runtime generation, and Python stubs.
- Add regression coverage for referenced, nested, unrelated, and delegate-free signatures.