### PR TITLE
Clarify GitHub-only Python wheel installation

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -367,7 +367,15 @@ extends:
                 ```bash
                 npm install @microsoft/dynwinrt
                 npm install -D @microsoft/dynwinrt-codegen
-                python -m pip install dynwinrt dynwinrt-codegen
+                ```
+
+                Python packages are distributed as GitHub Release assets until
+                PyPI publication is enabled. Download the `dynwinrt` wheel that
+                matches your CPython version and Windows architecture, plus the
+                matching `dynwinrt_codegen` wheel, then install both files:
+
+                ```powershell
+                python -m pip install <dynwinrt-wheel>.whl <dynwinrt-codegen-wheel>.whl
                 ```
 
                 ## What's Included


### PR DESCRIPTION
## Summary
- remove the unavailable name-only PyPI install command from generated release notes
- explain that Python packages are currently distributed as GitHub Release assets
- instruct users to download matching runtime/codegen wheels and install the local files

## Current release
The existing `v0.1.0-preview.20` Release notes were corrected directly to match the actual distribution state.

## Validation
- confirmed both PyPI project endpoints currently return 404
- confirmed the GitHub Release contains all 10 Python wheels
- ran `git diff --check`
