### PR TITLE
Gate PyPI publishing behind an opt-in release switch

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -20,6 +20,10 @@ parameters:
     displayName: Sign and release the packages (DoEsrp)
     type: boolean
     default: true
+  - name: PublishPyPI
+    displayName: Publish Python packages to PyPI
+    type: boolean
+    default: false
   - name: signingIdentity
     type: object
     default:
@@ -531,6 +535,7 @@ extends:
                 mainpublisher: 'ESRPRELPACMAN'
                 domaintenantid: ${{ parameters.signingIdentity.tenantId }}
 
+    - ${{ if and(eq(parameters.DoEsrp, 'true'), eq(parameters.PublishPyPI, 'true')) }}:
       - stage: Release_PyPI
         displayName: Publish to PyPI
         dependsOn:

--- a/bindings/py/README.md
+++ b/bindings/py/README.md
@@ -53,9 +53,11 @@ To release:
 3. The ADO pipeline waits for the complete wheel set, downloads it through the
    repository's GitHub service connection, and revalidates every filename,
    platform tag, Python ABI tag, metadata record, type stub, and native payload.
-4. ADO publishes the eight `dynwinrt` wheels first and the two
-   `dynwinrt-codegen` wheels second through the Microsoft ESRP release identity.
-   PyPI publication is not available from GitHub Actions.
+4. PyPI publication is opt-in: the ADO `PublishPyPI` parameter is disabled by
+   default. When explicitly enabled with `DoEsrp`, ADO publishes the eight
+   `dynwinrt` wheels first and the two `dynwinrt-codegen` wheels second through
+   the Microsoft ESRP release identity. PyPI publication is not available from
+   GitHub Actions.
 
 Before the first release, onboard both PyPI project names to the configured ESRP
 service connection and confirm the signing identity, owners, and approvers.

--- a/docs/status/PYTHON_CHECKLIST.md
+++ b/docs/status/PYTHON_CHECKLIST.md
@@ -102,7 +102,8 @@ of a dynamic projection.
       wheel set to the shared JavaScript GitHub release.
 - [ ] Publish signed/provenanced wheels to an approved internal Python feed.
 - [x] Route production PyPI publication through the official 1ES ADO release
-      pipeline and Microsoft ESRP identity.
+      pipeline and Microsoft ESRP identity, behind the opt-in `PublishPyPI`
+      parameter that is disabled by default.
 - [ ] Complete one-time ESRP/PyPI onboarding for `dynwinrt` and
       `dynwinrt-codegen`, including release owners and approvers.
 - [x] Add complete tested Python wheel assets and installation notes to GitHub


### PR DESCRIPTION
## Summary
- add a `PublishPyPI` ADO boolean parameter that defaults to `false`
- include `Release_PyPI` only when both `DoEsrp` and `PublishPyPI` are enabled, while leaving GitHub release creation, Python wheel verification, and npm ESRP publication unchanged
- document that PyPI publication is opt-in and disabled by default

## Validation
- parsed `.pipelines/release.yml` with PyYAML
- validated all four `DoEsrp`/`PublishPyPI` stage graphs and stage dependencies
- verified npm and PyPI stage bodies are unchanged from `main`, including runtime-first/codegen-second PyPI publication
- ran `git diff --check`