### PR TITLE
Add Electron sample for Windows SMTC and GSMTC media controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,16 @@ instructions are in [`bindings/py/README.md`](bindings/py/README.md).
 Python runtime, codegen, packaging, and WinUI readiness are tracked in
 [`docs/status/PYTHON_CHECKLIST.md`](docs/status/PYTHON_CHECKLIST.md).
 
+Electron samples include:
+
+- [Windows Hello](samples/js/windows-hello/README.md) — WinRT async APIs and
+  HWND-bound Classic COM interop.
+- [Share UI](samples/js/electron-share-ui/README.md) — typed WinRT and
+  `IDataTransferManagerInterop`.
+- [System Media Controls](samples/js/electron-smtc/README.md) — complete SMTC
+  publication and GSMTC loopback control, with automated event and state
+  validation.
+
 For deployment, see
 [Package a dynwinrt Node.js application as MSIX](docs/guides/windows/msix-packaging.md).
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ Electron samples include:
   HWND-bound Classic COM interop.
 - [Share UI](samples/js/electron-share-ui/README.md) — typed WinRT and
   `IDataTransferManagerInterop`.
-- [System Media Controls](samples/js/electron-smtc/README.md) — complete SMTC
-  publication and GSMTC loopback control, with automated event and state
-  validation.
+- [System Media Controls](samples/js/electron-smtc/README.md) — interactive,
+  end-to-end SMTC publication and GSMTC loopback control with playlist,
+  artwork, live timeline, session discovery, and automated validation.
 
 For deployment, see
 [Package a dynwinrt Node.js application as MSIX](docs/guides/windows/msix-packaging.md).

--- a/samples/js/electron-smtc/.gitignore
+++ b/samples/js/electron-smtc/.gitignore
@@ -1,0 +1,4 @@
+Assets/
+generated/
+node_modules/
+.winapp/

--- a/samples/js/electron-smtc/README.md
+++ b/samples/js/electron-smtc/README.md
@@ -12,11 +12,22 @@ The sample covers:
 
 - acquiring SMTC for an Electron `BrowserWindow` HWND through
   `ISystemMediaTransportControlsInterop`;
-- metadata and `SystemMediaTransportControlsDisplayUpdater`;
-- playback state and timeline updates;
-- play, pause, next, previous, seek, playback-rate, shuffle, and repeat requests;
-- SMTC and GSMTC event subscriptions; and
-- media-property, playback-info, and timeline round trips.
+- a three-track playlist with generated artwork, rich music metadata, and
+  `SystemMediaTransportControlsDisplayUpdater`;
+- a live playback clock with track transitions, seek, rate, shuffle, and repeat;
+- play, pause, toggle, stop, next, previous, record, fast-forward, rewind, and
+  channel requests;
+- SMTC sound-level, transport, and request events;
+- GSMTC manager, media-property, playback-info, and timeline events;
+- global session discovery and current-session highlighting; and
+- the complete GSMTC playback capability matrix.
+
+The UI presents the SMTC publisher and GSMTC controller side by side so each
+request and resulting state change is visible. A small Web Audio synthesizer
+generates original notes locally and follows the published playback state,
+track, position, and rate; no media files or network downloads are used. The
+window uses native Windows 11 Mica plus the system light/dark theme, accent
+color, and Fluent-style controls.
 
 ## Prerequisites
 
@@ -47,8 +58,11 @@ npm run generate
 npm start
 ```
 
-To launch the UI and immediately populate it with a complete successful
-loopback run:
+Use the GSMTC panel to control the published session, or use Windows hardware
+media keys and the system media UI. The session list also shows other media
+applications visible to GSMTC.
+
+To launch the UI and immediately populate it with a successful loopback run:
 
 ```powershell
 npm run demo
@@ -61,6 +75,8 @@ npm run check
 ```
 
 The check registers the Electron debug identity, runs a hidden Electron window,
-publishes an SMTC session, discovers it through GSMTC, issues real transport
-requests, verifies the resulting callbacks and state, prints the result as
-JSON, and exits nonzero on any failure.
+publishes an SMTC session, discovers it through GSMTC, issues every supported
+transport request, verifies artwork and metadata, exercises the live timeline
+and playlist, validates the capability matrix and event round trips, prints the
+result as JSON, and exits nonzero on any failure. Synthesized audio is disabled
+in this validation mode.

--- a/samples/js/electron-smtc/README.md
+++ b/samples/js/electron-smtc/README.md
@@ -1,0 +1,66 @@
+# Electron System Media Controls
+
+This sample uses dynwinrt to exercise both Windows media-control surfaces from
+one Electron process:
+
+- **SMTC** (`Windows.Media.SystemMediaTransportControls`) publishes the Electron
+  window as a media source for hardware keys and the Windows media UI.
+- **GSMTC** (`Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager`)
+  discovers that session and controls it as another media controller would.
+
+The sample covers:
+
+- acquiring SMTC for an Electron `BrowserWindow` HWND through
+  `ISystemMediaTransportControlsInterop`;
+- metadata and `SystemMediaTransportControlsDisplayUpdater`;
+- playback state and timeline updates;
+- play, pause, next, previous, seek, playback-rate, shuffle, and repeat requests;
+- SMTC and GSMTC event subscriptions; and
+- media-property, playback-info, and timeline round trips.
+
+## Prerequisites
+
+- Windows 10 version 1809 or later;
+- Node.js and Rust/Cargo;
+- a Windows SDK containing `Windows.winmd`;
+- `Microsoft.Windows.SDK.Win32Metadata` in the NuGet global cache (or set
+  `DYNWINRT_WIN32_WINMD`); and
+- Developer Mode, because the sample registers a sparse debug identity with
+  the restricted `globalMediaControl` capability.
+
+## Run
+
+Build the local JavaScript runtime once from the repository root:
+
+```powershell
+cd bindings\js
+npm install
+npm run build
+```
+
+Then install, generate, and start the sample:
+
+```powershell
+cd samples\js\electron-smtc
+npm install
+npm run generate
+npm start
+```
+
+To launch the UI and immediately populate it with a complete successful
+loopback run:
+
+```powershell
+npm run demo
+```
+
+## Automated loopback validation
+
+```powershell
+npm run check
+```
+
+The check registers the Electron debug identity, runs a hidden Electron window,
+publishes an SMTC session, discovers it through GSMTC, issues real transport
+requests, verifies the resulting callbacks and state, prints the result as
+JSON, and exits nonzero on any failure.

--- a/samples/js/electron-smtc/README.md
+++ b/samples/js/electron-smtc/README.md
@@ -20,8 +20,8 @@ The sample covers:
 
 ## Prerequisites
 
-- Windows 10 version 1809 or later;
-- Node.js and Rust/Cargo;
+- Windows 10 version 2004 or later;
+- Node.js 22.12 or later and Rust/Cargo;
 - a Windows SDK containing `Windows.winmd`;
 - `Microsoft.Windows.SDK.Win32Metadata` in the NuGet global cache (or set
   `DYNWINRT_WIN32_WINMD`); and

--- a/samples/js/electron-smtc/appxmanifest.xml
+++ b/samples/js/electron-smtc/appxmanifest.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  IgnorableNamespaces="uap rescap uap10">
+  <Identity
+    Name="dynwinrt-smtc-sample"
+    Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+    Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>dynwinrt SMTC Sample</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily
+      Name="Windows.Desktop"
+      MinVersion="10.0.19041.0"
+      MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Applications>
+    <Application
+      Id="dynwinrtSmtcSample"
+      Executable="electron.exe"
+      uap10:TrustLevel="mediumIL"
+      uap10:RuntimeBehavior="packagedClassicApp">
+      <uap:VisualElements
+        DisplayName="dynwinrt SMTC Sample"
+        Description="Electron SMTC and GSMTC loopback sample"
+        BackgroundColor="#005fb8"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png" />
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <rescap:Capability Name="globalMediaControl" />
+  </Capabilities>
+</Package>

--- a/samples/js/electron-smtc/generate.ps1
+++ b/samples/js/electron-smtc/generate.ps1
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+$output = Join-Path $PSScriptRoot "generated"
+
+$windowsWinmd = Get-ChildItem `
+    "C:\Program Files (x86)\Windows Kits\10\UnionMetadata" `
+    -Filter Windows.winmd `
+    -Recurse `
+    -ErrorAction SilentlyContinue |
+    Sort-Object FullName -Descending |
+    Select-Object -First 1 -ExpandProperty FullName
+
+if (-not $windowsWinmd) {
+    throw "Windows.winmd was not found. Install a Windows 10/11 SDK."
+}
+
+$win32Winmd = $env:DYNWINRT_WIN32_WINMD
+if (-not $win32Winmd -or -not (Test-Path $win32Winmd)) {
+    $win32Winmd = Get-ChildItem `
+        (Join-Path $env:USERPROFILE ".nuget\packages\microsoft.windows.sdk.win32metadata") `
+        -Filter Windows.Win32.winmd `
+        -Recurse `
+        -ErrorAction SilentlyContinue |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+
+if (-not $win32Winmd) {
+    throw "Windows.Win32.winmd was not found. Set DYNWINRT_WIN32_WINMD or install Microsoft.Windows.SDK.Win32Metadata."
+}
+
+if (Test-Path $output) {
+    Remove-Item $output -Recurse -Force
+}
+
+& cargo run --quiet --manifest-path (Join-Path $repoRoot "Cargo.toml") `
+    -p dynwinrt-codegen -- generate `
+    --winmd $windowsWinmd `
+    --class-name "Windows.Media.SystemMediaTransportControls,Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager" `
+    --output $output
+if ($LASTEXITCODE -ne 0) {
+    throw "WinRT generation failed with exit code $LASTEXITCODE."
+}
+
+& cargo run --quiet --manifest-path (Join-Path $repoRoot "Cargo.toml") `
+    -p dynwinrt-codegen -- generate `
+    --winmd $win32Winmd `
+    --ref $windowsWinmd `
+    --class-name Windows.Win32.System.WinRT.ISystemMediaTransportControlsInterop `
+    --output $output
+if ($LASTEXITCODE -ne 0) {
+    throw "Classic COM generation failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Generated SMTC and GSMTC bindings in $output"

--- a/samples/js/electron-smtc/index.html
+++ b/samples/js/electron-smtc/index.html
@@ -4,44 +4,317 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'"
+      content="default-src 'self'; img-src 'self'; script-src 'self'; style-src 'self'"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>dynwinrt System Media Controls</title>
     <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
-    <main>
-      <h1>System Media Controls</h1>
-      <p>
-        Publish an Electron SMTC session, then discover and control it through
-        the global GSMTC session manager.
-      </p>
-      <div class="form">
-        <label>Title <input id="title" value="dynwinrt SMTC sample" /></label>
-        <label>Artist <input id="artist" value="dynwinrt" /></label>
-        <label
-          >Duration (seconds)
-          <input id="duration" type="number" value="300" min="1"
-        /></label>
-        <label
-          >Seek position (seconds)
-          <input id="position" type="number" value="42" min="0"
-        /></label>
-      </div>
-      <div class="actions">
-        <button id="initialize">Initialize</button>
-        <button id="update">Update metadata/timeline</button>
-        <button id="play">Play through GSMTC</button>
-        <button id="pause">Pause through GSMTC</button>
-        <button id="seek">Seek through GSMTC</button>
-        <button id="validate">Run full validation</button>
-      </div>
-      <h2>State</h2>
-      <pre id="status">Not initialized.</pre>
-      <h2>Events</h2>
-      <pre id="events">Waiting for events…</pre>
-    </main>
+    <div class="app-shell">
+      <header class="app-header">
+        <div class="brand">
+          <div class="app-mark" aria-hidden="true">♪</div>
+          <div>
+            <h1>System Media Controls</h1>
+            <p>SMTC publisher and GSMTC controller loopback</p>
+          </div>
+        </div>
+        <div class="header-actions">
+          <span id="connection-status" class="status-pill idle"
+            >Not initialized</span
+          >
+          <button id="validate" class="button subtle">Run validation</button>
+          <button id="initialize" class="button primary">
+            Start media session
+          </button>
+        </div>
+      </header>
+
+      <main>
+        <section class="player-surface">
+          <aside class="playlist-pane">
+            <div class="pane-heading">
+              <span class="overline">Queue</span>
+              <h2>Runtime Radio</h2>
+              <p>Original audio synthesized locally</p>
+            </div>
+
+            <ol id="playlist" class="playlist">
+              <li class="active">Neon Window</li>
+              <li>Metadata Drive</li>
+              <li>Interop Nights</li>
+            </ol>
+
+            <details class="metadata-editor">
+              <summary>Edit current metadata</summary>
+              <div class="form-grid">
+                <label>
+                  Title
+                  <input id="title" value="Neon Window" />
+                </label>
+                <label>
+                  Artist
+                  <input id="artist" value="dynwinrt Ensemble" />
+                </label>
+                <label>
+                  Duration in seconds
+                  <input id="duration" type="number" value="185" min="1" />
+                </label>
+                <button id="update" class="button primary">
+                  Publish metadata
+                </button>
+              </div>
+            </details>
+          </aside>
+
+          <section class="now-playing-pane">
+            <div class="cover-stage">
+              <img
+                id="publisher-artwork"
+                class="artwork"
+                src="./Assets/AlbumBlue.png"
+                alt="Current album artwork"
+              />
+            </div>
+
+            <div class="track-copy">
+              <span id="publisher-track-number" class="overline"
+                >Track 1 of 3</span
+              >
+              <h2 id="publisher-title">Neon Window</h2>
+              <p id="publisher-artist" class="artist">dynwinrt Ensemble</p>
+              <p id="publisher-album" class="secondary">
+                Runtime Radio · Electronic
+              </p>
+              <div class="state-row">
+                <span id="publisher-status" class="state-chip">Stopped</span>
+                <span id="publisher-rate" class="state-chip">1.00x</span>
+                <span id="publisher-mode" class="state-chip">Sequential</span>
+              </div>
+            </div>
+
+            <div class="timeline">
+              <input
+                id="seek"
+                type="range"
+                min="0"
+                max="185"
+                value="0"
+                aria-label="Seek through GSMTC"
+              />
+              <input
+                id="publisher-progress"
+                class="visually-hidden"
+                type="range"
+                min="0"
+                max="185"
+                value="0"
+                disabled
+                aria-hidden="true"
+              />
+              <div class="timeline-labels">
+                <span id="publisher-position">0:00</span>
+                <span id="seek-value" class="visually-hidden">0:00</span>
+                <span id="publisher-duration">3:05</span>
+              </div>
+            </div>
+
+            <div class="transport" aria-label="GSMTC transport controls">
+              <button
+                data-action="previous"
+                data-capability="previous"
+                class="icon-button"
+                aria-label="Previous track"
+                title="Previous track"
+              >
+                <svg viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M4 4h2v12H4V4Zm3 6 9-6v12l-9-6Z" />
+                </svg>
+              </button>
+              <button
+                data-action="rewind"
+                data-capability="rewind"
+                class="icon-button"
+                aria-label="Rewind 15 seconds"
+                title="Rewind 15 seconds"
+              >
+                <svg viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M9 4v4l-6-4v12l6-4v4l8-6-8-6Z" />
+                </svg>
+              </button>
+              <button
+                data-action="toggle"
+                data-capability="toggle"
+                class="icon-button play-button primary"
+                aria-label="Play or pause"
+                title="Play or pause"
+              >
+                <svg viewBox="0 0 20 20" aria-hidden="true">
+                  <path id="toggle-icon-path" d="M6 3.8v12.4L16 10 6 3.8Z" />
+                </svg>
+              </button>
+              <button
+                data-action="stop"
+                data-capability="stop"
+                class="icon-button"
+                aria-label="Stop"
+                title="Stop"
+              >
+                <svg viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M5 5h10v10H5V5Z" />
+                </svg>
+              </button>
+              <button
+                data-action="fastForward"
+                data-capability="fastForward"
+                class="icon-button"
+                aria-label="Forward 15 seconds"
+                title="Forward 15 seconds"
+              >
+                <svg viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M11 4v4l6-4v12l-6-4v4l-8-6 8-6Z" />
+                </svg>
+              </button>
+              <button
+                data-action="next"
+                data-capability="next"
+                class="icon-button"
+                aria-label="Next track"
+                title="Next track"
+              >
+                <svg viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="m4 4 9 6-9 6V4Zm10 0h2v12h-2V4Z" />
+                </svg>
+              </button>
+            </div>
+
+            <div class="playback-options">
+              <div class="audio-status">
+                <div class="audio-glyph" aria-hidden="true">♫</div>
+                <div>
+                  <strong>Generated audio</strong>
+                  <span id="audio-status">Ready when playback starts</span>
+                </div>
+                <button id="audio-toggle" class="button subtle">Mute</button>
+              </div>
+
+              <label>
+                Speed
+                <select id="rate">
+                  <option value="0.5">0.50x</option>
+                  <option value="1" selected>1.00x</option>
+                  <option value="1.25">1.25x</option>
+                  <option value="1.5">1.50x</option>
+                  <option value="2">2.00x</option>
+                </select>
+              </label>
+
+              <label class="switch-option">
+                <input id="shuffle" type="checkbox" />
+                <span>Shuffle</span>
+              </label>
+
+              <label>
+                Repeat
+                <select id="repeat">
+                  <option value="0" selected>None</option>
+                  <option value="1">Track</option>
+                  <option value="2">List</option>
+                </select>
+              </label>
+            </div>
+
+            <details class="advanced-controls">
+              <summary>More transport controls</summary>
+              <div class="advanced-actions">
+                <button
+                  data-action="record"
+                  data-capability="record"
+                  class="button"
+                >
+                  Record request
+                </button>
+                <button
+                  data-action="channelDown"
+                  data-capability="channelDown"
+                  class="button"
+                >
+                  Channel down
+                </button>
+                <button
+                  data-action="channelUp"
+                  data-capability="channelUp"
+                  class="button"
+                >
+                  Channel up
+                </button>
+              </div>
+            </details>
+          </section>
+        </section>
+
+        <section class="observer-grid">
+          <article class="info-card gsmct-card">
+            <div class="card-heading">
+              <div>
+                <span class="overline">Observed through GSMTC</span>
+                <h2>Global media session</h2>
+              </div>
+              <span class="role-badge">Controller</span>
+            </div>
+            <div class="session-summary">
+              <img
+                id="controller-artwork"
+                class="artwork-small"
+                src="./Assets/AlbumBlue.png"
+                alt="Artwork observed through GSMTC"
+              />
+              <div>
+                <h3 id="controller-title">Waiting for session</h3>
+                <p id="controller-artist">No media properties yet</p>
+                <p id="controller-source" class="source-id">Source AUMID</p>
+              </div>
+            </div>
+            <div id="capabilities" class="capability-grid">
+              <span class="capability pending">Waiting for playback info</span>
+            </div>
+          </article>
+
+          <article class="info-card sessions-card">
+            <div class="card-heading">
+              <div>
+                <span class="overline">Windows discovery</span>
+                <h2>Media sessions</h2>
+              </div>
+              <button id="refresh-sessions" class="button subtle">
+                Refresh
+              </button>
+            </div>
+            <div id="sessions" class="sessions">
+              <p class="empty-state">Start the sample to enumerate GSMTC.</p>
+            </div>
+          </article>
+        </section>
+
+        <details class="developer-tools">
+          <summary>Developer diagnostics</summary>
+          <div class="diagnostics">
+            <div class="diagnostics-heading">
+              <h2>SMTC and GSMTC event flow</h2>
+              <button id="clear-events" class="button subtle">Clear</button>
+            </div>
+            <ol id="events" class="event-list">
+              <li class="empty-state">Waiting for SMTC and GSMTC events.</li>
+            </ol>
+            <details class="validation-output">
+              <summary>Validation result</summary>
+              <pre id="status">No validation has run.</pre>
+            </details>
+          </div>
+        </details>
+      </main>
+    </div>
     <script src="./renderer.js"></script>
   </body>
 </html>

--- a/samples/js/electron-smtc/index.html
+++ b/samples/js/electron-smtc/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self'"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>dynwinrt System Media Controls</title>
+    <link rel="stylesheet" href="./style.css" />
+  </head>
+  <body>
+    <main>
+      <h1>System Media Controls</h1>
+      <p>
+        Publish an Electron SMTC session, then discover and control it through
+        the global GSMTC session manager.
+      </p>
+      <div class="form">
+        <label>Title <input id="title" value="dynwinrt SMTC sample" /></label>
+        <label>Artist <input id="artist" value="dynwinrt" /></label>
+        <label
+          >Duration (seconds)
+          <input id="duration" type="number" value="300" min="1"
+        /></label>
+        <label
+          >Seek position (seconds)
+          <input id="position" type="number" value="42" min="0"
+        /></label>
+      </div>
+      <div class="actions">
+        <button id="initialize">Initialize</button>
+        <button id="update">Update metadata/timeline</button>
+        <button id="play">Play through GSMTC</button>
+        <button id="pause">Pause through GSMTC</button>
+        <button id="seek">Seek through GSMTC</button>
+        <button id="validate">Run full validation</button>
+      </div>
+      <h2>State</h2>
+      <pre id="status">Not initialized.</pre>
+      <h2>Events</h2>
+      <pre id="events">Waiting for events…</pre>
+    </main>
+    <script src="./renderer.js"></script>
+  </body>
+</html>

--- a/samples/js/electron-smtc/main.js
+++ b/samples/js/electron-smtc/main.js
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const path = require("node:path");
+const { app, BrowserWindow, ipcMain } = require("electron");
+const { roInitialize } = require("@microsoft/dynwinrt");
+const { MediaControlsLoopback } = require("./media-controls.js");
+
+const validationMode = process.argv.includes("--validate");
+const demoMode = process.argv.includes("--demo");
+let loopback;
+
+app.setAppUserModelId("Microsoft.dynwinrt.SmtcSample");
+
+function createWindow() {
+  const window = new BrowserWindow({
+    width: 760,
+    height: 720,
+    show: !validationMode,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+  window.loadFile("index.html");
+
+  loopback = new MediaControlsLoopback(window, (event) => {
+    if (!window.isDestroyed()) window.webContents.send("smtc:event", event);
+  });
+  window.once("closed", () => loopback?.dispose());
+  return window;
+}
+
+function requireLoopback() {
+  if (!loopback) throw new Error("The Electron window is not ready.");
+  return loopback;
+}
+
+ipcMain.handle("smtc:initialize", (_event, options) =>
+  requireLoopback().initialize(options),
+);
+ipcMain.handle("smtc:update", (_event, options) =>
+  requireLoopback().update(options),
+);
+ipcMain.handle("smtc:control", (_event, action, value) =>
+  requireLoopback().control(action, value),
+);
+ipcMain.handle("smtc:snapshot", () => requireLoopback().snapshot());
+ipcMain.handle("smtc:validate", () => requireLoopback().validate());
+
+app.whenReady().then(async () => {
+  roInitialize(1);
+  const window = createWindow();
+
+  if (validationMode || demoMode) {
+    try {
+      const result = await loopback.validate();
+      const failures = Object.entries(result.checks).filter(
+        ([, passed]) => !passed,
+      );
+      if (failures.length > 0) {
+        throw new Error(
+          `Validation failed: ${JSON.stringify(result, null, 2)}`,
+        );
+      }
+      console.log(JSON.stringify(result, null, 2));
+      if (validationMode) {
+        app.exit(0);
+      } else {
+        await window.webContents.executeJavaScript(
+          `window.showValidationResult(${JSON.stringify(result)})`,
+        );
+      }
+    } catch (error) {
+      console.error(error);
+      if (validationMode) {
+        app.exit(1);
+      } else {
+        await window.webContents.executeJavaScript(
+          `window.showValidationResult(${JSON.stringify({
+            error: "Automatic validation failed. See the terminal for details.",
+          })})`,
+        );
+      }
+    }
+  }
+});
+
+app.on("window-all-closed", () => app.quit());

--- a/samples/js/electron-smtc/main.js
+++ b/samples/js/electron-smtc/main.js
@@ -10,12 +10,18 @@ const validationMode = process.argv.includes("--validate");
 const demoMode = process.argv.includes("--demo");
 let loopback;
 
+app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 app.setAppUserModelId("Microsoft.dynwinrt.SmtcSample");
 
 function createWindow() {
   const window = new BrowserWindow({
-    width: 760,
-    height: 720,
+    width: 1180,
+    height: 860,
+    minWidth: 920,
+    minHeight: 680,
+    autoHideMenuBar: true,
+    backgroundColor: "#00000000",
+    backgroundMaterial: "mica",
     show: !validationMode,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
@@ -55,6 +61,7 @@ ipcMain.handle("smtc:control", (_event, action, value) =>
   requireLoopback().control(action, value),
 );
 ipcMain.handle("smtc:snapshot", () => requireLoopback().snapshot());
+ipcMain.handle("smtc:sessions", () => requireLoopback().listSessions());
 ipcMain.handle("smtc:validate", () => requireLoopback().validate());
 
 app.whenReady().then(async () => {
@@ -72,10 +79,16 @@ app.whenReady().then(async () => {
           `Validation failed: ${JSON.stringify(result, null, 2)}`,
         );
       }
-      console.log(JSON.stringify(result, null, 2));
       if (validationMode) {
+        console.log(JSON.stringify(result, null, 2));
         app.exit(0);
       } else {
+        await loopback.initialize();
+        await loopback.control("play");
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        result.snapshot = await loopback.snapshot();
+        result.sessions = await loopback.listSessions();
+        console.log(JSON.stringify(result, null, 2));
         await window.webContents.executeJavaScript(
           `window.showValidationResult(${JSON.stringify(result)})`,
         );

--- a/samples/js/electron-smtc/main.js
+++ b/samples/js/electron-smtc/main.js
@@ -28,7 +28,15 @@ function createWindow() {
   loopback = new MediaControlsLoopback(window, (event) => {
     if (!window.isDestroyed()) window.webContents.send("smtc:event", event);
   });
-  window.once("closed", () => loopback?.dispose());
+  window.once("closed", () => {
+    try {
+      loopback?.dispose();
+    } catch (error) {
+      console.error("Failed to dispose the media controls loopback.", error);
+    } finally {
+      loopback = undefined;
+    }
+  });
   return window;
 }
 

--- a/samples/js/electron-smtc/media-controls.js
+++ b/samples/js/electron-smtc/media-controls.js
@@ -1,0 +1,425 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const {
+  GlobalSystemMediaTransportControlsSessionManager,
+} = require("./generated/GlobalSystemMediaTransportControlsSessionManager.js");
+const {
+  MediaPlaybackAutoRepeatMode,
+} = require("./generated/MediaPlaybackAutoRepeatMode.js");
+const { MediaPlaybackStatus } = require("./generated/MediaPlaybackStatus.js");
+const { MediaPlaybackType } = require("./generated/MediaPlaybackType.js");
+const {
+  SystemMediaTransportControls,
+} = require("./generated/SystemMediaTransportControls.js");
+const {
+  SystemMediaTransportControlsButton,
+} = require("./generated/SystemMediaTransportControlsButton.js");
+const {
+  SystemMediaTransportControlsTimelineProperties,
+} = require("./generated/SystemMediaTransportControlsTimelineProperties.js");
+const {
+  ISystemMediaTransportControlsInterop,
+} = require("./generated/com/ISystemMediaTransportControlsInterop.js");
+
+const TICKS_PER_SECOND = 10_000_000n;
+
+function secondsToTicks(seconds) {
+  return BigInt(Math.round(Number(seconds) * Number(TICKS_PER_SECOND)));
+}
+
+function ticksToSeconds(ticks) {
+  return Number(ticks) / Number(TICKS_PER_SECOND);
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitUntil(predicate, message, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await sleep(50);
+  }
+  throw new Error(message);
+}
+
+class MediaControlsLoopback {
+  constructor(window, emitEvent = () => {}) {
+    this.window = window;
+    this.emitEvent = emitEvent;
+    this.smtc = null;
+    this.manager = null;
+    this.session = null;
+    this.timeline = null;
+    this.title = "";
+    this.artist = "";
+    this.durationSeconds = 300;
+    this.positionSeconds = 0;
+    this.unsubscribers = [];
+    this.eventCounts = this.#newEventCounts();
+  }
+
+  #newEventCounts() {
+    return {
+      buttonPressed: 0,
+      positionRequested: 0,
+      playbackRateRequested: 0,
+      shuffleRequested: 0,
+      repeatRequested: 0,
+      managerSessionsChanged: 0,
+      managerCurrentSessionChanged: 0,
+      mediaPropertiesChanged: 0,
+      playbackInfoChanged: 0,
+      timelinePropertiesChanged: 0,
+    };
+  }
+
+  #emit(type, detail = {}) {
+    this.emitEvent({ type, timestamp: new Date().toISOString(), ...detail });
+  }
+
+  #updateMetadata() {
+    const updater = this.smtc.displayUpdater;
+    updater.type = MediaPlaybackType.Music;
+    updater.appMediaId = "dynwinrt-electron-smtc";
+    updater.musicProperties.title = this.title;
+    updater.musicProperties.artist = this.artist;
+    updater.musicProperties.albumTitle = "dynwinrt samples";
+    updater.musicProperties.trackNumber = 1;
+    updater.update();
+  }
+
+  #updateTimeline() {
+    this.timeline.startTime = { duration: 0n };
+    this.timeline.minSeekTime = { duration: 0n };
+    this.timeline.endTime = { duration: secondsToTicks(this.durationSeconds) };
+    this.timeline.maxSeekTime = {
+      duration: secondsToTicks(this.durationSeconds),
+    };
+    this.timeline.position = { duration: secondsToTicks(this.positionSeconds) };
+    this.smtc.updateTimelineProperties(this.timeline);
+  }
+
+  #subscribeManagerEvents() {
+    this.unsubscribers.push(
+      this.manager.onSessionsChanged(() => {
+        this.eventCounts.managerSessionsChanged += 1;
+        this.#emit("sessions-changed");
+      }),
+      this.manager.onCurrentSessionChanged(() => {
+        this.eventCounts.managerCurrentSessionChanged += 1;
+        this.#emit("current-session-changed");
+      }),
+    );
+  }
+
+  #subscribeSmtcEvents() {
+    this.unsubscribers.push(
+      this.smtc.onButtonPressed((_sender, args) => {
+        this.eventCounts.buttonPressed += 1;
+        if (args.button === SystemMediaTransportControlsButton.Play) {
+          this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
+        } else if (args.button === SystemMediaTransportControlsButton.Pause) {
+          this.smtc.playbackStatus = MediaPlaybackStatus.Paused;
+        } else if (args.button === SystemMediaTransportControlsButton.Stop) {
+          this.smtc.playbackStatus = MediaPlaybackStatus.Stopped;
+        }
+        this.#emit("button-pressed", { button: args.button });
+      }),
+      this.smtc.onPlaybackPositionChangeRequested((_sender, args) => {
+        this.eventCounts.positionRequested += 1;
+        this.positionSeconds = ticksToSeconds(
+          args.requestedPlaybackPosition.duration,
+        );
+        this.#updateTimeline();
+        this.#emit("position-requested", {
+          positionSeconds: this.positionSeconds,
+        });
+      }),
+      this.smtc.onPlaybackRateChangeRequested((_sender, args) => {
+        this.eventCounts.playbackRateRequested += 1;
+        this.smtc.playbackRate = args.requestedPlaybackRate;
+        this.#emit("playback-rate-requested", {
+          playbackRate: args.requestedPlaybackRate,
+        });
+      }),
+      this.smtc.onShuffleEnabledChangeRequested((_sender, args) => {
+        this.eventCounts.shuffleRequested += 1;
+        this.smtc.shuffleEnabled = args.requestedShuffleEnabled;
+        this.#emit("shuffle-requested", {
+          enabled: args.requestedShuffleEnabled,
+        });
+      }),
+      this.smtc.onAutoRepeatModeChangeRequested((_sender, args) => {
+        this.eventCounts.repeatRequested += 1;
+        this.smtc.autoRepeatMode = args.requestedAutoRepeatMode;
+        this.#emit("repeat-requested", { mode: args.requestedAutoRepeatMode });
+      }),
+    );
+  }
+
+  #subscribeSessionEvents() {
+    this.unsubscribers.push(
+      this.session.onMediaPropertiesChanged(() => {
+        this.eventCounts.mediaPropertiesChanged += 1;
+        this.#emit("media-properties-changed");
+      }),
+      this.session.onPlaybackInfoChanged(() => {
+        this.eventCounts.playbackInfoChanged += 1;
+        this.#emit("playback-info-changed");
+      }),
+      this.session.onTimelinePropertiesChanged(() => {
+        this.eventCounts.timelinePropertiesChanged += 1;
+        this.#emit("timeline-properties-changed");
+      }),
+    );
+  }
+
+  async #findOwnSession() {
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      for (const candidate of this.manager.getSessions()?.toArray() ?? []) {
+        try {
+          const properties = await candidate.tryGetMediaPropertiesAsync();
+          if (properties?.title === this.title) return candidate;
+        } catch {
+          // The session may disappear between enumeration and metadata retrieval.
+        }
+      }
+      await sleep(100);
+    }
+    throw new Error(
+      "Timed out waiting for the Electron SMTC session in GSMTC.",
+    );
+  }
+
+  async initialize(options = {}) {
+    this.dispose();
+    this.eventCounts = this.#newEventCounts();
+    this.title = options.title?.trim() || `dynwinrt SMTC ${process.pid}`;
+    this.artist = options.artist?.trim() || "dynwinrt";
+    this.durationSeconds = Math.max(1, Number(options.durationSeconds) || 300);
+    this.positionSeconds = Math.max(
+      0,
+      Math.min(this.durationSeconds, Number(options.positionSeconds) || 0),
+    );
+
+    this.manager =
+      await GlobalSystemMediaTransportControlsSessionManager.requestAsync();
+    this.#subscribeManagerEvents();
+
+    const interop = ISystemMediaTransportControlsInterop.create();
+    try {
+      const raw = interop.getForWindow(this.window.getNativeWindowHandle());
+      this.smtc = SystemMediaTransportControls._fromNative(raw);
+    } finally {
+      interop.release();
+    }
+
+    this.timeline = new SystemMediaTransportControlsTimelineProperties();
+    this.smtc.isEnabled = true;
+    this.smtc.isPlayEnabled = true;
+    this.smtc.isPauseEnabled = true;
+    this.smtc.isStopEnabled = true;
+    this.smtc.isNextEnabled = true;
+    this.smtc.isPreviousEnabled = true;
+    this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
+    this.#subscribeSmtcEvents();
+    this.#updateMetadata();
+    this.#updateTimeline();
+
+    this.session = await this.#findOwnSession();
+    this.#subscribeSessionEvents();
+    this.#emit("initialized", {
+      sourceAppUserModelId: this.session.sourceAppUserModelId,
+    });
+    return this.snapshot();
+  }
+
+  async update(options = {}) {
+    if (!this.smtc) throw new Error("Initialize the media session first.");
+    if (options.title?.trim()) this.title = options.title.trim();
+    if (options.artist?.trim()) this.artist = options.artist.trim();
+    if (options.durationSeconds != null) {
+      this.durationSeconds = Math.max(1, Number(options.durationSeconds));
+    }
+    if (options.positionSeconds != null) {
+      this.positionSeconds = Math.max(
+        0,
+        Math.min(this.durationSeconds, Number(options.positionSeconds)),
+      );
+    }
+    this.#updateMetadata();
+    this.#updateTimeline();
+    return this.snapshot();
+  }
+
+  async control(action, value) {
+    if (!this.session) throw new Error("Initialize the media session first.");
+    switch (action) {
+      case "play":
+        return this.session.tryPlayAsync();
+      case "pause":
+        return this.session.tryPauseAsync();
+      case "stop":
+        return this.session.tryStopAsync();
+      case "next":
+        return this.session.trySkipNextAsync();
+      case "previous":
+        return this.session.trySkipPreviousAsync();
+      case "seek":
+        return this.session.tryChangePlaybackPositionAsync(
+          secondsToTicks(value),
+        );
+      case "rate":
+        return this.session.tryChangePlaybackRateAsync(Number(value));
+      case "shuffle":
+        return this.session.tryChangeShuffleActiveAsync(Boolean(value));
+      case "repeat":
+        return this.session.tryChangeAutoRepeatModeAsync(Number(value));
+      default:
+        throw new Error(`Unknown media-control action: ${action}`);
+    }
+  }
+
+  async snapshot() {
+    if (!this.session) throw new Error("Initialize the media session first.");
+    const properties = await this.session.tryGetMediaPropertiesAsync();
+    const playback = this.session.getPlaybackInfo();
+    const timeline = this.session.getTimelineProperties();
+    return {
+      sourceAppUserModelId: this.session.sourceAppUserModelId,
+      title: properties?.title ?? "",
+      artist: properties?.artist ?? "",
+      playbackStatus: playback?.playbackStatus ?? null,
+      playbackRate: playback?.playbackRate ?? null,
+      shuffleActive: playback?.isShuffleActive ?? null,
+      autoRepeatMode: playback?.autoRepeatMode ?? null,
+      positionSeconds: timeline
+        ? ticksToSeconds(timeline.position.duration)
+        : null,
+      durationSeconds: timeline
+        ? ticksToSeconds(timeline.endTime.duration)
+        : null,
+      eventCounts: { ...this.eventCounts },
+    };
+  }
+
+  async validate() {
+    await this.initialize({
+      title: "dynwinrt automated SMTC",
+      artist: "dynwinrt",
+      durationSeconds: 180,
+      positionSeconds: 10,
+    });
+
+    const runRequest = async (counter, action, value, message) => {
+      const before = this.eventCounts[counter];
+      const accepted = await this.control(action, value);
+      await waitUntil(() => this.eventCounts[counter] > before, message);
+      return accepted;
+    };
+
+    const pauseAccepted = await runRequest(
+      "buttonPressed",
+      "pause",
+      undefined,
+      "Pause did not trigger ButtonPressed.",
+    );
+    const playAccepted = await runRequest(
+      "buttonPressed",
+      "play",
+      undefined,
+      "Play did not trigger ButtonPressed.",
+    );
+    const nextAccepted = await runRequest(
+      "buttonPressed",
+      "next",
+      undefined,
+      "Next did not trigger ButtonPressed.",
+    );
+    const previousAccepted = await runRequest(
+      "buttonPressed",
+      "previous",
+      undefined,
+      "Previous did not trigger ButtonPressed.",
+    );
+    const seekAccepted = await runRequest(
+      "positionRequested",
+      "seek",
+      42,
+      "Seek did not trigger PlaybackPositionChangeRequested.",
+    );
+    const rateAccepted = await runRequest(
+      "playbackRateRequested",
+      "rate",
+      1.25,
+      "Rate change did not trigger PlaybackRateChangeRequested.",
+    );
+    const shuffleAccepted = await runRequest(
+      "shuffleRequested",
+      "shuffle",
+      true,
+      "Shuffle did not trigger ShuffleEnabledChangeRequested.",
+    );
+    const repeatAccepted = await runRequest(
+      "repeatRequested",
+      "repeat",
+      MediaPlaybackAutoRepeatMode.Track,
+      "Repeat did not trigger AutoRepeatModeChangeRequested.",
+    );
+
+    const mediaBefore = this.eventCounts.mediaPropertiesChanged;
+    this.title = "dynwinrt automated SMTC validated";
+    this.#updateMetadata();
+    await waitUntil(
+      () => this.eventCounts.mediaPropertiesChanged > mediaBefore,
+      "DisplayUpdater.Update did not trigger MediaPropertiesChanged.",
+    );
+
+    const snapshot = await this.snapshot();
+    const checks = {
+      pauseAccepted,
+      playAccepted,
+      nextAccepted,
+      previousAccepted,
+      seekAccepted,
+      rateAccepted,
+      shuffleAccepted,
+      repeatAccepted,
+      managerObservedSession:
+        this.eventCounts.managerSessionsChanged > 0 ||
+        this.eventCounts.managerCurrentSessionChanged > 0,
+      titleRoundTrip: snapshot.title === this.title,
+      positionRoundTrip: Math.abs(snapshot.positionSeconds - 42) < 0.01,
+      playbackRateRoundTrip: snapshot.playbackRate === 1.25,
+      shuffleRoundTrip: snapshot.shuffleActive === true,
+      repeatRoundTrip:
+        snapshot.autoRepeatMode === MediaPlaybackAutoRepeatMode.Track,
+      playbackInfoEvents: this.eventCounts.playbackInfoChanged > 0,
+      timelineEvents: this.eventCounts.timelinePropertiesChanged > 0,
+    };
+    return { checks, snapshot };
+  }
+
+  dispose() {
+    for (const unsubscribe of this.unsubscribers.splice(0).reverse()) {
+      try {
+        unsubscribe();
+      } catch {}
+    }
+    if (this.smtc) {
+      try {
+        this.smtc.isEnabled = false;
+      } catch {}
+    }
+    this.smtc = null;
+    this.manager = null;
+    this.session = null;
+    this.timeline = null;
+  }
+}
+
+module.exports = { MediaControlsLoopback };

--- a/samples/js/electron-smtc/media-controls.js
+++ b/samples/js/electron-smtc/media-controls.js
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+const path = require("node:path");
 const {
   GlobalSystemMediaTransportControlsSessionManager,
 } = require("./generated/GlobalSystemMediaTransportControlsSessionManager.js");
@@ -9,6 +10,10 @@ const {
 } = require("./generated/MediaPlaybackAutoRepeatMode.js");
 const { MediaPlaybackStatus } = require("./generated/MediaPlaybackStatus.js");
 const { MediaPlaybackType } = require("./generated/MediaPlaybackType.js");
+const {
+  RandomAccessStreamReference,
+} = require("./generated/RandomAccessStreamReference.js");
+const { StorageFile } = require("./generated/StorageFile.js");
 const {
   SystemMediaTransportControls,
 } = require("./generated/SystemMediaTransportControls.js");
@@ -24,6 +29,42 @@ const {
 const { releaseProjected } = require("./generated/lifetime.js");
 
 const TICKS_PER_SECOND = 10_000_000n;
+const TIMELINE_INTERVAL_MS = 500;
+const SEEK_STEP_SECONDS = 15;
+
+const DEFAULT_PLAYLIST = Object.freeze([
+  Object.freeze({
+    title: "Neon Window",
+    artist: "dynwinrt Ensemble",
+    albumTitle: "Runtime Radio",
+    genre: "Electronic",
+    durationSeconds: 185,
+    artworkUrl: "./Assets/AlbumBlue.png",
+  }),
+  Object.freeze({
+    title: "Metadata Drive",
+    artist: "The Interface Band",
+    albumTitle: "Runtime Radio",
+    genre: "Synthwave",
+    durationSeconds: 214,
+    artworkUrl: "./Assets/AlbumPurple.png",
+  }),
+  Object.freeze({
+    title: "Interop Nights",
+    artist: "COM & The Projections",
+    albumTitle: "Runtime Radio",
+    genre: "Ambient",
+    durationSeconds: 168,
+    artworkUrl: "./Assets/AlbumOrange.png",
+  }),
+]);
+
+const BUTTON_NAMES = new Map(
+  Object.entries(SystemMediaTransportControlsButton).map(([name, value]) => [
+    value,
+    name,
+  ]),
+);
 
 function secondsToTicks(seconds) {
   return BigInt(Math.round(Number(seconds) * Number(TICKS_PER_SECOND)));
@@ -35,6 +76,18 @@ function ticksToSeconds(ticks) {
 
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function finiteNumber(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    throw new TypeError(`${name} must be a finite number.`);
+  }
+  return number;
 }
 
 function releaseProjectedValues(...values) {
@@ -67,17 +120,26 @@ class MediaControlsLoopback {
     this.manager = null;
     this.session = null;
     this.timeline = null;
-    this.title = "";
-    this.artist = "";
-    this.durationSeconds = 300;
-    this.positionSeconds = 0;
+    this.artworkReferences = [];
     this.unsubscribers = [];
+    this.timelineTimer = null;
+    this.playlist = [];
+    this.trackIndex = 0;
+    this.durationSeconds = 0;
+    this.positionSeconds = 0;
+    this.playbackStatus = MediaPlaybackStatus.Stopped;
+    this.playbackRate = 1;
+    this.shuffleEnabled = false;
+    this.autoRepeatMode = MediaPlaybackAutoRepeatMode.None;
+    this.lastPositionUpdateAt = Date.now();
+    this.recordRequests = 0;
     this.eventCounts = this.#newEventCounts();
   }
 
   #newEventCounts() {
     return {
       buttonPressed: 0,
+      propertyChanged: 0,
       positionRequested: 0,
       playbackRateRequested: 0,
       shuffleRequested: 0,
@@ -87,7 +149,13 @@ class MediaControlsLoopback {
       mediaPropertiesChanged: 0,
       playbackInfoChanged: 0,
       timelinePropertiesChanged: 0,
+      trackChanged: 0,
+      timelineTicks: 0,
     };
+  }
+
+  #currentTrack() {
+    return this.playlist[this.trackIndex];
   }
 
   #emit(type, detail = {}) {
@@ -104,20 +172,57 @@ class MediaControlsLoopback {
     };
   }
 
+  async #loadArtworkReferences() {
+    const references = [];
+    try {
+      for (const track of this.playlist) {
+        let file;
+        try {
+          const artworkPath = path.join(__dirname, track.artworkUrl);
+          file = await StorageFile.getFileFromPathAsync(artworkPath);
+          if (!file) {
+            throw new Error(`Artwork file was not found: ${artworkPath}`);
+          }
+          const reference = RandomAccessStreamReference.createFromFile(file);
+          if (!reference) {
+            throw new Error(
+              `Could not create a stream reference for ${artworkPath}.`,
+            );
+          }
+          references.push(reference);
+        } finally {
+          releaseProjectedValues(file);
+        }
+      }
+      this.artworkReferences = references;
+    } catch (error) {
+      releaseProjectedValues(...references);
+      throw error;
+    }
+  }
+
   #updateMetadata() {
+    const track = this.#currentTrack();
     const updater = this.smtc.displayUpdater;
     let musicProperties;
+    let genres;
     try {
       updater.type = MediaPlaybackType.Music;
-      updater.appMediaId = "dynwinrt-electron-smtc";
+      updater.appMediaId = `dynwinrt-electron-smtc-${this.trackIndex + 1}`;
+      updater.thumbnail = this.artworkReferences[this.trackIndex];
       musicProperties = updater.musicProperties;
-      musicProperties.title = this.title;
-      musicProperties.artist = this.artist;
-      musicProperties.albumTitle = "dynwinrt samples";
-      musicProperties.trackNumber = 1;
+      musicProperties.title = track.title;
+      musicProperties.artist = track.artist;
+      musicProperties.albumArtist = "dynwinrt Samples";
+      musicProperties.albumTitle = track.albumTitle;
+      musicProperties.trackNumber = this.trackIndex + 1;
+      musicProperties.albumTrackCount = this.playlist.length;
+      genres = musicProperties.genres;
+      genres.clear();
+      genres.append(track.genre);
       updater.update();
     } finally {
-      releaseProjectedValues(musicProperties, updater);
+      releaseProjectedValues(genres, musicProperties, updater);
     }
   }
 
@@ -132,18 +237,178 @@ class MediaControlsLoopback {
     this.smtc.updateTimelineProperties(this.timeline);
   }
 
+  #captureElapsedPosition() {
+    const now = Date.now();
+    if (this.playbackStatus === MediaPlaybackStatus.Playing) {
+      const elapsedSeconds = (now - this.lastPositionUpdateAt) / 1000;
+      this.positionSeconds = Math.min(
+        this.durationSeconds,
+        this.positionSeconds + elapsedSeconds * this.playbackRate,
+      );
+    }
+    this.lastPositionUpdateAt = now;
+  }
+
+  #setPlaybackStatus(status, resetPosition = false) {
+    this.#captureElapsedPosition();
+    if (resetPosition) this.positionSeconds = 0;
+    this.playbackStatus = status;
+    this.smtc.playbackStatus = status;
+    this.lastPositionUpdateAt = Date.now();
+    this.#updateTimeline();
+    this.#emit("publisher-state-changed", {
+      flow: "SMTC publisher",
+      playbackStatus: status,
+      positionSeconds: this.positionSeconds,
+    });
+  }
+
+  #seekTo(positionSeconds, reason) {
+    this.positionSeconds = Math.max(
+      0,
+      Math.min(
+        this.durationSeconds,
+        finiteNumber(positionSeconds, "Playback position"),
+      ),
+    );
+    this.lastPositionUpdateAt = Date.now();
+    this.#updateTimeline();
+    this.#emit("position-changed", {
+      flow: "SMTC publisher",
+      reason,
+      positionSeconds: this.positionSeconds,
+    });
+  }
+
+  #relativeTrackIndex(offset) {
+    const count = this.playlist.length;
+    if (this.shuffleEnabled && offset > 0 && count > 1) {
+      return (
+        (this.trackIndex + 1 + Math.floor(Math.random() * (count - 1))) % count
+      );
+    }
+    return (this.trackIndex + offset + count) % count;
+  }
+
+  #selectTrack(index, reason) {
+    this.trackIndex = index;
+    this.durationSeconds = this.#currentTrack().durationSeconds;
+    this.positionSeconds = 0;
+    this.lastPositionUpdateAt = Date.now();
+    this.#updateMetadata();
+    this.#updateTimeline();
+    this.eventCounts.trackChanged += 1;
+    this.#emit("track-changed", {
+      flow: "SMTC publisher -> GSMTC",
+      reason,
+      trackIndex: this.trackIndex,
+      title: this.#currentTrack().title,
+    });
+  }
+
+  #selectRelativeTrack(offset, reason) {
+    this.#selectTrack(this.#relativeTrackIndex(offset), reason);
+  }
+
+  #advanceTimeline() {
+    if (!this.smtc) return;
+    if (this.playbackStatus !== MediaPlaybackStatus.Playing) {
+      this.lastPositionUpdateAt = Date.now();
+      return;
+    }
+
+    this.#captureElapsedPosition();
+    if (this.positionSeconds >= this.durationSeconds) {
+      if (this.autoRepeatMode === MediaPlaybackAutoRepeatMode.Track) {
+        this.#seekTo(0, "repeat-track");
+      } else if (
+        this.shuffleEnabled ||
+        this.trackIndex < this.playlist.length - 1 ||
+        this.autoRepeatMode === MediaPlaybackAutoRepeatMode.List
+      ) {
+        this.#selectRelativeTrack(1, "automatic-next");
+      } else {
+        this.positionSeconds = this.durationSeconds;
+        this.playbackStatus = MediaPlaybackStatus.Stopped;
+        this.smtc.playbackStatus = MediaPlaybackStatus.Stopped;
+        this.#updateTimeline();
+      }
+    } else {
+      this.#updateTimeline();
+    }
+
+    this.eventCounts.timelineTicks += 1;
+    this.#emit("timeline-tick", {
+      flow: "SMTC publisher -> GSMTC",
+      positionSeconds: this.positionSeconds,
+      durationSeconds: this.durationSeconds,
+    });
+  }
+
+  #startTimelineTimer() {
+    this.timelineTimer = setInterval(() => {
+      try {
+        this.#advanceTimeline();
+      } catch (error) {
+        this.#emit("timeline-error", {
+          flow: "SMTC publisher",
+          error: errorMessage(error),
+        });
+      }
+    }, TIMELINE_INTERVAL_MS);
+  }
+
+  #handleButton(button) {
+    switch (button) {
+      case SystemMediaTransportControlsButton.Play:
+        this.#setPlaybackStatus(MediaPlaybackStatus.Playing);
+        break;
+      case SystemMediaTransportControlsButton.Pause:
+        this.#setPlaybackStatus(MediaPlaybackStatus.Paused);
+        break;
+      case SystemMediaTransportControlsButton.Stop:
+        this.#setPlaybackStatus(MediaPlaybackStatus.Stopped, true);
+        break;
+      case SystemMediaTransportControlsButton.Next:
+      case SystemMediaTransportControlsButton.ChannelUp:
+        this.#selectRelativeTrack(1, BUTTON_NAMES.get(button));
+        break;
+      case SystemMediaTransportControlsButton.Previous:
+      case SystemMediaTransportControlsButton.ChannelDown:
+        this.#selectRelativeTrack(-1, BUTTON_NAMES.get(button));
+        break;
+      case SystemMediaTransportControlsButton.FastForward:
+        this.#seekTo(this.positionSeconds + SEEK_STEP_SECONDS, "fast-forward");
+        break;
+      case SystemMediaTransportControlsButton.Rewind:
+        this.#seekTo(this.positionSeconds - SEEK_STEP_SECONDS, "rewind");
+        break;
+      case SystemMediaTransportControlsButton.Record:
+        this.recordRequests += 1;
+        break;
+      default:
+        throw new Error(`Unsupported SMTC button value: ${button}`);
+    }
+
+    this.#emit("button-pressed", {
+      flow: "GSMTC controller -> SMTC",
+      button,
+      buttonName: BUTTON_NAMES.get(button) ?? String(button),
+    });
+  }
+
   #subscribeManagerEvents() {
     this.unsubscribers.push(
       this.manager.onSessionsChanged(
         this.#releasedEventHandler(() => {
           this.eventCounts.managerSessionsChanged += 1;
-          this.#emit("sessions-changed");
+          this.#emit("sessions-changed", { flow: "GSMTC manager" });
         }),
       ),
       this.manager.onCurrentSessionChanged(
         this.#releasedEventHandler(() => {
           this.eventCounts.managerCurrentSessionChanged += 1;
-          this.#emit("current-session-changed");
+          this.#emit("current-session-changed", { flow: "GSMTC manager" });
         }),
       ),
     );
@@ -154,52 +419,60 @@ class MediaControlsLoopback {
       this.smtc.onButtonPressed(
         this.#releasedEventHandler((args) => {
           this.eventCounts.buttonPressed += 1;
-          if (args.button === SystemMediaTransportControlsButton.Play) {
-            this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
-          } else if (args.button === SystemMediaTransportControlsButton.Pause) {
-            this.smtc.playbackStatus = MediaPlaybackStatus.Paused;
-          } else if (args.button === SystemMediaTransportControlsButton.Stop) {
-            this.smtc.playbackStatus = MediaPlaybackStatus.Stopped;
-          }
-          this.#emit("button-pressed", { button: args.button });
+          this.#handleButton(args.button);
+        }),
+      ),
+      this.smtc.onPropertyChanged(
+        this.#releasedEventHandler((args) => {
+          this.eventCounts.propertyChanged += 1;
+          this.#emit("smtc-property-changed", {
+            flow: "Windows -> SMTC publisher",
+            property: args.property,
+            soundLevel: this.smtc.soundLevel,
+          });
         }),
       ),
       this.smtc.onPlaybackPositionChangeRequested(
         this.#releasedEventHandler((args) => {
           this.eventCounts.positionRequested += 1;
-          this.positionSeconds = ticksToSeconds(
-            args.requestedPlaybackPosition.duration,
+          this.#seekTo(
+            ticksToSeconds(args.requestedPlaybackPosition.duration),
+            "GSMTC seek request",
           );
-          this.#updateTimeline();
-          this.#emit("position-requested", {
-            positionSeconds: this.positionSeconds,
-          });
         }),
       ),
       this.smtc.onPlaybackRateChangeRequested(
         this.#releasedEventHandler((args) => {
           this.eventCounts.playbackRateRequested += 1;
-          this.smtc.playbackRate = args.requestedPlaybackRate;
+          this.#captureElapsedPosition();
+          this.playbackRate = args.requestedPlaybackRate;
+          this.smtc.playbackRate = this.playbackRate;
+          this.#updateTimeline();
           this.#emit("playback-rate-requested", {
-            playbackRate: args.requestedPlaybackRate,
+            flow: "GSMTC controller -> SMTC",
+            playbackRate: this.playbackRate,
           });
         }),
       ),
       this.smtc.onShuffleEnabledChangeRequested(
         this.#releasedEventHandler((args) => {
           this.eventCounts.shuffleRequested += 1;
-          this.smtc.shuffleEnabled = args.requestedShuffleEnabled;
+          this.shuffleEnabled = args.requestedShuffleEnabled;
+          this.smtc.shuffleEnabled = this.shuffleEnabled;
           this.#emit("shuffle-requested", {
-            enabled: args.requestedShuffleEnabled,
+            flow: "GSMTC controller -> SMTC",
+            enabled: this.shuffleEnabled,
           });
         }),
       ),
       this.smtc.onAutoRepeatModeChangeRequested(
         this.#releasedEventHandler((args) => {
           this.eventCounts.repeatRequested += 1;
-          this.smtc.autoRepeatMode = args.requestedAutoRepeatMode;
+          this.autoRepeatMode = args.requestedAutoRepeatMode;
+          this.smtc.autoRepeatMode = this.autoRepeatMode;
           this.#emit("repeat-requested", {
-            mode: args.requestedAutoRepeatMode,
+            flow: "GSMTC controller -> SMTC",
+            mode: this.autoRepeatMode,
           });
         }),
       ),
@@ -211,19 +484,25 @@ class MediaControlsLoopback {
       this.session.onMediaPropertiesChanged(
         this.#releasedEventHandler(() => {
           this.eventCounts.mediaPropertiesChanged += 1;
-          this.#emit("media-properties-changed");
+          this.#emit("media-properties-changed", {
+            flow: "SMTC publisher -> GSMTC controller",
+          });
         }),
       ),
       this.session.onPlaybackInfoChanged(
         this.#releasedEventHandler(() => {
           this.eventCounts.playbackInfoChanged += 1;
-          this.#emit("playback-info-changed");
+          this.#emit("playback-info-changed", {
+            flow: "SMTC publisher -> GSMTC controller",
+          });
         }),
       ),
       this.session.onTimelinePropertiesChanged(
         this.#releasedEventHandler(() => {
           this.eventCounts.timelinePropertiesChanged += 1;
-          this.#emit("timeline-properties-changed");
+          this.#emit("timeline-properties-changed", {
+            flow: "SMTC publisher -> GSMTC controller",
+          });
         }),
       ),
     );
@@ -245,12 +524,15 @@ class MediaControlsLoopback {
           let properties;
           try {
             properties = await candidate.tryGetMediaPropertiesAsync();
-            if (properties?.title === this.title) {
+            if (properties?.title === this.#currentTrack().title) {
               match = candidate;
               break;
             }
-          } catch {
-            // The session may disappear between enumeration and metadata retrieval.
+          } catch (error) {
+            this.#emit("session-read-retry", {
+              flow: "GSMTC manager",
+              error: errorMessage(error),
+            });
           } finally {
             releaseProjectedValues(properties);
           }
@@ -270,20 +552,74 @@ class MediaControlsLoopback {
     );
   }
 
+  #publisherState() {
+    const track = this.#currentTrack();
+    return {
+      trackIndex: this.trackIndex,
+      trackCount: this.playlist.length,
+      title: track.title,
+      artist: track.artist,
+      albumTitle: track.albumTitle,
+      genre: track.genre,
+      artworkUrl: track.artworkUrl,
+      durationSeconds: this.durationSeconds,
+      positionSeconds: this.positionSeconds,
+      playbackStatus: this.playbackStatus,
+      playbackRate: this.playbackRate,
+      shuffleEnabled: this.shuffleEnabled,
+      autoRepeatMode: this.autoRepeatMode,
+      soundLevel: this.smtc?.soundLevel ?? null,
+      recordRequests: this.recordRequests,
+      playlist: this.playlist.map((item, index) => ({
+        index,
+        title: item.title,
+        artist: item.artist,
+        durationSeconds: item.durationSeconds,
+        artworkUrl: item.artworkUrl,
+      })),
+    };
+  }
+
   async initialize(options = {}) {
     this.dispose();
     this.eventCounts = this.#newEventCounts();
-    this.title = options.title?.trim() || `dynwinrt SMTC ${process.pid}`;
-    this.artist = options.artist?.trim() || "dynwinrt";
-    this.durationSeconds = Math.max(1, Number(options.durationSeconds) || 300);
+    this.playlist = DEFAULT_PLAYLIST.map((track) => ({ ...track }));
+    this.trackIndex = 0;
+
+    const track = this.#currentTrack();
+    if (options.title?.trim()) track.title = options.title.trim();
+    if (options.artist?.trim()) track.artist = options.artist.trim();
+    if (options.durationSeconds != null) {
+      track.durationSeconds = Math.max(
+        1,
+        finiteNumber(options.durationSeconds, "Duration"),
+      );
+    }
+
+    this.durationSeconds = track.durationSeconds;
     this.positionSeconds = Math.max(
       0,
-      Math.min(this.durationSeconds, Number(options.positionSeconds) || 0),
+      Math.min(
+        this.durationSeconds,
+        options.positionSeconds == null
+          ? 0
+          : finiteNumber(options.positionSeconds, "Playback position"),
+      ),
     );
+    this.playbackStatus = MediaPlaybackStatus.Playing;
+    this.playbackRate = 1;
+    this.shuffleEnabled = false;
+    this.autoRepeatMode = MediaPlaybackAutoRepeatMode.None;
+    this.recordRequests = 0;
+    this.lastPositionUpdateAt = Date.now();
 
     try {
+      await this.#loadArtworkReferences();
       this.manager =
         await GlobalSystemMediaTransportControlsSessionManager.requestAsync();
+      if (!this.manager) {
+        throw new Error("GSMTC session manager initialization returned null.");
+      }
       this.#subscribeManagerEvents();
 
       const interop = ISystemMediaTransportControlsInterop.create();
@@ -295,20 +631,30 @@ class MediaControlsLoopback {
       }
 
       this.timeline = new SystemMediaTransportControlsTimelineProperties();
-      this.smtc.isEnabled = true;
       this.smtc.isPlayEnabled = true;
       this.smtc.isPauseEnabled = true;
       this.smtc.isStopEnabled = true;
+      this.smtc.isRecordEnabled = true;
+      this.smtc.isFastForwardEnabled = true;
+      this.smtc.isRewindEnabled = true;
       this.smtc.isNextEnabled = true;
       this.smtc.isPreviousEnabled = true;
-      this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
+      this.smtc.isChannelUpEnabled = true;
+      this.smtc.isChannelDownEnabled = true;
+      this.smtc.playbackStatus = this.playbackStatus;
+      this.smtc.playbackRate = this.playbackRate;
+      this.smtc.shuffleEnabled = this.shuffleEnabled;
+      this.smtc.autoRepeatMode = this.autoRepeatMode;
       this.#subscribeSmtcEvents();
+      this.smtc.isEnabled = true;
       this.#updateMetadata();
       this.#updateTimeline();
 
       this.session = await this.#findOwnSession();
       this.#subscribeSessionEvents();
+      this.#startTimelineTimer();
       this.#emit("initialized", {
+        flow: "SMTC publisher -> GSMTC manager",
         sourceAppUserModelId: this.session.sourceAppUserModelId,
       });
       return await this.snapshot();
@@ -327,19 +673,26 @@ class MediaControlsLoopback {
 
   async update(options = {}) {
     if (!this.smtc) throw new Error("Initialize the media session first.");
-    if (options.title?.trim()) this.title = options.title.trim();
-    if (options.artist?.trim()) this.artist = options.artist.trim();
+    const track = this.#currentTrack();
+    if (options.title?.trim()) track.title = options.title.trim();
+    if (options.artist?.trim()) track.artist = options.artist.trim();
     if (options.durationSeconds != null) {
-      this.durationSeconds = Math.max(1, Number(options.durationSeconds));
-    }
-    if (options.positionSeconds != null) {
-      this.positionSeconds = Math.max(
-        0,
-        Math.min(this.durationSeconds, Number(options.positionSeconds)),
+      track.durationSeconds = Math.max(
+        1,
+        finiteNumber(options.durationSeconds, "Duration"),
+      );
+      this.durationSeconds = track.durationSeconds;
+      this.positionSeconds = Math.min(
+        this.positionSeconds,
+        this.durationSeconds,
       );
     }
     this.#updateMetadata();
     this.#updateTimeline();
+    this.#emit("metadata-updated", {
+      flow: "SMTC publisher -> GSMTC controller",
+      title: track.title,
+    });
     return this.snapshot();
   }
 
@@ -350,22 +703,38 @@ class MediaControlsLoopback {
         return this.session.tryPlayAsync();
       case "pause":
         return this.session.tryPauseAsync();
+      case "toggle":
+        return this.session.tryTogglePlayPauseAsync();
       case "stop":
         return this.session.tryStopAsync();
+      case "record":
+        return this.session.tryRecordAsync();
+      case "fastForward":
+        return this.session.tryFastForwardAsync();
+      case "rewind":
+        return this.session.tryRewindAsync();
       case "next":
         return this.session.trySkipNextAsync();
       case "previous":
         return this.session.trySkipPreviousAsync();
+      case "channelUp":
+        return this.session.tryChangeChannelUpAsync();
+      case "channelDown":
+        return this.session.tryChangeChannelDownAsync();
       case "seek":
         return this.session.tryChangePlaybackPositionAsync(
-          secondsToTicks(value),
+          secondsToTicks(finiteNumber(value, "Playback position")),
         );
       case "rate":
-        return this.session.tryChangePlaybackRateAsync(Number(value));
+        return this.session.tryChangePlaybackRateAsync(
+          finiteNumber(value, "Playback rate"),
+        );
       case "shuffle":
         return this.session.tryChangeShuffleActiveAsync(Boolean(value));
       case "repeat":
-        return this.session.tryChangeAutoRepeatModeAsync(Number(value));
+        return this.session.tryChangeAutoRepeatModeAsync(
+          finiteNumber(value, "Repeat mode"),
+        );
       default:
         throw new Error(`Unknown media-control action: ${action}`);
     }
@@ -374,30 +743,168 @@ class MediaControlsLoopback {
   async snapshot() {
     if (!this.session) throw new Error("Initialize the media session first.");
     let properties;
+    let genres;
+    let thumbnail;
     let playback;
+    let controls;
     let timeline;
     try {
       properties = await this.session.tryGetMediaPropertiesAsync();
+      genres = properties?.genres;
+      thumbnail = properties?.thumbnail;
       playback = this.session.getPlaybackInfo();
+      controls = playback?.controls;
       timeline = this.session.getTimelineProperties();
+
       return {
-        sourceAppUserModelId: this.session.sourceAppUserModelId,
-        title: properties?.title ?? "",
-        artist: properties?.artist ?? "",
-        playbackStatus: playback?.playbackStatus ?? null,
-        playbackRate: playback?.playbackRate ?? null,
-        shuffleActive: playback?.isShuffleActive ?? null,
-        autoRepeatMode: playback?.autoRepeatMode ?? null,
-        positionSeconds: timeline
-          ? ticksToSeconds(timeline.position.duration)
-          : null,
-        durationSeconds: timeline
-          ? ticksToSeconds(timeline.endTime.duration)
-          : null,
+        publisher: this.#publisherState(),
+        controller: {
+          sourceAppUserModelId: this.session.sourceAppUserModelId,
+          metadata: {
+            title: properties?.title ?? "",
+            subtitle: properties?.subtitle ?? "",
+            albumArtist: properties?.albumArtist ?? "",
+            artist: properties?.artist ?? "",
+            albumTitle: properties?.albumTitle ?? "",
+            trackNumber: properties?.trackNumber ?? null,
+            albumTrackCount: properties?.albumTrackCount ?? null,
+            genres: genres?.toArray() ?? [],
+            hasThumbnail: thumbnail != null,
+          },
+          playback: {
+            status: playback?.playbackStatus ?? null,
+            rate: playback?.playbackRate ?? null,
+            shuffleActive: playback?.isShuffleActive ?? null,
+            autoRepeatMode: playback?.autoRepeatMode ?? null,
+          },
+          timeline: {
+            startSeconds: timeline
+              ? ticksToSeconds(timeline.startTime.duration)
+              : null,
+            endSeconds: timeline
+              ? ticksToSeconds(timeline.endTime.duration)
+              : null,
+            minSeekSeconds: timeline
+              ? ticksToSeconds(timeline.minSeekTime.duration)
+              : null,
+            maxSeekSeconds: timeline
+              ? ticksToSeconds(timeline.maxSeekTime.duration)
+              : null,
+            positionSeconds: timeline
+              ? ticksToSeconds(timeline.position.duration)
+              : null,
+            lastUpdatedTime: timeline
+              ? String(timeline.lastUpdatedTime.universalTime)
+              : null,
+          },
+          capabilities: controls
+            ? {
+                play: controls.isPlayEnabled,
+                pause: controls.isPauseEnabled,
+                stop: controls.isStopEnabled,
+                record: controls.isRecordEnabled,
+                fastForward: controls.isFastForwardEnabled,
+                rewind: controls.isRewindEnabled,
+                next: controls.isNextEnabled,
+                previous: controls.isPreviousEnabled,
+                channelUp: controls.isChannelUpEnabled,
+                channelDown: controls.isChannelDownEnabled,
+                toggle: controls.isPlayPauseToggleEnabled,
+                shuffle: controls.isShuffleEnabled,
+                repeat: controls.isRepeatEnabled,
+                rate: controls.isPlaybackRateEnabled,
+                seek: controls.isPlaybackPositionEnabled,
+              }
+            : {},
+        },
         eventCounts: { ...this.eventCounts },
       };
     } finally {
-      releaseProjectedValues(timeline, playback, properties);
+      releaseProjectedValues(
+        timeline,
+        controls,
+        playback,
+        thumbnail,
+        genres,
+        properties,
+      );
+    }
+  }
+
+  async #readSessionSummary(candidate, currentKey, ownKey) {
+    let properties;
+    let playback;
+    try {
+      properties = await candidate.tryGetMediaPropertiesAsync();
+      playback = candidate.getPlaybackInfo();
+      const sourceAppUserModelId = candidate.sourceAppUserModelId;
+      const title = properties?.title ?? "";
+      const key = `${sourceAppUserModelId}\0${title}`;
+      return {
+        sourceAppUserModelId,
+        title,
+        artist: properties?.artist ?? "",
+        playbackStatus: playback?.playbackStatus ?? null,
+        isCurrent: key === currentKey,
+        isOwn: key === ownKey,
+      };
+    } finally {
+      releaseProjectedValues(playback, properties);
+    }
+  }
+
+  async listSessions() {
+    if (!this.manager || !this.session) {
+      throw new Error("Initialize the media session first.");
+    }
+
+    let currentSession;
+    let currentProperties;
+    let sessions;
+    try {
+      currentSession = this.manager.getCurrentSession();
+      currentProperties = await currentSession?.tryGetMediaPropertiesAsync();
+      const currentKey = currentSession
+        ? `${currentSession.sourceAppUserModelId}\0${
+            currentProperties?.title ?? ""
+          }`
+        : null;
+      const ownKey = `${this.session.sourceAppUserModelId}\0${
+        this.#currentTrack().title
+      }`;
+
+      sessions = this.manager.getSessions();
+      if (!sessions) return [];
+      const candidates = sessions.toArray();
+      const summaries = [];
+      try {
+        for (const candidate of candidates) {
+          try {
+            summaries.push(
+              await this.#readSessionSummary(candidate, currentKey, ownKey),
+            );
+          } catch (error) {
+            summaries.push({
+              sourceAppUserModelId: "",
+              title: "Session became unavailable",
+              artist: "",
+              playbackStatus: null,
+              isCurrent: false,
+              isOwn: false,
+              error: errorMessage(error),
+            });
+          }
+        }
+      } finally {
+        releaseProjectedValues(...candidates);
+      }
+      return summaries.sort(
+        (left, right) =>
+          Number(right.isOwn) - Number(left.isOwn) ||
+          Number(right.isCurrent) - Number(left.isCurrent),
+      );
+    } finally {
+      releaseProjectedValues(sessions, currentProperties, currentSession);
     }
   }
 
@@ -408,6 +915,14 @@ class MediaControlsLoopback {
       durationSeconds: 180,
       positionSeconds: 10,
     });
+
+    const liveStart = this.positionSeconds;
+    await waitUntil(
+      () => this.positionSeconds > liveStart + 0.2,
+      "Live timeline did not advance while playing.",
+      2500,
+    );
+    const liveTimelineAdvanced = this.positionSeconds > liveStart;
 
     const runRequest = async (counter, action, value, message) => {
       const before = this.eventCounts[counter];
@@ -428,18 +943,67 @@ class MediaControlsLoopback {
       undefined,
       "Play did not trigger ButtonPressed.",
     );
+
+    const originalTrack = this.trackIndex;
     const nextAccepted = await runRequest(
       "buttonPressed",
       "next",
       undefined,
       "Next did not trigger ButtonPressed.",
     );
+    const nextChangedTrack = this.trackIndex !== originalTrack;
     const previousAccepted = await runRequest(
       "buttonPressed",
       "previous",
       undefined,
       "Previous did not trigger ButtonPressed.",
     );
+    const previousRestoredTrack = this.trackIndex === originalTrack;
+
+    const recordAccepted = await runRequest(
+      "buttonPressed",
+      "record",
+      undefined,
+      "Record did not trigger ButtonPressed.",
+    );
+    const beforeFastForward = this.positionSeconds;
+    const fastForwardAccepted = await runRequest(
+      "buttonPressed",
+      "fastForward",
+      undefined,
+      "Fast-forward did not trigger ButtonPressed.",
+    );
+    const fastForwardMoved =
+      this.positionSeconds >= beforeFastForward + SEEK_STEP_SECONDS - 0.1;
+    const rewindAccepted = await runRequest(
+      "buttonPressed",
+      "rewind",
+      undefined,
+      "Rewind did not trigger ButtonPressed.",
+    );
+    const rewindMovedBack =
+      Math.abs(this.positionSeconds - beforeFastForward) < 0.5;
+
+    const channelUpAccepted = await runRequest(
+      "buttonPressed",
+      "channelUp",
+      undefined,
+      "Channel up did not trigger ButtonPressed.",
+    );
+    const channelDownAccepted = await runRequest(
+      "buttonPressed",
+      "channelDown",
+      undefined,
+      "Channel down did not trigger ButtonPressed.",
+    );
+    const channelRoundTrip = this.trackIndex === originalTrack;
+    const toggleAccepted = await runRequest(
+      "buttonPressed",
+      "toggle",
+      undefined,
+      "Play/pause toggle did not trigger ButtonPressed.",
+    );
+
     const seekAccepted = await runRequest(
       "positionRequested",
       "seek",
@@ -466,36 +1030,83 @@ class MediaControlsLoopback {
     );
 
     const mediaBefore = this.eventCounts.mediaPropertiesChanged;
-    this.title = "dynwinrt automated SMTC validated";
+    this.#currentTrack().title = "dynwinrt automated SMTC validated";
     this.#updateMetadata();
     await waitUntil(
       () => this.eventCounts.mediaPropertiesChanged > mediaBefore,
       "DisplayUpdater.Update did not trigger MediaPropertiesChanged.",
     );
 
-    const snapshot = await this.snapshot();
+    let snapshot;
+    await waitUntil(
+      async () => {
+        snapshot = await this.snapshot();
+        return snapshot.controller.metadata.hasThumbnail;
+      },
+      "GSMTC did not expose the published artwork.",
+      10_000,
+    );
+    const sessions = await this.listSessions();
+    const { controller } = snapshot;
+    const capabilities = controller.capabilities;
     const checks = {
       pauseAccepted,
       playAccepted,
       nextAccepted,
       previousAccepted,
+      recordAccepted,
+      fastForwardAccepted,
+      rewindAccepted,
+      channelUpAccepted,
+      channelDownAccepted,
+      toggleAccepted,
       seekAccepted,
       rateAccepted,
       shuffleAccepted,
       repeatAccepted,
+      liveTimelineAdvanced,
+      nextChangedTrack,
+      previousRestoredTrack,
+      fastForwardMoved,
+      rewindMovedBack,
+      channelRoundTrip,
       managerObservedSession:
         this.eventCounts.managerSessionsChanged > 0 ||
         this.eventCounts.managerCurrentSessionChanged > 0,
-      titleRoundTrip: snapshot.title === this.title,
-      positionRoundTrip: Math.abs(snapshot.positionSeconds - 42) < 0.01,
-      playbackRateRoundTrip: snapshot.playbackRate === 1.25,
-      shuffleRoundTrip: snapshot.shuffleActive === true,
+      ownSessionListed: sessions.some((item) => item.isOwn),
+      titleRoundTrip: controller.metadata.title === this.#currentTrack().title,
+      artworkRoundTrip: controller.metadata.hasThumbnail,
+      genreRoundTrip: controller.metadata.genres.includes(
+        this.#currentTrack().genre,
+      ),
+      positionRoundTrip:
+        Math.abs(controller.timeline.positionSeconds - 42) < 0.1,
+      playbackRateRoundTrip: controller.playback.rate === 1.25,
+      shuffleRoundTrip: controller.playback.shuffleActive === true,
       repeatRoundTrip:
-        snapshot.autoRepeatMode === MediaPlaybackAutoRepeatMode.Track,
+        controller.playback.autoRepeatMode ===
+        MediaPlaybackAutoRepeatMode.Track,
+      coreCapabilities:
+        capabilities.play &&
+        capabilities.stop &&
+        capabilities.next &&
+        capabilities.previous &&
+        capabilities.seek &&
+        (capabilities.play || capabilities.pause),
+      advancedCapabilities:
+        capabilities.record &&
+        capabilities.fastForward &&
+        capabilities.rewind &&
+        capabilities.channelUp &&
+        capabilities.channelDown &&
+        capabilities.toggle &&
+        capabilities.rate &&
+        capabilities.shuffle &&
+        capabilities.repeat,
       playbackInfoEvents: this.eventCounts.playbackInfoChanged > 0,
       timelineEvents: this.eventCounts.timelinePropertiesChanged > 0,
     };
-    return { checks, snapshot };
+    return { checks, snapshot, sessions };
   }
 
   dispose() {
@@ -508,6 +1119,10 @@ class MediaControlsLoopback {
       }
     };
 
+    if (this.timelineTimer) {
+      clearInterval(this.timelineTimer);
+      this.timelineTimer = null;
+    }
     for (const unsubscribe of this.unsubscribers.splice(0).reverse()) {
       cleanup(unsubscribe);
     }
@@ -522,6 +1137,7 @@ class MediaControlsLoopback {
       this.timeline,
       this.smtc,
       this.manager,
+      ...this.artworkReferences,
     ]) {
       if (value) cleanup(() => releaseProjected(value));
     }
@@ -530,6 +1146,8 @@ class MediaControlsLoopback {
     this.manager = null;
     this.session = null;
     this.timeline = null;
+    this.artworkReferences = [];
+    this.playlist = [];
 
     if (firstError) throw firstError;
   }

--- a/samples/js/electron-smtc/media-controls.js
+++ b/samples/js/electron-smtc/media-controls.js
@@ -21,6 +21,7 @@ const {
 const {
   ISystemMediaTransportControlsInterop,
 } = require("./generated/com/ISystemMediaTransportControlsInterop.js");
+const { releaseProjected } = require("./generated/lifetime.js");
 
 const TICKS_PER_SECOND = 10_000_000n;
 
@@ -34,6 +35,19 @@ function ticksToSeconds(ticks) {
 
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function releaseProjectedValues(...values) {
+  let firstError;
+  for (const value of values) {
+    if (value == null) continue;
+    try {
+      releaseProjected(value);
+    } catch (error) {
+      firstError ??= error;
+    }
+  }
+  if (firstError) throw firstError;
 }
 
 async function waitUntil(predicate, message, timeoutMs = 5000) {
@@ -80,15 +94,31 @@ class MediaControlsLoopback {
     this.emitEvent({ type, timestamp: new Date().toISOString(), ...detail });
   }
 
+  #releasedEventHandler(callback) {
+    return (sender, args) => {
+      try {
+        callback(args);
+      } finally {
+        releaseProjectedValues(args, sender);
+      }
+    };
+  }
+
   #updateMetadata() {
     const updater = this.smtc.displayUpdater;
-    updater.type = MediaPlaybackType.Music;
-    updater.appMediaId = "dynwinrt-electron-smtc";
-    updater.musicProperties.title = this.title;
-    updater.musicProperties.artist = this.artist;
-    updater.musicProperties.albumTitle = "dynwinrt samples";
-    updater.musicProperties.trackNumber = 1;
-    updater.update();
+    let musicProperties;
+    try {
+      updater.type = MediaPlaybackType.Music;
+      updater.appMediaId = "dynwinrt-electron-smtc";
+      musicProperties = updater.musicProperties;
+      musicProperties.title = this.title;
+      musicProperties.artist = this.artist;
+      musicProperties.albumTitle = "dynwinrt samples";
+      musicProperties.trackNumber = 1;
+      updater.update();
+    } finally {
+      releaseProjectedValues(musicProperties, updater);
+    }
   }
 
   #updateTimeline() {
@@ -104,90 +134,135 @@ class MediaControlsLoopback {
 
   #subscribeManagerEvents() {
     this.unsubscribers.push(
-      this.manager.onSessionsChanged(() => {
-        this.eventCounts.managerSessionsChanged += 1;
-        this.#emit("sessions-changed");
-      }),
-      this.manager.onCurrentSessionChanged(() => {
-        this.eventCounts.managerCurrentSessionChanged += 1;
-        this.#emit("current-session-changed");
-      }),
+      this.manager.onSessionsChanged(
+        this.#releasedEventHandler(() => {
+          this.eventCounts.managerSessionsChanged += 1;
+          this.#emit("sessions-changed");
+        }),
+      ),
+      this.manager.onCurrentSessionChanged(
+        this.#releasedEventHandler(() => {
+          this.eventCounts.managerCurrentSessionChanged += 1;
+          this.#emit("current-session-changed");
+        }),
+      ),
     );
   }
 
   #subscribeSmtcEvents() {
     this.unsubscribers.push(
-      this.smtc.onButtonPressed((_sender, args) => {
-        this.eventCounts.buttonPressed += 1;
-        if (args.button === SystemMediaTransportControlsButton.Play) {
-          this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
-        } else if (args.button === SystemMediaTransportControlsButton.Pause) {
-          this.smtc.playbackStatus = MediaPlaybackStatus.Paused;
-        } else if (args.button === SystemMediaTransportControlsButton.Stop) {
-          this.smtc.playbackStatus = MediaPlaybackStatus.Stopped;
-        }
-        this.#emit("button-pressed", { button: args.button });
-      }),
-      this.smtc.onPlaybackPositionChangeRequested((_sender, args) => {
-        this.eventCounts.positionRequested += 1;
-        this.positionSeconds = ticksToSeconds(
-          args.requestedPlaybackPosition.duration,
-        );
-        this.#updateTimeline();
-        this.#emit("position-requested", {
-          positionSeconds: this.positionSeconds,
-        });
-      }),
-      this.smtc.onPlaybackRateChangeRequested((_sender, args) => {
-        this.eventCounts.playbackRateRequested += 1;
-        this.smtc.playbackRate = args.requestedPlaybackRate;
-        this.#emit("playback-rate-requested", {
-          playbackRate: args.requestedPlaybackRate,
-        });
-      }),
-      this.smtc.onShuffleEnabledChangeRequested((_sender, args) => {
-        this.eventCounts.shuffleRequested += 1;
-        this.smtc.shuffleEnabled = args.requestedShuffleEnabled;
-        this.#emit("shuffle-requested", {
-          enabled: args.requestedShuffleEnabled,
-        });
-      }),
-      this.smtc.onAutoRepeatModeChangeRequested((_sender, args) => {
-        this.eventCounts.repeatRequested += 1;
-        this.smtc.autoRepeatMode = args.requestedAutoRepeatMode;
-        this.#emit("repeat-requested", { mode: args.requestedAutoRepeatMode });
-      }),
+      this.smtc.onButtonPressed(
+        this.#releasedEventHandler((args) => {
+          this.eventCounts.buttonPressed += 1;
+          if (args.button === SystemMediaTransportControlsButton.Play) {
+            this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
+          } else if (args.button === SystemMediaTransportControlsButton.Pause) {
+            this.smtc.playbackStatus = MediaPlaybackStatus.Paused;
+          } else if (args.button === SystemMediaTransportControlsButton.Stop) {
+            this.smtc.playbackStatus = MediaPlaybackStatus.Stopped;
+          }
+          this.#emit("button-pressed", { button: args.button });
+        }),
+      ),
+      this.smtc.onPlaybackPositionChangeRequested(
+        this.#releasedEventHandler((args) => {
+          this.eventCounts.positionRequested += 1;
+          this.positionSeconds = ticksToSeconds(
+            args.requestedPlaybackPosition.duration,
+          );
+          this.#updateTimeline();
+          this.#emit("position-requested", {
+            positionSeconds: this.positionSeconds,
+          });
+        }),
+      ),
+      this.smtc.onPlaybackRateChangeRequested(
+        this.#releasedEventHandler((args) => {
+          this.eventCounts.playbackRateRequested += 1;
+          this.smtc.playbackRate = args.requestedPlaybackRate;
+          this.#emit("playback-rate-requested", {
+            playbackRate: args.requestedPlaybackRate,
+          });
+        }),
+      ),
+      this.smtc.onShuffleEnabledChangeRequested(
+        this.#releasedEventHandler((args) => {
+          this.eventCounts.shuffleRequested += 1;
+          this.smtc.shuffleEnabled = args.requestedShuffleEnabled;
+          this.#emit("shuffle-requested", {
+            enabled: args.requestedShuffleEnabled,
+          });
+        }),
+      ),
+      this.smtc.onAutoRepeatModeChangeRequested(
+        this.#releasedEventHandler((args) => {
+          this.eventCounts.repeatRequested += 1;
+          this.smtc.autoRepeatMode = args.requestedAutoRepeatMode;
+          this.#emit("repeat-requested", {
+            mode: args.requestedAutoRepeatMode,
+          });
+        }),
+      ),
     );
   }
 
   #subscribeSessionEvents() {
     this.unsubscribers.push(
-      this.session.onMediaPropertiesChanged(() => {
-        this.eventCounts.mediaPropertiesChanged += 1;
-        this.#emit("media-properties-changed");
-      }),
-      this.session.onPlaybackInfoChanged(() => {
-        this.eventCounts.playbackInfoChanged += 1;
-        this.#emit("playback-info-changed");
-      }),
-      this.session.onTimelinePropertiesChanged(() => {
-        this.eventCounts.timelinePropertiesChanged += 1;
-        this.#emit("timeline-properties-changed");
-      }),
+      this.session.onMediaPropertiesChanged(
+        this.#releasedEventHandler(() => {
+          this.eventCounts.mediaPropertiesChanged += 1;
+          this.#emit("media-properties-changed");
+        }),
+      ),
+      this.session.onPlaybackInfoChanged(
+        this.#releasedEventHandler(() => {
+          this.eventCounts.playbackInfoChanged += 1;
+          this.#emit("playback-info-changed");
+        }),
+      ),
+      this.session.onTimelinePropertiesChanged(
+        this.#releasedEventHandler(() => {
+          this.eventCounts.timelinePropertiesChanged += 1;
+          this.#emit("timeline-properties-changed");
+        }),
+      ),
     );
   }
 
   async #findOwnSession() {
     const deadline = Date.now() + 10_000;
     while (Date.now() < deadline) {
-      for (const candidate of this.manager.getSessions()?.toArray() ?? []) {
-        try {
-          const properties = await candidate.tryGetMediaPropertiesAsync();
-          if (properties?.title === this.title) return candidate;
-        } catch {
-          // The session may disappear between enumeration and metadata retrieval.
-        }
+      const sessions = this.manager.getSessions();
+      if (!sessions) {
+        await sleep(100);
+        continue;
       }
+
+      const candidates = sessions.toArray();
+      let match = null;
+      try {
+        for (const candidate of candidates) {
+          let properties;
+          try {
+            properties = await candidate.tryGetMediaPropertiesAsync();
+            if (properties?.title === this.title) {
+              match = candidate;
+              break;
+            }
+          } catch {
+            // The session may disappear between enumeration and metadata retrieval.
+          } finally {
+            releaseProjectedValues(properties);
+          }
+        }
+      } finally {
+        releaseProjectedValues(
+          ...candidates.filter((candidate) => candidate !== match),
+          sessions,
+        );
+      }
+
+      if (match) return match;
       await sleep(100);
     }
     throw new Error(
@@ -206,36 +281,48 @@ class MediaControlsLoopback {
       Math.min(this.durationSeconds, Number(options.positionSeconds) || 0),
     );
 
-    this.manager =
-      await GlobalSystemMediaTransportControlsSessionManager.requestAsync();
-    this.#subscribeManagerEvents();
-
-    const interop = ISystemMediaTransportControlsInterop.create();
     try {
-      const raw = interop.getForWindow(this.window.getNativeWindowHandle());
-      this.smtc = SystemMediaTransportControls._fromNative(raw);
-    } finally {
-      interop.release();
+      this.manager =
+        await GlobalSystemMediaTransportControlsSessionManager.requestAsync();
+      this.#subscribeManagerEvents();
+
+      const interop = ISystemMediaTransportControlsInterop.create();
+      try {
+        const raw = interop.getForWindow(this.window.getNativeWindowHandle());
+        this.smtc = SystemMediaTransportControls._fromNative(raw);
+      } finally {
+        interop.release();
+      }
+
+      this.timeline = new SystemMediaTransportControlsTimelineProperties();
+      this.smtc.isEnabled = true;
+      this.smtc.isPlayEnabled = true;
+      this.smtc.isPauseEnabled = true;
+      this.smtc.isStopEnabled = true;
+      this.smtc.isNextEnabled = true;
+      this.smtc.isPreviousEnabled = true;
+      this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
+      this.#subscribeSmtcEvents();
+      this.#updateMetadata();
+      this.#updateTimeline();
+
+      this.session = await this.#findOwnSession();
+      this.#subscribeSessionEvents();
+      this.#emit("initialized", {
+        sourceAppUserModelId: this.session.sourceAppUserModelId,
+      });
+      return await this.snapshot();
+    } catch (error) {
+      try {
+        this.dispose();
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "Media session initialization and cleanup failed.",
+        );
+      }
+      throw error;
     }
-
-    this.timeline = new SystemMediaTransportControlsTimelineProperties();
-    this.smtc.isEnabled = true;
-    this.smtc.isPlayEnabled = true;
-    this.smtc.isPauseEnabled = true;
-    this.smtc.isStopEnabled = true;
-    this.smtc.isNextEnabled = true;
-    this.smtc.isPreviousEnabled = true;
-    this.smtc.playbackStatus = MediaPlaybackStatus.Playing;
-    this.#subscribeSmtcEvents();
-    this.#updateMetadata();
-    this.#updateTimeline();
-
-    this.session = await this.#findOwnSession();
-    this.#subscribeSessionEvents();
-    this.#emit("initialized", {
-      sourceAppUserModelId: this.session.sourceAppUserModelId,
-    });
-    return this.snapshot();
   }
 
   async update(options = {}) {
@@ -286,25 +373,32 @@ class MediaControlsLoopback {
 
   async snapshot() {
     if (!this.session) throw new Error("Initialize the media session first.");
-    const properties = await this.session.tryGetMediaPropertiesAsync();
-    const playback = this.session.getPlaybackInfo();
-    const timeline = this.session.getTimelineProperties();
-    return {
-      sourceAppUserModelId: this.session.sourceAppUserModelId,
-      title: properties?.title ?? "",
-      artist: properties?.artist ?? "",
-      playbackStatus: playback?.playbackStatus ?? null,
-      playbackRate: playback?.playbackRate ?? null,
-      shuffleActive: playback?.isShuffleActive ?? null,
-      autoRepeatMode: playback?.autoRepeatMode ?? null,
-      positionSeconds: timeline
-        ? ticksToSeconds(timeline.position.duration)
-        : null,
-      durationSeconds: timeline
-        ? ticksToSeconds(timeline.endTime.duration)
-        : null,
-      eventCounts: { ...this.eventCounts },
-    };
+    let properties;
+    let playback;
+    let timeline;
+    try {
+      properties = await this.session.tryGetMediaPropertiesAsync();
+      playback = this.session.getPlaybackInfo();
+      timeline = this.session.getTimelineProperties();
+      return {
+        sourceAppUserModelId: this.session.sourceAppUserModelId,
+        title: properties?.title ?? "",
+        artist: properties?.artist ?? "",
+        playbackStatus: playback?.playbackStatus ?? null,
+        playbackRate: playback?.playbackRate ?? null,
+        shuffleActive: playback?.isShuffleActive ?? null,
+        autoRepeatMode: playback?.autoRepeatMode ?? null,
+        positionSeconds: timeline
+          ? ticksToSeconds(timeline.position.duration)
+          : null,
+        durationSeconds: timeline
+          ? ticksToSeconds(timeline.endTime.duration)
+          : null,
+        eventCounts: { ...this.eventCounts },
+      };
+    } finally {
+      releaseProjectedValues(timeline, playback, properties);
+    }
   }
 
   async validate() {
@@ -405,20 +499,39 @@ class MediaControlsLoopback {
   }
 
   dispose() {
-    for (const unsubscribe of this.unsubscribers.splice(0).reverse()) {
+    let firstError;
+    const cleanup = (action) => {
       try {
-        unsubscribe();
-      } catch {}
+        action();
+      } catch (error) {
+        firstError ??= error;
+      }
+    };
+
+    for (const unsubscribe of this.unsubscribers.splice(0).reverse()) {
+      cleanup(unsubscribe);
     }
     if (this.smtc) {
-      try {
+      cleanup(() => {
         this.smtc.isEnabled = false;
-      } catch {}
+      });
     }
+
+    for (const value of [
+      this.session,
+      this.timeline,
+      this.smtc,
+      this.manager,
+    ]) {
+      if (value) cleanup(() => releaseProjected(value));
+    }
+
     this.smtc = null;
     this.manager = null;
     this.session = null;
     this.timeline = null;
+
+    if (firstError) throw firstError;
   }
 }
 

--- a/samples/js/electron-smtc/package-lock.json
+++ b/samples/js/electron-smtc/package-lock.json
@@ -1,0 +1,228 @@
+{
+  "name": "dynwinrt-electron-smtc-sample",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dynwinrt-electron-smtc-sample",
+      "version": "1.0.0",
+      "dependencies": {
+        "@microsoft/dynwinrt": "file:../../../bindings/js"
+      },
+      "devDependencies": {
+        "@microsoft/winappcli": "^0.5.0",
+        "electron": "^41.10.3"
+      }
+    },
+    "../../../bindings/js": {
+      "name": "@microsoft/dynwinrt",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@napi-rs/cli": "^3.2.0",
+        "@napi-rs/wasm-runtime": "^1.0.4",
+        "@oxc-node/core": "^0.0.35",
+        "@taplo/cli": "^0.7.0",
+        "@tybys/wasm-util": "^0.10.0",
+        "ava": "^6.4.1",
+        "c8": "12.0.0",
+        "chalk": "^5.6.2",
+        "emnapi": "^1.5.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.1.6",
+        "npm-run-all2": "^8.0.4",
+        "oxlint": "^1.14.0",
+        "prettier": "^3.6.2",
+        "tinybench": "^6.0.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">= 12.22.0 < 13 || >= 14.17.0 < 15 || >= 15.12.0 < 16 || >= 16.0.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha1-Z4LA9gZuYLf9KG/npcdgD3ZQ1CA=",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha1-+WyioOibJ0kP+Pe1o5K9TfaUKZg=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@microsoft/dynwinrt": {
+      "resolved": "../../../bindings/js",
+      "link": true
+    },
+    "node_modules/@microsoft/winappcli": {
+      "version": "0.5.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/winappcli/-/winappcli-0.5.0.tgz",
+      "integrity": "sha1-v5+P3KblIBjv4YbBvgguWa7Cthk=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "winapp": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha1-SfGL08ZHhm3NpRoHVsFF4UWQzhY=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron": {
+      "version": "41.10.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron/-/electron-41.10.4.tgz",
+      "integrity": "sha1-p7dTq30KBK/VOf1DL6M4C3/rFAY=",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha1-Lx6Jwvbb00COGxcR3YLWLjF/WNo=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha1-Y3fplnlauwttNI6bPh37JDRajkI=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha1-rg9vYuBuBXqcu3srX94rt095G48=",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha1-KTV6iee3ykrvO/D9P9DNc4hCKek=",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/samples/js/electron-smtc/package-lock.json
+++ b/samples/js/electron-smtc/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dynwinrt-electron-smtc-sample",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@microsoft/dynwinrt": "file:../../../bindings/js"
       },

--- a/samples/js/electron-smtc/package-lock.json
+++ b/samples/js/electron-smtc/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@microsoft/winappcli": "^0.5.0",
-        "electron": "^41.10.3"
+        "electron": "^43.3.0"
       }
     },
     "../../../bindings/js": {
@@ -125,11 +125,10 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron/-/electron-41.10.4.tgz",
-      "integrity": "sha1-p7dTq30KBK/VOf1DL6M4C3/rFAY=",
+      "version": "43.3.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron/-/electron-43.3.0.tgz",
+      "integrity": "sha1-hRfL2UAtuX5yZ83tM8ASn/873Lg=",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -137,7 +136,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/samples/js/electron-smtc/package.json
+++ b/samples/js/electron-smtc/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dynwinrt-electron-smtc-sample",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Electron SMTC and GSMTC loopback sample using dynwinrt",
+  "main": "main.js",
+  "scripts": {
+    "generate": "powershell -NoProfile -ExecutionPolicy Bypass -File ./generate.ps1",
+    "setup-identity": "powershell -NoProfile -ExecutionPolicy Bypass -File ./setup-identity.ps1",
+    "check": "npm run generate && npm run setup-identity && electron . --validate",
+    "demo": "npm run setup-identity && electron . --demo",
+    "start": "npm run setup-identity && electron ."
+  },
+  "dependencies": {
+    "@microsoft/dynwinrt": "file:../../../bindings/js"
+  },
+  "devDependencies": {
+    "@microsoft/winappcli": "^0.5.0",
+    "electron": "^41.10.3"
+  }
+}

--- a/samples/js/electron-smtc/package.json
+++ b/samples/js/electron-smtc/package.json
@@ -9,13 +9,14 @@
     "setup-identity": "powershell -NoProfile -ExecutionPolicy Bypass -File ./setup-identity.ps1",
     "check": "npm run generate && npm run setup-identity && electron . --validate",
     "demo": "npm run setup-identity && electron . --demo",
-    "start": "npm run setup-identity && electron ."
+    "start": "npm run setup-identity && electron .",
+    "postinstall": "install-electron"
   },
   "dependencies": {
     "@microsoft/dynwinrt": "file:../../../bindings/js"
   },
   "devDependencies": {
     "@microsoft/winappcli": "^0.5.0",
-    "electron": "^41.10.3"
+    "electron": "^43.3.0"
   }
 }

--- a/samples/js/electron-smtc/preload.js
+++ b/samples/js/electron-smtc/preload.js
@@ -4,10 +4,12 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("systemMediaControls", {
+  audioEnabled: !process.argv.includes("--validate"),
   initialize: (options) => ipcRenderer.invoke("smtc:initialize", options),
   update: (options) => ipcRenderer.invoke("smtc:update", options),
   control: (action, value) => ipcRenderer.invoke("smtc:control", action, value),
   snapshot: () => ipcRenderer.invoke("smtc:snapshot"),
+  sessions: () => ipcRenderer.invoke("smtc:sessions"),
   validate: () => ipcRenderer.invoke("smtc:validate"),
   onEvent: (callback) => {
     const listener = (_event, value) => callback(value);

--- a/samples/js/electron-smtc/preload.js
+++ b/samples/js/electron-smtc/preload.js
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("systemMediaControls", {
+  initialize: (options) => ipcRenderer.invoke("smtc:initialize", options),
+  update: (options) => ipcRenderer.invoke("smtc:update", options),
+  control: (action, value) => ipcRenderer.invoke("smtc:control", action, value),
+  snapshot: () => ipcRenderer.invoke("smtc:snapshot"),
+  validate: () => ipcRenderer.invoke("smtc:validate"),
+  onEvent: (callback) => {
+    const listener = (_event, value) => callback(value);
+    ipcRenderer.on("smtc:event", listener);
+    return () => ipcRenderer.removeListener("smtc:event", listener);
+  },
+});

--- a/samples/js/electron-smtc/renderer.js
+++ b/samples/js/electron-smtc/renderer.js
@@ -1,71 +1,709 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const status = document.querySelector("#status");
-const events = document.querySelector("#events");
+const api = window.systemMediaControls;
+const element = (selector) => document.querySelector(selector);
 const eventLines = [];
+let initialized = false;
+let snapshotInFlight = false;
+let sessionsInFlight = false;
+let refreshTimer;
+let renderedTrackKey = "";
+
+const SMTC_STATUS_NAMES = {
+  0: "Closed",
+  1: "Changing",
+  2: "Stopped",
+  3: "Playing",
+  4: "Paused",
+};
+
+const GSMTC_STATUS_NAMES = {
+  0: "Closed",
+  1: "Opened",
+  2: "Changing",
+  3: "Stopped",
+  4: "Playing",
+  5: "Paused",
+};
+
+const REPEAT_MODE_NAMES = {
+  0: "No repeat",
+  1: "Repeat track",
+  2: "Repeat list",
+};
+
+const SYNTH_PROGRAMS = [
+  {
+    bpm: 104,
+    wave: "triangle",
+    notes: [72, 76, 79, 84, 79, 76, 74, 79, 81, 77, 74, 69, 72, 76, 79, 76],
+    bass: [48, 48, 45, 43],
+  },
+  {
+    bpm: 118,
+    wave: "sawtooth",
+    notes: [67, 70, 74, 77, 74, 70, 65, 69, 72, 76, 72, 69, 67, 72, 74, 70],
+    bass: [43, 46, 41, 45],
+  },
+  {
+    bpm: 82,
+    wave: "sine",
+    notes: [69, 76, 72, 79, 74, 81, 76, 72, 67, 74, 71, 78, 72, 79, 74, 71],
+    bass: [45, 41, 43, 40],
+  },
+];
+
+function midiToFrequency(note) {
+  return 440 * 2 ** ((note - 69) / 12);
+}
+
+class DemoSynth {
+  constructor(available) {
+    this.available = available;
+    this.enabled = available;
+    this.context = null;
+    this.master = null;
+    this.scheduler = null;
+    this.latestPublisher = null;
+    this.trackIndex = -1;
+    this.playbackRate = 1;
+    this.step = 0;
+    this.nextNoteTime = 0;
+    this.lastPosition = 0;
+    this.lastSyncAt = performance.now();
+    this.playing = false;
+    this.#report(
+      available
+        ? "Ready when playback starts"
+        : "Muted during automated validation",
+    );
+  }
+
+  #report(message) {
+    element("#audio-status").textContent = message;
+    const toggle = element("#audio-toggle");
+    toggle.disabled = !this.available;
+    toggle.textContent = this.enabled ? "Mute" : "Enable";
+  }
+
+  #ensureContext() {
+    if (!this.available) return null;
+    if (!this.context) {
+      this.context = new AudioContext({ latencyHint: "interactive" });
+      this.master = this.context.createGain();
+      this.master.gain.value = 0.0001;
+      this.master.connect(this.context.destination);
+    }
+    return this.context;
+  }
+
+  async unlock() {
+    if (!this.enabled) return;
+    const context = this.#ensureContext();
+    if (context?.state === "suspended") await context.resume();
+  }
+
+  #program() {
+    return SYNTH_PROGRAMS[this.trackIndex % SYNTH_PROGRAMS.length];
+  }
+
+  #baseStepSeconds() {
+    return 60 / this.#program().bpm / 2;
+  }
+
+  #resetPosition(publisher) {
+    const context = this.#ensureContext();
+    const program = this.#program();
+    this.step =
+      Math.floor(publisher.positionSeconds / this.#baseStepSeconds()) %
+      program.notes.length;
+    this.nextNoteTime = (context?.currentTime ?? 0) + 0.03;
+  }
+
+  #scheduleVoice(note, when, duration, level, wave) {
+    const context = this.context;
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    const attack = Math.min(0.025, duration * 0.15);
+
+    oscillator.type = wave;
+    oscillator.frequency.setValueAtTime(midiToFrequency(note), when);
+    gain.gain.setValueAtTime(0.0001, when);
+    gain.gain.exponentialRampToValueAtTime(level, when + attack);
+    gain.gain.exponentialRampToValueAtTime(0.0001, when + duration);
+    oscillator.connect(gain);
+    gain.connect(this.master);
+    oscillator.start(when);
+    oscillator.stop(when + duration + 0.02);
+    oscillator.addEventListener(
+      "ended",
+      () => {
+        oscillator.disconnect();
+        gain.disconnect();
+      },
+      { once: true },
+    );
+  }
+
+  #scheduleAhead() {
+    if (!this.playing || !this.context) return;
+    const program = this.#program();
+    const stepSeconds = this.#baseStepSeconds() / this.playbackRate;
+    const horizon = this.context.currentTime + 0.14;
+
+    while (this.nextNoteTime < horizon) {
+      const noteIndex = this.step % program.notes.length;
+      this.#scheduleVoice(
+        program.notes[noteIndex],
+        this.nextNoteTime,
+        stepSeconds * 0.82,
+        0.32,
+        program.wave,
+      );
+      if (this.step % 2 === 0) {
+        const bassIndex = Math.floor(this.step / 4) % program.bass.length;
+        this.#scheduleVoice(
+          program.bass[bassIndex],
+          this.nextNoteTime,
+          stepSeconds * 1.7,
+          0.16,
+          "sine",
+        );
+      }
+      this.nextNoteTime += stepSeconds;
+      this.step += 1;
+    }
+  }
+
+  #stop(message) {
+    if (this.scheduler) {
+      clearInterval(this.scheduler);
+      this.scheduler = null;
+    }
+    this.playing = false;
+    if (this.master && this.context) {
+      const now = this.context.currentTime;
+      this.master.gain.cancelScheduledValues(now);
+      this.master.gain.setTargetAtTime(0.0001, now, 0.025);
+    }
+    this.#report(message);
+  }
+
+  async sync(publisher) {
+    this.latestPublisher = publisher;
+    if (!this.available) return;
+    if (!this.enabled) {
+      this.#stop("Audio muted");
+      return;
+    }
+
+    const shouldPlay = publisher.playbackStatus === 3;
+    const trackChanged = publisher.trackIndex !== this.trackIndex;
+    const elapsed =
+      ((performance.now() - this.lastSyncAt) / 1000) * this.playbackRate;
+    const predictedPosition = this.lastPosition + elapsed;
+    const positionDrift = Math.abs(
+      publisher.positionSeconds - predictedPosition,
+    );
+
+    this.trackIndex = publisher.trackIndex;
+    this.playbackRate = Math.max(0.25, publisher.playbackRate);
+    this.lastPosition = publisher.positionSeconds;
+    this.lastSyncAt = performance.now();
+
+    if (!shouldPlay) {
+      this.#stop(
+        `${SMTC_STATUS_NAMES[publisher.playbackStatus] ?? "Playback"} - audio idle`,
+      );
+      return;
+    }
+
+    await this.unlock();
+    if (trackChanged || !this.playing || positionDrift > 1.5) {
+      this.#resetPosition(publisher);
+    }
+    this.playing = true;
+    const now = this.context.currentTime;
+    this.master.gain.cancelScheduledValues(now);
+    this.master.gain.setValueAtTime(
+      Math.max(0.0001, this.master.gain.value),
+      now,
+    );
+    this.master.gain.linearRampToValueAtTime(0.12, now + 0.05);
+    if (!this.scheduler) {
+      this.scheduler = setInterval(() => this.#scheduleAhead(), 30);
+    }
+    this.#scheduleAhead();
+    this.#report(`Playing locally generated track ${publisher.trackIndex + 1}`);
+  }
+
+  async toggle() {
+    this.enabled = !this.enabled;
+    if (!this.enabled) {
+      this.#stop("Audio muted");
+      return;
+    }
+    await this.unlock();
+    if (this.latestPublisher) await this.sync(this.latestPublisher);
+    else this.#report("Ready when playback starts");
+  }
+
+  dispose() {
+    this.#stop("Audio stopped");
+    void this.context?.close();
+    this.context = null;
+    this.master = null;
+  }
+}
+
+const synth = new DemoSynth(api.audioEnabled);
+let latestPublisher;
+
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds)) return "--:--";
+  const value = Math.max(0, Math.round(seconds));
+  const minutes = Math.floor(value / 60);
+  return `${minutes}:${String(value % 60).padStart(2, "0")}`;
+}
+
+function safeJson(value) {
+  return JSON.stringify(
+    value,
+    (_key, item) => (typeof item === "bigint" ? String(item) : item),
+    2,
+  );
+}
+
+function playbackModeLabel(publisher) {
+  const modes = [];
+  if (publisher.shuffleEnabled) modes.push("Shuffle");
+  if (publisher.autoRepeatMode !== 0) {
+    modes.push(REPEAT_MODE_NAMES[publisher.autoRepeatMode]);
+  }
+  return modes.join(" + ") || "Sequential";
+}
 
 function options() {
   return {
-    title: document.querySelector("#title").value,
-    artist: document.querySelector("#artist").value,
-    durationSeconds: Number(document.querySelector("#duration").value),
-    positionSeconds: Number(document.querySelector("#position").value),
+    title: element("#title").value,
+    artist: element("#artist").value,
+    durationSeconds: Number(element("#duration").value),
   };
 }
 
 function show(value) {
-  status.textContent = JSON.stringify(value, null, 2);
+  element("#status").textContent = safeJson(value);
 }
 
-window.showValidationResult = show;
+function setConnection(label, state) {
+  const status = element("#connection-status");
+  status.textContent = label;
+  status.className = `status-pill ${state}`;
+}
 
-async function run(action) {
-  try {
-    show(await action());
-  } catch (error) {
-    show({ error: error instanceof Error ? error.message : String(error) });
+function observe(promise) {
+  promise.catch((error) => {
+    console.error("SMTC sample operation failed.", error);
+  });
+}
+
+function renderPlaylist(publisher) {
+  const playlist = element("#playlist");
+  playlist.replaceChildren();
+  for (const track of publisher.playlist) {
+    const item = document.createElement("li");
+    item.dataset.index = String(track.index + 1).padStart(2, "0");
+    if (track.index === publisher.trackIndex) item.classList.add("active");
+
+    const title = document.createElement("span");
+    title.textContent = track.title;
+    const duration = document.createElement("span");
+    duration.className = "track-duration";
+    duration.textContent = formatTime(track.durationSeconds);
+    item.append(title, duration);
+    playlist.append(item);
   }
 }
 
-window.systemMediaControls.onEvent((event) => {
-  eventLines.unshift(JSON.stringify(event));
-  events.textContent = eventLines.slice(0, 30).join("\n");
+function renderCapabilities(capabilities) {
+  const container = element("#capabilities");
+  container.replaceChildren();
+  const entries = Object.entries(capabilities);
+  if (entries.length === 0) {
+    const pending = document.createElement("span");
+    pending.className = "capability pending";
+    pending.textContent = "Waiting for playback info";
+    container.append(pending);
+  } else {
+    for (const [name, enabled] of entries) {
+      const chip = document.createElement("span");
+      chip.className = `capability ${enabled ? "enabled" : "disabled"}`;
+      chip.textContent = `${name}: ${enabled ? "enabled" : "disabled"}`;
+      container.append(chip);
+    }
+  }
+
+  for (const button of document.querySelectorAll("[data-capability]")) {
+    const capability = button.dataset.capability;
+    button.disabled = !initialized || capabilities[capability] !== true;
+  }
+}
+
+function renderSnapshot(snapshot) {
+  const { publisher, controller } = snapshot;
+  const { metadata, playback, timeline, capabilities } = controller;
+  latestPublisher = publisher;
+  observe(synth.sync(publisher));
+
+  element("#publisher-artwork").src = publisher.artworkUrl;
+  element("#publisher-track-number").textContent =
+    `Track ${publisher.trackIndex + 1} of ${publisher.trackCount}`;
+  element("#publisher-title").textContent = publisher.title;
+  element("#publisher-artist").textContent = publisher.artist;
+  element("#publisher-album").textContent =
+    `${publisher.albumTitle} · ${publisher.genre}`;
+  element("#publisher-status").textContent =
+    SMTC_STATUS_NAMES[publisher.playbackStatus] ??
+    String(publisher.playbackStatus);
+  element("#publisher-rate").textContent =
+    `${publisher.playbackRate.toFixed(2)}x`;
+  element("#publisher-mode").textContent = playbackModeLabel(publisher);
+  const isPlaying = publisher.playbackStatus === 3;
+  const toggleButton = element('[data-action="toggle"]');
+  toggleButton.setAttribute("aria-label", isPlaying ? "Pause" : "Play");
+  toggleButton.title = isPlaying ? "Pause" : "Play";
+  element("#toggle-icon-path").setAttribute(
+    "d",
+    isPlaying ? "M5.5 4h3v12h-3V4Zm6 0h3v12h-3V4Z" : "M6 3.8v12.4L16 10 6 3.8Z",
+  );
+
+  const publisherProgress = element("#publisher-progress");
+  publisherProgress.max = String(publisher.durationSeconds);
+  publisherProgress.value = String(publisher.positionSeconds);
+  element("#publisher-position").textContent = formatTime(
+    publisher.positionSeconds,
+  );
+  element("#publisher-duration").textContent = formatTime(
+    publisher.durationSeconds,
+  );
+  renderPlaylist(publisher);
+
+  const trackKey = `${publisher.trackIndex}\0${publisher.title}`;
+  if (
+    trackKey !== renderedTrackKey &&
+    !["title", "artist", "duration"].includes(document.activeElement?.id)
+  ) {
+    element("#title").value = publisher.title;
+    element("#artist").value = publisher.artist;
+    element("#duration").value = String(publisher.durationSeconds);
+    renderedTrackKey = trackKey;
+  }
+
+  element("#controller-artwork").src = publisher.artworkUrl;
+  element("#controller-artwork").hidden = !metadata.hasThumbnail;
+  element("#controller-title").textContent = metadata.title || "No media title";
+  element("#controller-artist").textContent = [
+    metadata.artist,
+    metadata.albumTitle,
+  ]
+    .filter(Boolean)
+    .join(" - ");
+  element("#controller-source").textContent =
+    controller.sourceAppUserModelId || "No source AUMID";
+
+  const seek = element("#seek");
+  seek.max = String(timeline.endSeconds ?? publisher.durationSeconds);
+  if (document.activeElement !== seek) {
+    seek.value = String(timeline.positionSeconds ?? 0);
+    element("#seek-value").textContent = formatTime(
+      timeline.positionSeconds ?? 0,
+    );
+  }
+
+  const rate = element("#rate");
+  const rateValue = String(playback.rate ?? publisher.playbackRate);
+  if ([...rate.options].some((option) => option.value === rateValue)) {
+    rate.value = rateValue;
+  }
+  element("#shuffle").checked =
+    playback.shuffleActive ?? publisher.shuffleEnabled;
+  element("#repeat").value = String(
+    playback.autoRepeatMode ?? publisher.autoRepeatMode,
+  );
+  renderCapabilities(capabilities);
+
+  setConnection(
+    `${GSMTC_STATUS_NAMES[playback.status] ?? "Connected"} via GSMTC`,
+    "active",
+  );
+}
+
+function renderSessions(sessions) {
+  const container = element("#sessions");
+  container.replaceChildren();
+  if (sessions.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "empty-state";
+    empty.textContent = "No global media sessions are currently available.";
+    container.append(empty);
+    return;
+  }
+
+  for (const session of sessions) {
+    const card = document.createElement("article");
+    card.className = "session-card";
+    if (session.isOwn) card.classList.add("own");
+    if (session.isCurrent) card.classList.add("current");
+
+    const title = document.createElement("h3");
+    title.textContent = session.title || "Untitled media session";
+    const artist = document.createElement("p");
+    artist.textContent = session.artist || "Unknown artist";
+    const source = document.createElement("p");
+    source.textContent = session.sourceAppUserModelId || session.error || "";
+    const badges = document.createElement("div");
+    badges.className = "session-badges";
+    if (session.isOwn) {
+      const own = document.createElement("span");
+      own.textContent = "This sample";
+      badges.append(own);
+    }
+    if (session.isCurrent) {
+      const current = document.createElement("span");
+      current.textContent = "Windows current";
+      badges.append(current);
+    }
+    const status = document.createElement("span");
+    status.textContent =
+      GSMTC_STATUS_NAMES[session.playbackStatus] ?? "Unavailable";
+    badges.append(status);
+    card.append(title, artist, source, badges);
+    container.append(card);
+  }
+}
+
+function renderEvents() {
+  const list = element("#events");
+  list.replaceChildren();
+  if (eventLines.length === 0) {
+    const empty = document.createElement("li");
+    empty.className = "empty-state";
+    empty.textContent = "Waiting for SMTC and GSMTC events.";
+    list.append(empty);
+    return;
+  }
+
+  for (const event of eventLines) {
+    const item = document.createElement("li");
+    item.className = "event-item";
+    if (event.flow?.startsWith("GSMTC controller")) {
+      item.classList.add("controller");
+    } else if (event.flow?.includes("manager")) {
+      item.classList.add("manager");
+    }
+
+    const time = document.createElement("span");
+    time.className = "event-time";
+    time.textContent = new Date(event.timestamp).toLocaleTimeString();
+    const type = document.createElement("span");
+    type.className = "event-type";
+    type.textContent = event.type;
+    const flow = document.createElement("span");
+    flow.className = "event-flow";
+    flow.textContent = event.flow ?? "Loopback";
+    const detail = document.createElement("span");
+    detail.className = "event-detail";
+    const detailValue = { ...event };
+    delete detailValue.type;
+    delete detailValue.timestamp;
+    delete detailValue.flow;
+    detail.textContent =
+      Object.keys(detailValue).length > 0 ? safeJson(detailValue) : "";
+    item.append(time, type, flow, detail);
+    list.append(item);
+  }
+}
+
+async function run(action) {
+  try {
+    return await action();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    setConnection("Operation failed", "error");
+    show({ error: message });
+    throw error;
+  }
+}
+
+async function refreshSnapshot() {
+  if (!initialized || snapshotInFlight) return;
+  snapshotInFlight = true;
+  try {
+    renderSnapshot(await api.snapshot());
+  } catch (error) {
+    setConnection("Snapshot unavailable", "error");
+    show({ error: error instanceof Error ? error.message : String(error) });
+  } finally {
+    snapshotInFlight = false;
+  }
+}
+
+async function refreshSessions() {
+  if (!initialized || sessionsInFlight) return;
+  sessionsInFlight = true;
+  try {
+    renderSessions(await api.sessions());
+  } catch (error) {
+    show({ error: error instanceof Error ? error.message : String(error) });
+  } finally {
+    sessionsInFlight = false;
+  }
+}
+
+function scheduleRefresh() {
+  if (refreshTimer) return;
+  refreshTimer = setTimeout(() => {
+    refreshTimer = undefined;
+    void refreshSnapshot();
+  }, 120);
+}
+
+async function initialize() {
+  setConnection("Starting native session", "idle");
+  const snapshot = await run(() => api.initialize(options()));
+  initialized = true;
+  element("#initialize").textContent = "Restart media session";
+  renderSnapshot(snapshot);
+  await refreshSessions();
+  return snapshot;
+}
+
+async function sendControl(action, value) {
+  const accepted = await run(() => api.control(action, value));
+  scheduleRefresh();
+  return accepted;
+}
+
+element("#initialize").addEventListener("click", () => {
+  observe(
+    (async () => {
+      await synth.unlock();
+      return initialize();
+    })(),
+  );
 });
 
-document
-  .querySelector("#initialize")
-  .addEventListener("click", () =>
-    run(() => window.systemMediaControls.initialize(options())),
+element("#update").addEventListener("click", () => {
+  observe(
+    run(async () => {
+      const snapshot = await api.update(options());
+      renderSnapshot(snapshot);
+      show({ updated: snapshot.controller.metadata });
+    }),
   );
-document
-  .querySelector("#update")
-  .addEventListener("click", () =>
-    run(() => window.systemMediaControls.update(options())),
+});
+
+for (const button of document.querySelectorAll("[data-action]")) {
+  button.disabled = true;
+  button.addEventListener("click", () => {
+    observe(
+      (async () => {
+        await synth.unlock();
+        return sendControl(button.dataset.action);
+      })(),
+    );
+  });
+}
+
+element("#audio-toggle").addEventListener("click", () => {
+  observe(synth.toggle());
+});
+
+element("#seek").addEventListener("input", (event) => {
+  element("#seek-value").textContent = formatTime(Number(event.target.value));
+});
+element("#seek").addEventListener("change", (event) => {
+  observe(sendControl("seek", Number(event.target.value)));
+});
+element("#rate").addEventListener("change", (event) => {
+  observe(sendControl("rate", Number(event.target.value)));
+});
+element("#shuffle").addEventListener("change", (event) => {
+  observe(sendControl("shuffle", event.target.checked));
+});
+element("#repeat").addEventListener("change", (event) => {
+  observe(sendControl("repeat", Number(event.target.value)));
+});
+
+element("#refresh-sessions").addEventListener("click", () => {
+  void refreshSessions();
+});
+element("#clear-events").addEventListener("click", () => {
+  eventLines.length = 0;
+  renderEvents();
+});
+
+element("#validate").addEventListener("click", () => {
+  observe(
+    run(async () => {
+      setConnection("Running loopback validation", "idle");
+      const result = await api.validate();
+      initialized = true;
+      element("#initialize").textContent = "Restart media session";
+      renderSnapshot(result.snapshot);
+      renderSessions(result.sessions);
+      show(result);
+      const failures = Object.values(result.checks).filter(
+        (passed) => !passed,
+      ).length;
+      setConnection(
+        failures === 0
+          ? `${Object.keys(result.checks).length} checks passed`
+          : `${failures} checks failed`,
+        failures === 0 ? "active" : "error",
+      );
+    }),
   );
-document.querySelector("#play").addEventListener("click", () =>
-  run(async () => ({
-    accepted: await window.systemMediaControls.control("play"),
-    snapshot: await window.systemMediaControls.snapshot(),
-  })),
-);
-document.querySelector("#pause").addEventListener("click", () =>
-  run(async () => ({
-    accepted: await window.systemMediaControls.control("pause"),
-    snapshot: await window.systemMediaControls.snapshot(),
-  })),
-);
-document.querySelector("#seek").addEventListener("click", () =>
-  run(async () => ({
-    accepted: await window.systemMediaControls.control(
-      "seek",
-      Number(document.querySelector("#position").value),
-    ),
-    snapshot: await window.systemMediaControls.snapshot(),
-  })),
-);
-document
-  .querySelector("#validate")
-  .addEventListener("click", () =>
-    run(() => window.systemMediaControls.validate()),
-  );
+});
+
+const unsubscribe = api.onEvent((event) => {
+  eventLines.unshift(event);
+  eventLines.splice(60);
+  renderEvents();
+  scheduleRefresh();
+  if (
+    event.type === "sessions-changed" ||
+    event.type === "current-session-changed"
+  ) {
+    void refreshSessions();
+  }
+});
+
+window.showValidationResult = (result) => {
+  if (result.error) {
+    setConnection("Validation failed", "error");
+    show(result);
+    return;
+  }
+  initialized = true;
+  element("#initialize").textContent = "Restart media session";
+  renderSnapshot(result.snapshot);
+  renderSessions(result.sessions ?? []);
+  show(result);
+  setConnection(`${Object.keys(result.checks).length} checks passed`, "active");
+};
+
+const snapshotInterval = setInterval(() => {
+  void refreshSnapshot();
+}, 1000);
+const sessionsInterval = setInterval(() => {
+  void refreshSessions();
+}, 5000);
+window.addEventListener("beforeunload", () => {
+  initialized = false;
+  clearInterval(snapshotInterval);
+  clearInterval(sessionsInterval);
+  unsubscribe();
+  synth.dispose();
+});

--- a/samples/js/electron-smtc/renderer.js
+++ b/samples/js/electron-smtc/renderer.js
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const status = document.querySelector("#status");
+const events = document.querySelector("#events");
+const eventLines = [];
+
+function options() {
+  return {
+    title: document.querySelector("#title").value,
+    artist: document.querySelector("#artist").value,
+    durationSeconds: Number(document.querySelector("#duration").value),
+    positionSeconds: Number(document.querySelector("#position").value),
+  };
+}
+
+function show(value) {
+  status.textContent = JSON.stringify(value, null, 2);
+}
+
+window.showValidationResult = show;
+
+async function run(action) {
+  try {
+    show(await action());
+  } catch (error) {
+    show({ error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+window.systemMediaControls.onEvent((event) => {
+  eventLines.unshift(JSON.stringify(event));
+  events.textContent = eventLines.slice(0, 30).join("\n");
+});
+
+document
+  .querySelector("#initialize")
+  .addEventListener("click", () =>
+    run(() => window.systemMediaControls.initialize(options())),
+  );
+document
+  .querySelector("#update")
+  .addEventListener("click", () =>
+    run(() => window.systemMediaControls.update(options())),
+  );
+document.querySelector("#play").addEventListener("click", () =>
+  run(async () => ({
+    accepted: await window.systemMediaControls.control("play"),
+    snapshot: await window.systemMediaControls.snapshot(),
+  })),
+);
+document.querySelector("#pause").addEventListener("click", () =>
+  run(async () => ({
+    accepted: await window.systemMediaControls.control("pause"),
+    snapshot: await window.systemMediaControls.snapshot(),
+  })),
+);
+document.querySelector("#seek").addEventListener("click", () =>
+  run(async () => ({
+    accepted: await window.systemMediaControls.control(
+      "seek",
+      Number(document.querySelector("#position").value),
+    ),
+    snapshot: await window.systemMediaControls.snapshot(),
+  })),
+);
+document
+  .querySelector("#validate")
+  .addEventListener("click", () =>
+    run(() => window.systemMediaControls.validate()),
+  );

--- a/samples/js/electron-smtc/setup-identity.ps1
+++ b/samples/js/electron-smtc/setup-identity.ps1
@@ -10,13 +10,16 @@ Add-Type -AssemblyName System.Drawing
 function New-SampleLogo {
     param(
         [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)][int]$Size
+        [Parameter(Mandatory = $true)][int]$Size,
+        [System.Drawing.Color]$BackgroundColor = [System.Drawing.Color]::FromArgb(0, 95, 184),
+        [string]$Label = ""
     )
 
     $bitmap = [System.Drawing.Bitmap]::new($Size, $Size)
     $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
     try {
-        $graphics.Clear([System.Drawing.Color]::FromArgb(0, 95, 184))
+        $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+        $graphics.Clear($BackgroundColor)
         $pen = [System.Drawing.Pen]::new([System.Drawing.Color]::White, [Math]::Max(2, $Size / 18))
         try {
             $margin = [Math]::Max(4, [int]($Size * 0.2))
@@ -43,6 +46,148 @@ function New-SampleLogo {
         finally {
             $pen.Dispose()
         }
+        if ($Label) {
+            $font = [System.Drawing.Font]::new(
+                "Segoe UI",
+                [single]($Size * 0.12),
+                [System.Drawing.FontStyle]::Bold,
+                [System.Drawing.GraphicsUnit]::Pixel)
+            $brush = [System.Drawing.SolidBrush]::new([System.Drawing.Color]::White)
+            $format = [System.Drawing.StringFormat]::new()
+            try {
+                $format.Alignment = [System.Drawing.StringAlignment]::Center
+                $format.LineAlignment = [System.Drawing.StringAlignment]::Center
+                $bounds = [System.Drawing.RectangleF]::new(
+                    0,
+                    [single]($Size * 0.72),
+                    $Size,
+                    [single]($Size * 0.18))
+                $graphics.DrawString($Label, $font, $brush, $bounds, $format)
+            }
+            finally {
+                $format.Dispose()
+                $brush.Dispose()
+                $font.Dispose()
+            }
+        }
+        $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    }
+    finally {
+        $graphics.Dispose()
+        $bitmap.Dispose()
+    }
+}
+
+function New-AlbumArtwork {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][System.Drawing.Color]$StartColor,
+        [Parameter(Mandatory = $true)][System.Drawing.Color]$EndColor,
+        [Parameter(Mandatory = $true)][System.Drawing.Color]$AccentColor,
+        [Parameter(Mandatory = $true)][string]$TrackNumber
+    )
+
+    $size = 512
+    $bitmap = [System.Drawing.Bitmap]::new($size, $size)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+        $graphics.SmoothingMode = [System.Drawing.Drawing2D.SmoothingMode]::AntiAlias
+        $bounds = [System.Drawing.Rectangle]::new(0, 0, $size, $size)
+        $gradient = [System.Drawing.Drawing2D.LinearGradientBrush]::new(
+            $bounds,
+            $StartColor,
+            $EndColor,
+            [System.Drawing.Drawing2D.LinearGradientMode]::ForwardDiagonal)
+        try {
+            $graphics.FillRectangle($gradient, $bounds)
+        }
+        finally {
+            $gradient.Dispose()
+        }
+
+        $glow = [System.Drawing.SolidBrush]::new(
+            [System.Drawing.Color]::FromArgb(36, 255, 255, 255))
+        try {
+            $graphics.FillEllipse($glow, -110, 35, 390, 390)
+            $graphics.FillEllipse($glow, 270, 255, 330, 330)
+        }
+        finally {
+            $glow.Dispose()
+        }
+
+        $arcPen = [System.Drawing.Pen]::new(
+            [System.Drawing.Color]::FromArgb(
+                205,
+                $AccentColor.R,
+                $AccentColor.G,
+                $AccentColor.B),
+            14)
+        try {
+            $arcPen.StartCap = [System.Drawing.Drawing2D.LineCap]::Round
+            $arcPen.EndCap = [System.Drawing.Drawing2D.LineCap]::Round
+            for ($index = 0; $index -lt 5; $index++) {
+                $inset = 58 + $index * 42
+                $diameter = $size - 2 * $inset
+                $graphics.DrawArc(
+                    $arcPen,
+                    $inset,
+                    $inset,
+                    $diameter,
+                    $diameter,
+                    205 + $index * 11,
+                    235)
+            }
+        }
+        finally {
+            $arcPen.Dispose()
+        }
+
+        $linePen = [System.Drawing.Pen]::new(
+            [System.Drawing.Color]::FromArgb(110, 255, 255, 255),
+            5)
+        try {
+            for ($index = 0; $index -lt 7; $index++) {
+                $x = 58 + $index * 32
+                $height = 26 + (($index * 29) % 72)
+                $graphics.DrawLine($linePen, $x, 396 - $height, $x, 396)
+            }
+        }
+        finally {
+            $linePen.Dispose()
+        }
+
+        $numberFont = [System.Drawing.Font]::new(
+            "Segoe UI Variable Display",
+            68,
+            [System.Drawing.FontStyle]::Bold,
+            [System.Drawing.GraphicsUnit]::Pixel)
+        $captionFont = [System.Drawing.Font]::new(
+            "Segoe UI",
+            22,
+            [System.Drawing.FontStyle]::Bold,
+            [System.Drawing.GraphicsUnit]::Pixel)
+        $textBrush = [System.Drawing.SolidBrush]::new(
+            [System.Drawing.Color]::FromArgb(225, 255, 255, 255))
+        try {
+            $graphics.DrawString(
+                $TrackNumber,
+                $numberFont,
+                $textBrush,
+                [single]350,
+                [single]46)
+            $graphics.DrawString(
+                "RUNTIME RADIO",
+                $captionFont,
+                $textBrush,
+                [single]56,
+                [single]432)
+        }
+        finally {
+            $textBrush.Dispose()
+            $captionFont.Dispose()
+            $numberFont.Dispose()
+        }
+
         $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
     }
     finally {
@@ -54,6 +199,24 @@ function New-SampleLogo {
 New-SampleLogo (Join-Path $assets "StoreLogo.png") 50
 New-SampleLogo (Join-Path $assets "Square44x44Logo.png") 44
 New-SampleLogo (Join-Path $assets "Square150x150Logo.png") 150
+New-AlbumArtwork `
+    (Join-Path $assets "AlbumBlue.png") `
+    ([System.Drawing.Color]::FromArgb(0, 67, 135)) `
+    ([System.Drawing.Color]::FromArgb(0, 153, 188)) `
+    ([System.Drawing.Color]::FromArgb(126, 231, 255)) `
+    "01"
+New-AlbumArtwork `
+    (Join-Path $assets "AlbumPurple.png") `
+    ([System.Drawing.Color]::FromArgb(73, 34, 128)) `
+    ([System.Drawing.Color]::FromArgb(182, 64, 151)) `
+    ([System.Drawing.Color]::FromArgb(255, 171, 228)) `
+    "02"
+New-AlbumArtwork `
+    (Join-Path $assets "AlbumOrange.png") `
+    ([System.Drawing.Color]::FromArgb(120, 43, 14)) `
+    ([System.Drawing.Color]::FromArgb(229, 119, 36)) `
+    ([System.Drawing.Color]::FromArgb(255, 224, 151)) `
+    "03"
 
 Push-Location $PSScriptRoot
 try {

--- a/samples/js/electron-smtc/setup-identity.ps1
+++ b/samples/js/electron-smtc/setup-identity.ps1
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+$ErrorActionPreference = "Stop"
+$assets = Join-Path $PSScriptRoot "Assets"
+New-Item $assets -ItemType Directory -Force | Out-Null
+
+Add-Type -AssemblyName System.Drawing
+
+function New-SampleLogo {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][int]$Size
+    )
+
+    $bitmap = [System.Drawing.Bitmap]::new($Size, $Size)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+        $graphics.Clear([System.Drawing.Color]::FromArgb(0, 95, 184))
+        $pen = [System.Drawing.Pen]::new([System.Drawing.Color]::White, [Math]::Max(2, $Size / 18))
+        try {
+            $margin = [Math]::Max(4, [int]($Size * 0.2))
+            $graphics.DrawEllipse($pen, $margin, $margin, $Size - 2 * $margin, $Size - 2 * $margin)
+            $graphics.DrawLine(
+                $pen,
+                [int]($Size * 0.45),
+                [int]($Size * 0.35),
+                [int]($Size * 0.45),
+                [int]($Size * 0.65))
+            $graphics.DrawLine(
+                $pen,
+                [int]($Size * 0.45),
+                [int]($Size * 0.35),
+                [int]($Size * 0.68),
+                [int]($Size * 0.50))
+            $graphics.DrawLine(
+                $pen,
+                [int]($Size * 0.68),
+                [int]($Size * 0.50),
+                [int]($Size * 0.45),
+                [int]($Size * 0.65))
+        }
+        finally {
+            $pen.Dispose()
+        }
+        $bitmap.Save($Path, [System.Drawing.Imaging.ImageFormat]::Png)
+    }
+    finally {
+        $graphics.Dispose()
+        $bitmap.Dispose()
+    }
+}
+
+New-SampleLogo (Join-Path $assets "StoreLogo.png") 50
+New-SampleLogo (Join-Path $assets "Square44x44Logo.png") 44
+New-SampleLogo (Join-Path $assets "Square150x150Logo.png") 150
+
+Push-Location $PSScriptRoot
+try {
+    & npx winapp node add-electron-debug-identity --manifest appxmanifest.xml
+    if ($LASTEXITCODE -ne 0) {
+        throw "Creating the Electron debug identity failed with exit code $LASTEXITCODE."
+    }
+}
+finally {
+    Pop-Location
+}

--- a/samples/js/electron-smtc/style.css
+++ b/samples/js/electron-smtc/style.css
@@ -1,79 +1,922 @@
 :root {
   color-scheme: light dark;
-  font-family: "Segoe UI", sans-serif;
-  background: #f3f3f3;
-  color: #1a1a1a;
+  font-family: "Segoe UI Variable Text", "Segoe UI", system-ui, sans-serif;
+  --text-primary: var(--colorNeutralForeground1, #f5f5f5);
+  --text-secondary: var(--colorNeutralForeground2, #c7c7c7);
+  --text-tertiary: var(--colorNeutralForeground3, #9d9d9d);
+  --stroke: var(--colorNeutralStroke2, rgb(255 255 255 / 8%));
+  --stroke-strong: var(--colorNeutralStroke1, rgb(255 255 255 / 14%));
+  --layer: rgb(32 32 32 / 72%);
+  --card: rgb(255 255 255 / 5%);
+  --card-hover: rgb(255 255 255 / 8%);
+  --subtle: rgb(255 255 255 / 3.5%);
+  --accent: var(--colorBrandBackground, AccentColor);
+  --accent-subtle: rgb(96 205 255 / 11%);
+  --success: #6ccb5f;
+  --shadow: rgb(0 0 0 / 22%);
+  background: transparent;
+  color: var(--text-primary);
+  font-synthesis: none;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --text-primary: #1a1a1a;
+    --text-secondary: #424242;
+    --text-tertiary: #616161;
+    --stroke: rgb(0 0 0 / 6%);
+    --stroke-strong: rgb(0 0 0 / 14%);
+    --layer: rgb(243 243 243 / 76%);
+    --card: rgb(255 255 255 / 72%);
+    --card-hover: rgb(255 255 255 / 92%);
+    --subtle: rgb(255 255 255 / 46%);
+    --accent-subtle: rgb(0 95 184 / 8%);
+    --success: #0f7b0f;
+    --shadow: rgb(0 0 0 / 10%);
+  }
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
+  min-width: 320px;
+  min-height: 100vh;
   margin: 0;
+  background: transparent;
 }
 
-main {
-  max-width: 700px;
+button,
+input,
+select {
+  font: inherit;
+}
+
+input:not([type="checkbox"]),
+select {
+  width: 100%;
+}
+
+button,
+input,
+select,
+summary {
+  color: var(--text-primary);
+}
+
+button {
+  min-height: 32px;
+  padding: 5px 12px;
+  border: 1px solid var(--stroke-strong);
+  border-bottom-color: var(--stroke);
+  border-radius: 4px;
+  background: var(--card);
+  box-shadow: 0 1px 1px var(--shadow);
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  background: var(--card-hover);
+}
+
+button:active:not(:disabled) {
+  background: var(--subtle);
+  box-shadow: none;
+}
+
+button:disabled {
+  color: color-mix(in srgb, var(--text-primary) 36%, transparent);
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+button.primary {
+  border-color: transparent;
+  color: var(--colorNeutralForegroundOnBrand, white);
+  background: var(--accent);
+  box-shadow: none;
+}
+
+button.primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 90%, white);
+}
+
+button.subtle {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+input:not([type="range"], [type="checkbox"]),
+select {
+  min-height: 32px;
+  padding: 5px 9px;
+  border: 1px solid var(--stroke-strong);
+  border-bottom: 2px solid var(--stroke-strong);
+  border-radius: 4px;
+  background: var(--card);
+}
+
+input:focus-visible,
+select:focus-visible,
+button:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+input[type="range"] {
+  min-height: 20px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+button svg {
+  width: 20px;
+  height: 20px;
+  fill: currentcolor;
+}
+
+details > summary {
+  padding-block: 7px;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.app-shell {
+  width: min(1220px, 100%);
   margin: 0 auto;
   padding: 24px;
 }
 
-h1,
-h2 {
-  margin-bottom: 8px;
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--stroke);
+  border-radius: 10px;
+  background: var(--layer);
+  box-shadow: 0 2px 6px var(--shadow);
+  backdrop-filter: blur(24px) saturate(120%);
 }
 
-.form {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(220px, 1fr));
+.brand {
+  display: flex;
+  align-items: center;
+  min-width: 0;
   gap: 12px;
-  margin: 20px 0;
+}
+
+.app-mark {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--colorNeutralForegroundOnBrand, white);
+  background: var(--accent);
+  font-size: 1.35rem;
+  box-shadow: 0 2px 8px var(--shadow);
+}
+
+.brand h1 {
+  margin: 0;
+  font-family: "Segoe UI Variable Display", "Segoe UI", sans-serif;
+  font-size: 1.35rem;
+  font-weight: 620;
+  letter-spacing: -0.015em;
+}
+
+.brand p {
+  overflow: hidden;
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: var(--subtle);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.status-pill::before {
+  width: 7px;
+  height: 7px;
+  margin-right: 7px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  content: "";
+}
+
+.status-pill.active::before {
+  background: var(--success);
+}
+
+.status-pill.error::before {
+  background: var(--colorPaletteRedForeground1, #ff99a4);
+}
+
+main {
+  display: grid;
+  gap: 12px;
+}
+
+.player-surface {
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--stroke);
+  border-radius: 12px;
+  background: var(--layer);
+  box-shadow: 0 2px 8px var(--shadow);
+  backdrop-filter: blur(28px) saturate(125%);
+}
+
+.playlist-pane {
+  min-width: 0;
+  padding: 22px 18px;
+  border-right: 1px solid var(--stroke);
+  background: var(--subtle);
+}
+
+.pane-heading {
+  margin: 0 4px 18px;
+}
+
+.pane-heading h2,
+.card-heading h2,
+.diagnostics-heading h2 {
+  margin: 2px 0;
+  font-size: 1rem;
+  font-weight: 620;
+}
+
+.pane-heading p {
+  margin: 3px 0 0;
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+}
+
+.overline {
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.playlist {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.playlist li {
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 42px;
+  gap: 9px;
+  padding: 7px 9px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--text-secondary);
+  background: transparent;
+}
+
+.playlist li::before {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--text-tertiary);
+  background: var(--card);
+  content: attr(data-index);
+  font-size: 0.65rem;
+}
+
+.playlist li.active {
+  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
+  color: var(--text-primary);
+  background: var(--accent-subtle);
+}
+
+.playlist .track-duration {
+  color: var(--text-tertiary);
+  font-size: 0.7rem;
+}
+
+.metadata-editor {
+  margin-top: 16px;
+}
+
+.form-grid {
+  display: grid;
+  gap: 10px;
+  padding: 4px 2px 10px;
 }
 
 label {
   display: grid;
-  gap: 4px;
+  gap: 5px;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
 }
 
-input,
-button {
-  font: inherit;
-  padding: 8px 10px;
+.now-playing-pane {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  align-content: center;
+  align-items: center;
+  min-width: 0;
+  gap: 22px 28px;
+  padding: 30px 34px 24px;
 }
 
-.actions {
+.cover-stage {
+  grid-row: 1 / span 4;
+  align-self: start;
+}
+
+.artwork {
+  display: block;
+  width: min(220px, 100%);
+  aspect-ratio: 1;
+  border: 1px solid var(--stroke);
+  border-radius: 10px;
+  object-fit: cover;
+  box-shadow: 0 10px 28px var(--shadow);
+}
+
+.track-copy {
+  min-width: 0;
+  align-self: end;
+}
+
+.track-copy h2 {
+  overflow: hidden;
+  margin: 5px 0 2px;
+  font-family: "Segoe UI Variable Display", "Segoe UI", sans-serif;
+  font-size: clamp(1.65rem, 3.5vw, 2.35rem);
+  font-weight: 620;
+  letter-spacing: -0.035em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.track-copy p {
+  margin: 3px 0;
+}
+
+.artist {
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+.secondary,
+.source-id {
+  color: var(--text-tertiary);
+}
+
+.state-row {
   display: flex;
   flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 12px;
+}
+
+.state-chip,
+.role-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: var(--accent-subtle);
+  font-size: 0.68rem;
+}
+
+.timeline {
+  min-width: 0;
+}
+
+.timeline-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 3px;
+  color: var(--text-tertiary);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.transport {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: 8px;
 }
 
-button {
-  border: 1px solid #888;
-  border-radius: 4px;
+.transport button {
+  flex: 0 0 auto;
+}
+
+.icon-button {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  min-height: 40px;
+  padding: 0;
+  place-items: center;
+  border-radius: 50%;
+  background: transparent;
+  box-shadow: none;
+}
+
+.play-button {
+  width: 48px;
+  height: 48px;
+  min-height: 48px;
+  margin-inline: 4px;
+}
+
+.play-button svg {
+  width: 24px;
+  height: 24px;
+}
+
+.playback-options {
+  display: grid;
+  grid-template-columns: minmax(190px, 1.4fr) minmax(100px, 0.7fr) auto minmax(
+      100px,
+      0.7fr
+    );
+  align-items: end;
+  gap: 12px;
+}
+
+.audio-status {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr) auto;
+  align-items: center;
+  min-width: 0;
+  gap: 9px;
+  padding: 7px 8px;
+  border: 1px solid var(--stroke);
+  border-radius: 6px;
+  background: var(--card);
+}
+
+.audio-glyph {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 5px;
+  color: var(--colorNeutralForegroundOnBrand, white);
+  background: var(--accent);
+}
+
+.audio-status > div:nth-child(2) {
+  display: grid;
+  min-width: 0;
+}
+
+.audio-status strong,
+.audio-status span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audio-status strong {
+  font-size: 0.75rem;
+}
+
+.audio-status span {
+  color: var(--text-tertiary);
+  font-size: 0.65rem;
+}
+
+.switch-option {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+  flex-direction: row;
+  gap: 8px;
+  padding-bottom: 1px;
+}
+
+.switch-option input {
+  position: relative;
+  width: 40px;
+  height: 20px;
+  margin: 0;
+  border: 1px solid var(--text-tertiary);
+  border-radius: 999px;
+  appearance: none;
+  background: transparent;
   cursor: pointer;
 }
 
-pre {
-  min-height: 80px;
-  max-height: 210px;
+.switch-option input::before {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  content: "";
+  transition: transform 100ms ease;
+}
+
+.switch-option input:checked {
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.switch-option input:checked::before {
+  background: white;
+  transform: translateX(20px);
+}
+
+.advanced-controls {
+  grid-column: 2;
+}
+
+.advanced-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  padding: 4px 2px 8px;
+}
+
+.observer-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+}
+
+.info-card {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid var(--stroke);
+  border-radius: 8px;
+  background: var(--layer);
+  box-shadow: 0 2px 6px var(--shadow);
+  backdrop-filter: blur(24px) saturate(120%);
+}
+
+.card-heading,
+.diagnostics-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.session-summary {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+}
+
+.artwork-small {
+  width: 64px;
+  aspect-ratio: 1;
+  border-radius: 6px;
+  object-fit: cover;
+}
+
+.session-summary h3 {
+  overflow: hidden;
+  margin: 0 0 3px;
+  font-size: 0.95rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-summary p {
+  overflow: hidden;
+  margin: 2px 0;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-id {
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 0.64rem !important;
+}
+
+.capability-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 14px;
+}
+
+.capability {
+  padding: 3px 7px;
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  color: var(--text-tertiary);
+  background: var(--subtle);
+  font-size: 0.64rem;
+}
+
+.capability.enabled {
+  border-color: color-mix(in srgb, var(--success) 28%, transparent);
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 8%, transparent);
+}
+
+.sessions {
+  display: grid;
+  max-height: 190px;
+  gap: 7px;
   overflow: auto;
-  padding: 12px;
-  border: 1px solid #aaa;
+}
+
+.session-card {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--stroke);
+  border-radius: 5px;
+  background: var(--card);
+}
+
+.session-card.own {
+  border-color: color-mix(in srgb, var(--accent) 38%, transparent);
+  background: var(--accent-subtle);
+}
+
+.session-card.current {
+  box-shadow: inset 3px 0 var(--accent);
+}
+
+.session-card h3 {
+  overflow: hidden;
+  margin: 0 0 3px;
+  font-size: 0.82rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-card p {
+  overflow: hidden;
+  margin: 2px 0;
+  color: var(--text-tertiary);
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 7px;
+}
+
+.session-badges span {
+  padding: 2px 6px;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: var(--subtle);
+  font-size: 0.6rem;
+}
+
+.developer-tools {
+  border: 1px solid var(--stroke);
+  border-radius: 8px;
+  background: var(--layer);
+  backdrop-filter: blur(24px) saturate(120%);
+}
+
+.diagnostics {
+  padding: 2px 10px 14px;
+}
+
+.event-list {
+  display: grid;
+  max-height: 280px;
+  gap: 4px;
+  overflow: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.event-item {
+  display: grid;
+  grid-template-columns: 68px minmax(120px, 0.55fr) minmax(170px, 1fr) 2fr;
+  align-items: baseline;
+  gap: 9px;
+  padding: 7px 9px;
+  border-left: 2px solid var(--accent);
+  border-radius: 3px;
+  color: var(--text-secondary);
+  background: var(--card);
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 0.67rem;
+}
+
+.event-item.controller {
+  border-left-color: var(--colorPalettePurpleBorderActive, #c586c0);
+}
+
+.event-item.manager {
+  border-left-color: var(--colorPaletteDarkOrangeBorderActive, #f9a825);
+}
+
+.event-time,
+.event-detail {
+  overflow: hidden;
+  color: var(--text-tertiary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-type {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.event-flow {
+  color: var(--accent);
+}
+
+.validation-output {
+  margin-top: 10px;
+}
+
+.validation-output pre {
+  max-height: 240px;
+  overflow: auto;
+  margin: 5px 0 8px;
+  padding: 10px;
+  border: 1px solid var(--stroke);
   border-radius: 4px;
-  background: #fff;
+  color: var(--text-secondary);
+  background: var(--card);
+  font-family: "Cascadia Code", Consolas, monospace;
+  font-size: 0.7rem;
   white-space: pre-wrap;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    background: #202020;
-    color: #f5f5f5;
+.empty-state {
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+  font-style: italic;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+}
+
+@media (max-width: 980px) {
+  .player-surface {
+    grid-template-columns: 240px minmax(0, 1fr);
   }
 
-  pre {
-    background: #111;
+  .now-playing-pane {
+    grid-template-columns: 170px minmax(0, 1fr);
+    padding-inline: 24px;
+  }
+
+  .artwork {
+    width: 170px;
+  }
+
+  .playback-options {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .audio-status {
+    grid-column: 1 / -1;
+  }
+
+  .advanced-controls {
+    grid-column: 1 / -1;
+  }
+
+  .event-item {
+    grid-template-columns: 64px 1fr 1.3fr;
+  }
+
+  .event-detail {
+    display: none;
   }
 }
 
-@media (max-width: 560px) {
-  .form {
+@media (max-width: 760px) {
+  .app-shell {
+    padding: 14px;
+  }
+
+  .app-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .header-actions {
+    justify-content: flex-start;
+  }
+
+  .player-surface {
     grid-template-columns: 1fr;
+  }
+
+  .playlist-pane {
+    order: 2;
+    border-top: 1px solid var(--stroke);
+    border-right: 0;
+  }
+
+  .now-playing-pane {
+    grid-template-columns: 120px minmax(0, 1fr);
+    gap: 16px;
+    padding: 22px;
+  }
+
+  .cover-stage {
+    grid-row: auto;
+  }
+
+  .artwork {
+    width: 120px;
+  }
+
+  .timeline,
+  .transport,
+  .playback-options,
+  .advanced-controls {
+    grid-column: 1 / -1;
+  }
+
+  .observer-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .event-item {
+    grid-template-columns: 60px 1fr;
+  }
+
+  .event-flow {
+    display: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .player-surface,
+  .info-card,
+  .developer-tools,
+  .session-card,
+  .event-item {
+    border: 1px solid CanvasText;
+    background: Canvas;
+    backdrop-filter: none;
   }
 }

--- a/samples/js/electron-smtc/style.css
+++ b/samples/js/electron-smtc/style.css
@@ -1,0 +1,79 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", sans-serif;
+  background: #f3f3f3;
+  color: #1a1a1a;
+}
+
+body {
+  margin: 0;
+}
+
+main {
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+h1,
+h2 {
+  margin-bottom: 8px;
+}
+
+.form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 12px;
+  margin: 20px 0;
+}
+
+label {
+  display: grid;
+  gap: 4px;
+}
+
+input,
+button {
+  font: inherit;
+  padding: 8px 10px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  border: 1px solid #888;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+pre {
+  min-height: 80px;
+  max-height: 210px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid #aaa;
+  border-radius: 4px;
+  background: #fff;
+  white-space: pre-wrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background: #202020;
+    color: #f5f5f5;
+  }
+
+  pre {
+    background: #111;
+  }
+}
+
+@media (max-width: 560px) {
+  .form {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary

- add a standalone Electron sample that publishes its `BrowserWindow` as a native SMTC media source through `ISystemMediaTransportControlsInterop`
- simulate a three-track player with generated artwork, locally synthesized audio, live timeline, shuffle, repeat, seek, and playback-rate behavior
- discover and control the session through GSMTC, including the complete transport and playback capability surface
- show global session discovery, current-session state, metadata, capabilities, and bidirectional events in an interactive Windows-style UI
- add sparse debug identity setup with the restricted `globalMediaControl` capability and deterministic loopback validation
- link the sample from the repository README

## Validation

- `npm run check` in `samples/js/electron-smtc`
- all 33 SMTC/GSMTC checks pass, including manager/session events, artwork and metadata propagation, live timeline, transport requests, capability reporting, and state round trips

## Screenshot

![Interactive Electron SMTC and GSMTC sample](https://github.com/user-attachments/assets/a056f1eb-cd71-48dc-9ce8-8d3f1ea98e3b)
